### PR TITLE
WIP: Add some temporary driver tunables per task and update some aspects of launching the VMs.

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,31 @@
+FROM ubuntu:jammy
+
+ARG GO_VERSION="1.23.0"
+ARG USER_ID
+ARG GROUP_ID
+
+RUN apt-get update
+
+######################### install go
+RUN apt install -yq wget
+RUN wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz" && \
+    rm -f "${GO_VERSION}.linux-amd64.tar.gz"
+
+RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go
+RUN ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+########################### install stuff to build libvirt drivers
+RUN apt install -yq build-essential git libvirt-dev
+
+#################### create unprivileged user
+RUN addgroup --gid $GROUP_ID build && \
+    adduser --disabled-password --uid $USER_ID --gid $GROUP_ID build
+USER build
+
+############ setup slight caching
+RUN mkdir -p /home/build/go/pkg/mod
+
+ENV GOMODCACHE=/home/build/go/pkg/mod
+ENV GOPATH=/home/build/go

--- a/internal/shared/domain.go
+++ b/internal/shared/domain.go
@@ -56,6 +56,11 @@ type OSVariant struct {
 }
 
 type Config struct {
+	NomadNamespace string
+	NomadJob       string
+	NomadAlloc     string
+	NomadTask      string
+	//
 	RemoveConfigFiles bool
 	XMLConfig         string
 	Name              string

--- a/libvirt/libvirt.go
+++ b/libvirt/libvirt.go
@@ -323,7 +323,8 @@ func createCloudInitConfig(config *domain.Config) *cloudinit.Config {
 			Password: config.Password,
 			SSHKey:   config.SSHKey,
 		},
-		UserDataPath: config.CIUserData,
+		UserData:     config.CIUserData,
+		UserDataPath: config.CIUserDataPath,
 	}
 }
 
