### PR TITLE
net: add init controller functionality to prepare networking.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,8 @@ jobs:
       - name: "run tests"
         run: |
           make test-tools
-          make test
+          sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
+          sudo -E env "PATH=$PATH" make test
   build:
     name: "run build"
     runs-on: ubuntu-22.04

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.22
 replace github.com/armon/go-metrics => github.com/hashicorp/go-metrics v0.5.3
 
 require (
+	github.com/coreos/go-iptables v0.6.0
 	github.com/diskfs/go-diskfs v1.4.1
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/containerd/containerd v1.6.33 h1:8FYSFoV3UbizMgX7IKcP0GGAFw4+V3VPLo/C
 github.com/containerd/containerd v1.6.33/go.mod h1:Om5z+jDo6b8RkAxWf0ukj9JrPS/RYdhXNPwkZuuIyMk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
+github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/libvirt/net/net_default.go
+++ b/libvirt/net/net_default.go
@@ -10,3 +10,5 @@ import (
 )
 
 func (c *Controller) Fingerprint(_ map[string]*structs.Attribute) {}
+
+func (c *Controller) Init() error { return nil }

--- a/libvirt/net/net_linux.go
+++ b/libvirt/net/net_linux.go
@@ -6,8 +6,30 @@
 package net
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
+)
+
+const (
+	// preroutingIPTablesChainName is the IPTables chain name used by the
+	// driver for prerouting rules. This is currently used for entries within
+	// the filter table.
+	preroutingIPTablesChainName = "NOMAD_VT_PRT"
+
+	// forwardIPTablesChainName is the IPTables chain name used by the driver
+	// for forwarding rules. This is currently used for entries within the NAT
+	// table.
+	forwardIPTablesChainName = "NOMAD_VT_FW"
+
+	// iptablesNATTableName is the name of the nat table within iptables.
+	iptablesNATTableName = "nat"
+
+	// iptablesFilterTableName is the name of the filter table within iptables.
+	iptablesFilterTableName = "filter"
 )
 
 func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
@@ -57,4 +79,84 @@ func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
 		netBridgeNameKey := net.FingerprintAttributeKeyPrefix + networkName + ".bridge_name"
 		attr[netBridgeNameKey] = structs.NewStringAttribute(bridgeName)
 	}
+}
+
+func (c *Controller) Init() error {
+	// The function currently only calls another single function, but is
+	// intended to be easy and obvious to expand in the future if needed.
+	return c.ensureIPTables()
+}
+
+// ensureIPTables is responsible for ensuring the local host machine iptables
+// are configured with the chains and rules needed by the driver.
+//
+// On a new machine, this function creates the "NOMAD_VT_PRT" and "NOMAD_VT_FW"
+// chains. The "NOMAD_VT_PRT" chain then has a jump rule added to the "nat"
+// table; the "NOMAD_VT_FW" chain has a jump rule added to the "filter" table.
+func (c *Controller) ensureIPTables() error {
+
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("failed to create iptables handle: %w", err)
+	}
+
+	// Ensure the NAT prerouting chain is available and create the jump rule if
+	// needed.
+	natCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, preroutingIPTablesChainName)
+	if err != nil {
+		return fmt.Errorf("failed to create iptables chain %q: %w",
+			preroutingIPTablesChainName, err)
+	}
+	if natCreated {
+		if err := ipt.Insert(iptablesNATTableName, "PREROUTING", 1, []string{"-j", preroutingIPTablesChainName}...); err != nil {
+			return err
+		}
+		c.logger.Info("successfully created NAT prerouting iptables chain",
+			"name", preroutingIPTablesChainName)
+	}
+
+	// Ensure the filter forward chain is available and create the jump rule if
+	// needed.
+	filterCreated, err := ensureIPTablesChain(ipt, iptablesFilterTableName, forwardIPTablesChainName)
+	if err != nil {
+		return fmt.Errorf("failed to create iptables chain %q: %w",
+			forwardIPTablesChainName, err)
+	}
+	if filterCreated {
+		if err := ipt.Insert(iptablesFilterTableName, "FORWARD", 1, []string{"-j", forwardIPTablesChainName}...); err != nil {
+			return err
+		}
+		c.logger.Info("successfully created filter forward iptables chain",
+			"name", forwardIPTablesChainName)
+	}
+
+	return nil
+}
+
+func ensureIPTablesChain(ipt *iptables.IPTables, table, chain string) (bool, error) {
+
+	// List and iterate the currently configured iptables chains, so we can
+	// identify whether the chain already exist.
+	chains, err := ipt.ListChains(table)
+	if err != nil {
+		return false, err
+	}
+	for _, ch := range chains {
+		if ch == chain {
+			return false, nil
+		}
+	}
+
+	err = ipt.NewChain(table, chain)
+
+	// The error returned needs to be carefully checked as an exit code of 1
+	// indicates the chain exists. This might happen when another routine has
+	// created it.
+	var e *iptables.Error
+
+	if errors.As(err, &e) && e.ExitStatus() == 1 {
+		return false, nil
+	}
+
+	return true, err
 }

