### PR TITLE
net: new net package for network controller with fingerprinter.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/nomad v1.8.1
+	github.com/shoenig/test v1.7.1
 	libvirt.org/go/libvirt v1.10003.0
 	libvirt.org/libvirt-go-xml v7.4.0+incompatible
 )
@@ -102,7 +103,6 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.9 // indirect
 	github.com/shoenig/go-landlock v1.2.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/shoenig/test v1.7.1 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/libvirt/conn.go
+++ b/libvirt/conn.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package libvirt
+
+import (
+	"libvirt.org/go/libvirt"
+)
+
+// Connect is the production code of the libvirt backend that implements the
+// ConnectShim interface.
+type Connect struct {
+	conn *libvirt.Connect
+}
+
+func NewConnect(conn *libvirt.Connect) ConnectShim {
+	return &Connect{conn: conn}
+}
+
+func (c *Connect) ListNetworks() ([]string, error) {
+	return c.conn.ListNetworks()
+}
+
+func (c *Connect) LookupNetworkByName(name string) (ConnectNetworkShim, error) {
+	return c.conn.LookupNetworkByName(name)
+}

--- a/libvirt/conn_mock.go
+++ b/libvirt/conn_mock.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package libvirt
+
+import (
+	"fmt"
+)
+
+// ConnectMock is the primary mock interface that has default values for
+// testing. It implements the ConnectShim interface.
+type ConnectMock struct{}
+
+func (cm *ConnectMock) ListNetworks() ([]string, error) {
+	return []string{"default", "routed"}, nil
+}
+
+func (cm *ConnectMock) LookupNetworkByName(name string) (ConnectNetworkShim, error) {
+	switch name {
+	case "default":
+		return &ConnectNetworkMock{
+			name:       "default",
+			active:     true,
+			bridgeName: "virbr0",
+		}, nil
+	case "routed":
+		return &ConnectNetworkMock{
+			name:       "routed",
+			active:     false,
+			bridgeName: "br0",
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown network: %q", name)
+	}
+}
+
+// ConnectMockEmpty is a secondary mock that can be used to mimic a host where
+// no libvirt networks or other resources are available. It implements the
+// ConnectShim interface.
+type ConnectMockEmpty struct{}
+
+func (cme *ConnectMockEmpty) ListNetworks() ([]string, error) {
+	return []string{}, nil
+}
+
+func (cme *ConnectMockEmpty) LookupNetworkByName(name string) (ConnectNetworkShim, error) {
+	return nil, fmt.Errorf("unknown network: %q", name)
+}
+
+// ConnectNetworkMock implements the shim.Network interface for testing.
+type ConnectNetworkMock struct {
+	name       string
+	active     bool
+	bridgeName string
+}
+
+func (cnm *ConnectNetworkMock) IsActive() (bool, error) { return cnm.active, nil }
+
+func (cnm *ConnectNetworkMock) GetBridgeName() (string, error) { return cnm.bridgeName, nil }

--- a/libvirt/conn_mock_test.go
+++ b/libvirt/conn_mock_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package libvirt
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+var (
+	_ ConnectShim        = &ConnectMock{}
+	_ ConnectShim        = &ConnectMockEmpty{}
+	_ ConnectNetworkShim = &ConnectNetworkMock{}
+)
+
+func TestMock_ListNetworks(t *testing.T) {
+	mockConnect := &ConnectMock{}
+
+	netList, err := mockConnect.ListNetworks()
+	must.NoError(t, err)
+	must.Eq(t, []string{"default", "routed"}, netList)
+}
+
+func TestMock_LookupNetworkByName(t *testing.T) {
+	mockConnect := &ConnectMock{}
+
+	// Try looking up a network that doesn't exist.
+	net, err := mockConnect.LookupNetworkByName("no-found")
+	must.ErrorContains(t, err, "unknown network")
+	must.Nil(t, net)
+
+	// Lookup the default network.
+	net, err = mockConnect.LookupNetworkByName("default")
+	must.NoError(t, err)
+	must.NotNil(t, net)
+
+	// Lookup the routed network.
+	net, err = mockConnect.LookupNetworkByName("routed")
+	must.NoError(t, err)
+	must.NotNil(t, net)
+}
+
+func TestMockEmpty_ListNetworks(t *testing.T) {
+	mockConnect := &ConnectMockEmpty{}
+
+	netList, err := mockConnect.ListNetworks()
+	must.NoError(t, err)
+	must.Eq(t, []string{}, netList)
+}
+
+func TestMockEmpty_LookupNetworkByName(t *testing.T) {
+	mockConnect := &ConnectMockEmpty{}
+
+	// Try looking up a network that doesn't exist.
+	net, err := mockConnect.LookupNetworkByName("no-found")
+	must.ErrorContains(t, err, "unknown network")
+	must.Nil(t, net)
+
+	// Lookup the default network that doesn't exist.
+	net, err = mockConnect.LookupNetworkByName("default")
+	must.ErrorContains(t, err, "unknown network")
+	must.Nil(t, net)
+
+	// Lookup the routed network that doesn't exist.
+	net, err = mockConnect.LookupNetworkByName("routed")
+	must.ErrorContains(t, err, "unknown network")
+	must.Nil(t, net)
+}
+
+func TestMockNetwork(t *testing.T) {
+	mockNetwork := &ConnectNetworkMock{name: "default", active: true, bridgeName: "virbr0"}
+
+	bridgeName, err := mockNetwork.GetBridgeName()
+	must.NoError(t, err)
+	must.Eq(t, mockNetwork.bridgeName, bridgeName)
+
+	active, err := mockNetwork.IsActive()
+	must.NoError(t, err)
+	must.Eq(t, mockNetwork.active, active)
+}

--- a/libvirt/conn_shim.go
+++ b/libvirt/conn_shim.go
@@ -1,0 +1,48 @@
+package libvirt
+
+// ConnectShim is the shim interface that wraps libvirt connectivity. This
+// allows us to create a mock implementation for testing, as we cannot assume
+// we will always have expensive bare-metal hosts to run CI, especially on a
+// public repository. Functions should be added as required and match only
+// those provided by libvirt.Connect.
+//
+// Each implementation should be lightweight and not include any business
+// logic. This allows us to have more confidence in the mock behaving like the
+// libvirt backend and avoid bugs due to differences.
+type ConnectShim interface {
+
+	// ListNetworks returns an array of network names.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virConnectListNetworks
+	ListNetworks() ([]string, error)
+
+	// LookupNetworkByName returns a handle to the network object as defined by
+	// the name argument. If the network is not found, an error will be
+	// returned.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkLookupByName
+	LookupNetworkByName(name string) (ConnectNetworkShim, error)
+}
+
+// ConnectNetworkShim is the shim interface that wraps libvirt connectivity
+// specific to a named network. This allows us to create a mock implementation
+// for testing, as we cannot assume we will always have expensive bare-metal
+// hosts to run CI, especially on a public repository. Functions should be
+// added as required and match only those provided by libvirt.Network.
+type ConnectNetworkShim interface {
+
+	// IsActive returns whether the named network is active.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkIsActive
+	IsActive() (bool, error)
+
+	// GetBridgeName returns the bridge interface name assigned to the named
+	// network.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkGetBridgeName
+	GetBridgeName() (string, error)
+}

--- a/libvirt/conn_test.go
+++ b/libvirt/conn_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package libvirt
+
+import (
+	"libvirt.org/go/libvirt"
+)
+
+var (
+	_ ConnectShim        = &Connect{}
+	_ ConnectNetworkShim = &libvirt.Network{}
+)

--- a/libvirt/net/net.go
+++ b/libvirt/net/net.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package net
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
+)
+
+// Controller implements to Net interface and is the main/only way in which the
+// driver should interact with the network-subsystem.
+type Controller struct {
+	logger  hclog.Logger
+	netConn libvirt.ConnectShim
+}
+
+// NewController returns a Controller which implements the net.Net interface
+// and has a named logger, to ensure log messages can be easily tied to the
+// network system.
+func NewController(logger hclog.Logger, conn libvirt.ConnectShim) net.Net {
+	return &Controller{
+		logger:  logger.Named("net"),
+		netConn: conn,
+	}
+}