@@ -431,24 +432,19 @@ func (d *driver) CreateDomain(config *domain.Config) error {
 	cloudInitConfigPath := filepath.Join(d.dataDir, config.Name+".iso")
 	if config.RemoveConfigFiles {
 		defer func() {
-			err := os.Remove(cloudInitConfigPath)
-			if err != nil {
-				d.logger.Warn("unable to remove cloudinit configFile", "error", err)
-			}
-
+			// opportunistic
+			_ = os.Remove(cloudInitConfigPath)
 		}()
 	}
 
 	cic := createCloudInitConfig(config)
 	d.logger.Debug("creating ci configuration: ", fmt.Sprintf("%+v", cic))
 
-	err = d.ci.Apply(cic, cloudInitConfigPath)
-	if err != nil {
+	if err := d.ci.Apply(cic, cloudInitConfigPath); err != nil {
 		return fmt.Errorf("libvirt: unable to create cidata %s: %w", config.Name, err)
 	}
 
-	err = d.sp.Refresh(0)
-	if err != nil {
+	if err := d.sp.Refresh(0); err != nil {
 		return fmt.Errorf("libvirt: unable to refresh storage pool %s: %w", config.Name, err)
 	}
 
@@ -469,8 +465,7 @@ func (d *driver) CreateDomain(config *domain.Config) error {
 		return fmt.Errorf("libvirt: unable to define domain %s: %w", config.Name, err)
 	}
 
-	err = dom.Create()
-	if err != nil {
+	if err := dom.Create(); err != nil {
 		return fmt.Errorf("libvirt: unable to create domain %s: %w", config.Name, err)
 	}
 

--- a/libvirt/metadata/metadata.go
+++ b/libvirt/metadata/metadata.go
@@ -1,0 +1,33 @@
+package metadata
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+const hashivirtNamespace = "http://hashicorp.com/xmlns/1.0/hashivirt"
+
+type DriverDomain struct {
+	XMLName xml.Name           `xml:"http://hashicorp.com/xmlns/1.0/hashivirt hashivirt:instance"`
+	Nomad   *DriverDomainNomad `xml:"hashivirt:nomad"`
+}
+
+type DriverDomainNomad struct {
+	Namespace string `xml:"hashivirt:namespace,omitempty"`
+	Job       string `xml:"hashivirt:job"`
+	Alloc     string `xml:"hashivirt:alloc"`
+	Task      string `xml:"hashivirt:task"`
+}
+
+func (m *DriverDomain) XMLString() (string, error) {
+	out, err := xml.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	x := string(out)
+
+	// Stdlib cannot create `<foo:thing xmlns:foo="URI">` start elements, so fix it
+	x = strings.Replace(x, ` xmlns="`, ` xmlns:hashivirt="`, 1)
+
+	return x, nil
+}

--- a/libvirt/metadata/metadata_test.go
+++ b/libvirt/metadata/metadata_test.go
@@ -1,0 +1,72 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriverDomainMetadataXMLString(t *testing.T) {
+	type testcase struct {
+		in        *DriverDomain
+		expect    string
+		expectErr bool
+	}
+	run := func(t *testing.T, tc testcase) {
+		// got, err := xml.MarshalIndent(tc.in, "", "  ")
+		got, err := tc.in.XMLString()
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Equal(t, tc.expect, string(got))
+	}
+	cases := map[string]testcase{
+		"empty": {
+			in:     &DriverDomain{},
+			expect: `<hashivirt:instance xmlns:hashivirt="` + hashivirtNamespace + `"></hashivirt:instance>`,
+		},
+		"no namespace": {
+			// alloc: 317e26d8
+			in: &DriverDomain{
+				Nomad: &DriverDomainNomad{
+					Namespace: "",
+					Job:       "my-job",
+					Alloc:     "317e26d8",
+					Task:      "my-task",
+				},
+			},
+			expect: `<hashivirt:instance xmlns:hashivirt="` + hashivirtNamespace + `">
+  <hashivirt:nomad>
+    <hashivirt:job>my-job</hashivirt:job>
+    <hashivirt:alloc>317e26d8</hashivirt:alloc>
+    <hashivirt:task>my-task</hashivirt:task>
+  </hashivirt:nomad>
+</hashivirt:instance>`,
+		},
+		"with namespace": {
+			// alloc: 317e26d8
+			in: &DriverDomain{
+				Nomad: &DriverDomainNomad{
+					Namespace: "foo",
+					Job:       "my-job",
+					Alloc:     "317e26d8",
+					Task:      "my-task",
+				},
+			},
+			expect: `<hashivirt:instance xmlns:hashivirt="` + hashivirtNamespace + `">
+  <hashivirt:nomad>
+    <hashivirt:namespace>foo</hashivirt:namespace>
+    <hashivirt:job>my-job</hashivirt:job>
+    <hashivirt:alloc>317e26d8</hashivirt:alloc>
+    <hashivirt:task>my-task</hashivirt:task>
+  </hashivirt:nomad>
+</hashivirt:instance>`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/virt/config.go
+++ b/virt/config.go
@@ -37,9 +37,11 @@ var (
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"network_interface":               net.NetworkInterfaceHCLSpec(),
 		"use_thin_copy":                   hclspec.NewAttr("use_thin_copy", "bool", false),
+		"default_volume_size":             hclspec.NewAttr("default_volume_size", "number", false),
 		"image":                           hclspec.NewAttr("image", "string", true),
 		"hostname":                        hclspec.NewAttr("hostname", "string", false),
 		"user_data":                       hclspec.NewAttr("user_data", "string", false),
+		"user_data_path":                  hclspec.NewAttr("user_data_path", "string", false),
 		"default_user_authorized_ssh_key": hclspec.NewAttr("default_user_authorized_ssh_key", "string", false),
 		"default_user_password":           hclspec.NewAttr("default_user_password", "string", false),
 		"cmds":                            hclspec.NewAttr("cmds", "list(string)", false),
@@ -86,11 +88,13 @@ type TaskConfig struct {
 	Hostname            string         `codec:"hostname"`
 	OS                  *OS            `codec:"os"`
 	UserData            string         `codec:"user_data"`
+	UserDataPath        string         `codec:"user_data_path"`
 	TimeZone            *time.Location `codec:"timezone"`
 	CMDs                []string       `codec:"cmds"`
 	DefaultUserSSHKey   string         `codec:"default_user_authorized_ssh_key"`
 	DefaultUserPassword string         `codec:"default_user_password"`
 	UseThinCopy         bool           `codec:"use_thin_copy"`
+	DefaultVolumeSize   int64          `codec:"default_volume_size"`
 	// The list of network interfaces that should be added to the VM.
 	net.NetworkInterfacesConfig `codec:"network_interface"`
 }

--- a/virt/config_test.go
+++ b/virt/config_test.go
@@ -26,6 +26,7 @@ func TestConfig_Task(t *testing.T) {
 	expectedUseThinCopy := true
 	expectedARCH := "arm78"
 	expectedMachine := "R2D2"
+	expectedDefaultVolumeSize := int64(1024)
 
 	validHCL := `
   config {
@@ -36,6 +37,7 @@ func TestConfig_Task(t *testing.T) {
 	default_user_authorized_ssh_key =  "ssh-ed25519 testtesttest..."
 	default_user_password = "password"
 	use_thin_copy = true
+	default_volume_size = 1024
 	os {
 		arch = "arm78"
 		machine = "R2D2"
@@ -47,7 +49,8 @@ func TestConfig_Task(t *testing.T) {
 	parser.ParseHCL(t, validHCL, &tc)
 	must.SliceContainsAll(t, expectedCmds, tc.CMDs)
 	must.StrContains(t, expectedImg, tc.ImagePath)
-	must.True(t, expectedUseThinCopy)
+	must.Eq(t, expectedUseThinCopy, tc.UseThinCopy)
+	must.Eq(t, expectedDefaultVolumeSize, tc.DefaultVolumeSize)
 	must.StrContains(t, expectedDefaultUserSSHKey, tc.DefaultUserSSHKey)
 	must.StrContains(t, expectedDefaultUserPassword, tc.DefaultUserPassword)
 	must.StrContains(t, expectedHostname, tc.Hostname)

--- a/virt/driver.go
+++ b/virt/driver.go
@@ -540,6 +540,11 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHand
 	}
 
 	dc := &domain.Config{
+		NomadNamespace: cfg.Namespace,
+		NomadJob:       cfg.JobName, // cfg.JobID???
+		NomadAlloc:     cfg.AllocID,
+		NomadTask:      cfg.Name,
+		//
 		RemoveConfigFiles: true,
 		Name:              taskName,
 		Memory:            uint(cfg.Resources.NomadResources.Memory.MemoryMB),

--- a/virt/net/config.go
+++ b/virt/net/config.go
@@ -88,6 +88,7 @@ func NetworkInterfaceHCLSpec() *hclspec.Spec {
 	return hclspec.NewBlockList("network_interface", hclspec.NewObject(map[string]*hclspec.Spec{
 		"bridge": hclspec.NewBlock("bridge", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"name":  hclspec.NewAttr("name", "string", true),
+			"mac":   hclspec.NewAttr("mac", "string", false),
 			"ports": hclspec.NewAttr("ports", "list(string)", false),
 		})),
 	}))

--- a/virt/net/config_test.go
+++ b/virt/net/config_test.go
@@ -105,6 +105,30 @@ func Test_InterfaceHCLSpecification(t *testing.T) {
 		expectedOutput TaskConfig
 	}{
 		{
+			name: "full bridge with mac",
+			inputConfig: `
+config {
+  network_interface {
+    bridge {
+      name  = "virbr0"
+      mac   = "12:7c:5b:ce:49:54"
+      ports = ["ssh"]
+    }
+  }
+}
+`,
+			expectedOutput: TaskConfig{
+				NetworkInterfacesConfig: []*NetworkInterfaceConfig{
+					{
+						Bridge: &NetworkInterfaceBridgeConfig{
+							Name:  "virbr0",
+							MAC:   "12:7c:5b:ce:49:54",
+							Ports: []string{"ssh"},
+						},
+					},
+				}},
+		},
+		{
 			name: "full bridge",
 			inputConfig: `
 config {

--- a/virt/net/config_test.go
+++ b/virt/net/config_test.go
@@ -26,7 +26,7 @@ func TestNetworkInterfaces_Validate(t *testing.T) {
 		{
 			name:                   "empty list",
 			inputNetworkInterfaces: &NetworkInterfacesConfig{},
-			expectedOutput:         nil,
+			expectedOutput:         errors.New("only one network interface can be configured"),
 		},
 		{
 			name: "one interface",


### PR DESCRIPTION
stacked on https://github.com/hashicorp/nomad-driver-virt/pull/23

Sample job file using this: https://gist.github.com/rboyer/b267bde7e3dd74312add2c3b1946f4a7

This also now works in conjunction the `use_nomad=true` config setting in my poc code: https://github.com/hashicorp/runtime-kvm-net-poc