--- a/libvirt/net/net_linux_test.go
+++ b/libvirt/net/net_linux_test.go
@@ -6,8 +6,10 @@
 package net
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-virt/libvirt"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
@@ -39,4 +41,100 @@ func TestController_Fingerprint(t *testing.T) {
 	mockEmptyControllerAttrs := map[string]*structs.Attribute{}
 	mockEmptyController.Fingerprint(mockEmptyControllerAttrs)
 	must.Eq(t, map[string]*structs.Attribute{}, mockEmptyControllerAttrs)
+}
+
+func TestController_ensureIPTables(t *testing.T) {
+
+	ipt, err := iptables.New()
+	must.NoError(t, err)
+
+	// Try listing our custom chains to ensure they do not exist before the
+	// test starts.
+	natChains, err := ipt.ListChains(iptablesNATTableName)
+	must.NoError(t, err)
+	must.SliceNotContains(t, natChains, preroutingIPTablesChainName)
+
+	filterChains, err := ipt.ListChains(iptablesFilterTableName)
+	must.NoError(t, err)
+	must.SliceNotContains(t, filterChains, forwardIPTablesChainName)
+
+	// Add a cleanup function which will remove all the added iptables chain
+	// and rule entries. This avoids polluting the machine that runs the test,
+	// so our development machines do not require manual intervention after
+	// each test run.
+	//
+	// Any errors running the cleanup commands are logged, so developers can
+	// spot these and perform manual fixes. Manual fixes:
+	//  - sudo iptables -t filter -D FORWARD -j NOMAD_VT_FW
+	//  - sudo iptables -F NOMAD_VT_FW -t filter
+	//  - sudo iptables -X NOMAD_VT_FW -t filter
+	//  - sudo iptables -t nat -D PREROUTING -j NOMAD_VT_PRT
+	//  - sudo iptables -F NOMAD_VT_PRT -t nat
+	//  - sudo iptables -X NOMAD_VT_PRT -t nat
+	t.Cleanup(func() {
+		fn := func(e error) {
+			if e != nil {
+				t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
+			}
+		}
+
+		fn(ipt.Delete(iptablesNATTableName, "PREROUTING", []string{"-j", preroutingIPTablesChainName}...))
+		fn(ipt.ClearChain(iptablesNATTableName, preroutingIPTablesChainName))
+		fn(ipt.DeleteChain(iptablesNATTableName, preroutingIPTablesChainName))
+
+		fn(ipt.Delete(iptablesFilterTableName, "FORWARD", []string{"-j", forwardIPTablesChainName}...))
+		fn(ipt.ClearChain(iptablesFilterTableName, forwardIPTablesChainName))
+		fn(ipt.DeleteChain(iptablesFilterTableName, forwardIPTablesChainName))
+	})
+
+	mockController := &Controller{logger: hclog.NewNullLogger()}
+
+	// Trigger the ensure function which should add our base iptables chains
+	// and rules for the driver.
+	must.NoError(t, mockController.ensureIPTables())
+
+	// Ensure the custom chain is found within the NAT table and check that the
+	// table has a jump rule to the custom chain.
+	natChains, err = ipt.ListChains(iptablesNATTableName)
+	must.NoError(t, err)
+	must.SliceContains(t, natChains, preroutingIPTablesChainName)
+
+	natRules, err := ipt.List(iptablesNATTableName, "PREROUTING")
+	must.NoError(t, err)
+	must.SliceContains(t, natRules, "-A PREROUTING -j "+preroutingIPTablesChainName)
+
+	// Ensure the custom chain is found within the filter table and check that
+	// the table has a jump rule to the custom chain.
+	filterChains, err = ipt.ListChains(iptablesFilterTableName)
+	must.NoError(t, err)
+	must.SliceContains(t, filterChains, forwardIPTablesChainName)
+
+	filterRules, err := ipt.List(iptablesFilterTableName, "FORWARD")
+	must.NoError(t, err)
+	must.SliceContains(t, filterRules, "-A FORWARD -j "+forwardIPTablesChainName)
+
+	// Trigger the ensure function again. This tests that the function can
+	// handle being run multiple times without error, whilst maintaining the
+	// iptables setup we require.
+	must.NoError(t, mockController.ensureIPTables())
+
+	// Ensure the custom chain is found within the NAT table and check that the
+	// table has a jump rule to the custom chain.
+	natChains, err = ipt.ListChains(iptablesNATTableName)
+	must.NoError(t, err)
+	must.SliceContains(t, natChains, preroutingIPTablesChainName)
+
+	natRules, err = ipt.List(iptablesNATTableName, "PREROUTING")
+	must.NoError(t, err)
+	must.SliceContains(t, natRules, "-A PREROUTING -j "+preroutingIPTablesChainName)
+
+	// Ensure the custom chain is found within the filter table and check that
+	// the table has a jump rule to the custom chain.
+	filterChains, err = ipt.ListChains(iptablesFilterTableName)
+	must.NoError(t, err)
+	must.SliceContains(t, filterChains, forwardIPTablesChainName)
+
+	filterRules, err = ipt.List(iptablesFilterTableName, "FORWARD")
+	must.NoError(t, err)
+	must.SliceContains(t, filterRules, "-A FORWARD -j "+forwardIPTablesChainName)
 }

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -3,7 +3,9 @@
 
 package net
 