--- a/libvirt/net/net_default.go
+++ b/libvirt/net/net_default.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !linux
+
+package net
+
+import (
+	"github.com/hashicorp/nomad/plugins/shared/structs"
+)
+
+func (c *Controller) Fingerprint(_ map[string]*structs.Attribute) {}

--- a/libvirt/net/net_default_test.go
+++ b/libvirt/net/net_default_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !linux
+
+package net
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	"github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestController_Fingerprint(t *testing.T) {
+	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
+	mockControllerAttrs := map[string]*structs.Attribute{}
+	mockController.Fingerprint(mockControllerAttrs)
+	must.Eq(t, map[string]*structs.Attribute{}, mockControllerAttrs)
+}

--- a/libvirt/net/net_linux.go
+++ b/libvirt/net/net_linux.go
@@ -1,0 +1,60 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+package net
+
+import (
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
+	"github.com/hashicorp/nomad/plugins/shared/structs"
+)
+
+func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
+
+	// List the network names. This is terminal to the fingerprint process, as
+	// without this, we have nothing to query.
+	networkNames, err := c.netConn.ListNetworks()
+	if err != nil {
+		c.logger.Error("failed to list networks", "error", err)
+		return
+	}
+
+	// Iterate the list of network names getting a network handle, so we can
+	// query whether it is active.
+	for _, networkName := range networkNames {
+
+		networkInfo, err := c.netConn.LookupNetworkByName(networkName)
+		if err != nil {
+			c.logger.Error("failed to lookup network",
+				"network", networkName, "error", err)
+			continue
+		}
+
+		active, err := networkInfo.IsActive()
+		if err != nil {
+			c.logger.Error("failed to check network state",
+				"network", networkName, "error", err)
+			continue
+		}
+
+		// Populate the attributes mapping with our network state. Libvirt does
+		// not allow two networks of the same name, so there should be no
+		// concern about overwriting or duplicates.
+		netStateKey := net.FingerprintAttributeKeyPrefix + networkName + ".state"
+		attr[netStateKey] = structs.NewStringAttribute(net.IsActiveString(active))
+
+		bridgeName, err := networkInfo.GetBridgeName()
+		if err != nil {
+			c.logger.Error("failed to get network bridge name",
+				"network", networkName, "error", err)
+			continue
+		}
+
+		// Populate the attributes mapping with our bridge name. Only one
+		// bridge can be configured per network, so there should be no concern
+		// about overwriting or duplicates.
+		netBridgeNameKey := net.FingerprintAttributeKeyPrefix + networkName + ".bridge_name"
+		attr[netBridgeNameKey] = structs.NewStringAttribute(bridgeName)
+	}
+}