-import "github.com/hashicorp/nomad/plugins/shared/structs"
+import (
+	"github.com/hashicorp/nomad/plugins/shared/structs"
+)
 
 // Net is the interface that defines the virtualization network sub-system. It
 // should be the only link from the main driver and compute functionality, into
@@ -18,6 +20,13 @@ type Net interface {
 	// explains the lack of error response. Each entry should use
 	// FingerprintAttributeKeyPrefix as a base.
 	Fingerprint(map[string]*structs.Attribute)
+
+	// Init performs any initialization work needed by the network sub-system
+	// prior to being used by the driver. This will be called when the plugin
+	// is set up by Nomad and should be expected to run multiple times during
+	// a Nomad client's lifecycle. It should therefore be idempotent. Any error
+	// returned is considered fatal to the plugin.
+	Init() error
 }
 
 const (


### PR DESCRIPTION
When the driver starts, the host machine network requires minor configuration in order to accept VM workloads. This work currently configures new iptables chains and corresponding jump rules.

The new functionality is built into the net interface which can be called from the driver when required. The controller implements this requirement.

The new tests need to be run as root, therefore the CI workflow has been updated to allow this.

RFC: https://go.hashi.co/rfc/nmd-199
Related ticket: https://hashicorp.atlassian.net/browse/NET-10228