--- a/libvirt/net/net_linux_test.go
+++ b/libvirt/net/net_linux_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+package net
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	"github.com/hashicorp/nomad/plugins/shared/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestController_Fingerprint(t *testing.T) {
+
+	// Use a populated mock shim to test that we query and correctly populate
+	// the passed attributes.
+	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
+
+	mockControllerAttrs := map[string]*structs.Attribute{}
+	mockController.Fingerprint(mockControllerAttrs)
+
+	expectedOutput := map[string]*structs.Attribute{
+		"driver.virt.network.default.state":       structs.NewStringAttribute("active"),
+		"driver.virt.network.default.bridge_name": structs.NewStringAttribute("virbr0"),
+		"driver.virt.network.routed.state":        structs.NewStringAttribute("inactive"),
+		"driver.virt.network.routed.bridge_name":  structs.NewStringAttribute("br0"),
+	}
+	must.Eq(t, expectedOutput, mockControllerAttrs)
+
+	// Set the shim to our empty mock, to ensure we do not panic or have any
+	// other undesired outcome when the process does not find any networks
+	// available on the host.
+	mockEmptyController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMockEmpty{})
+
+	mockEmptyControllerAttrs := map[string]*structs.Attribute{}
+	mockEmptyController.Fingerprint(mockEmptyControllerAttrs)
+	must.Eq(t, map[string]*structs.Attribute{}, mockEmptyControllerAttrs)
+}

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package net
+
+import "github.com/hashicorp/nomad/plugins/shared/structs"
+
+// Net is the interface that defines the virtualization network sub-system. It
+// should be the only link from the main driver and compute functionality, into
+// the network. This helps encapsulate the logic making future development
+// easier, even allowing for this code to be moved into its own application if
+// desired.
+type Net interface {
+
+	// Fingerprint interrogates the host system and populates the attribute
+	// mapping with relevant network information. Any errors performing this
+	// should be logged by the implementor, but not considered terminal, which
+	// explains the lack of error response. Each entry should use
+	// FingerprintAttributeKeyPrefix as a base.
+	Fingerprint(map[string]*structs.Attribute)
+}
+
+const (
+	// FingerprintAttributeKeyPrefix is the key prefix to use when creating and
+	// adding attributes during the fingerprint process.
+	FingerprintAttributeKeyPrefix = "driver.virt.network."
+
+	// NetworkStateActive is string representation to declare a network is in
+	// active state. This is translated from "true" using the go-libvirt SDK
+	// and 1 from the raw libvirt API when query if the network is active.
+	NetworkStateActive = "active"
+
+	// NetworkStateInactive is string representation to declare a network is in
+	// inactive state. This is translated from "false" using the go-libvirt SDK
+	// and 0 from the raw libvirt API when query if the network is active.
+	NetworkStateInactive = "inactive"
+)
+
+// IsActiveString converts the boolean response from the IsActive call of
+// libvirt network to a human-readable string. This string copies the
+// vocabulary used by virsh for consistency.
+func IsActiveString(active bool) string {
+	if active {
+		return NetworkStateActive
+	}
+	return NetworkStateInactive
+}

--- a/virt/net/net_test.go
+++ b/virt/net/net_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package net
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_NetworkActiveString(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          bool
+		expectedOutput string
+	}{
+		{
+			name:           "active",
+			input:          true,
+			expectedOutput: "active",
+		},
+		{
+			name:           "inactive",
+			input:          false,
+			expectedOutput: "inactive",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := IsActiveString(tc.input)
+			must.Eq(t, tc.expectedOutput, actualOutput)
+		})
+	}
+}


### PR DESCRIPTION
The new net package will host all network code via a controller from the main driver codebase. In order to allow for easier testing that does not require expensive machines, a shim is used for backend connectivity to libvirt. This allows us to use mocks for testing, which replicate libvirt API call returns.

This initial commit includes the fingerprint functionality, which will populate network specific data into the driver attributes data mapping.

RFC: https://go.hashi.co/rfc/nmd-199
Related ticket: https://hashicorp.atlassian.net/browse/NET-10228