### PR TITLE
net: add process for adding and removing VM port mapping rules.

### DIFF
--- a/libvirt/conn_mock.go
+++ b/libvirt/conn_mock.go
@@ -5,6 +5,9 @@ package libvirt
 
 import (
 	"fmt"
+	"time"
+
+	"libvirt.org/go/libvirt"
 )
 
 // ConnectMock is the primary mock interface that has default values for
@@ -22,12 +25,24 @@ func (cm *ConnectMock) LookupNetworkByName(name string) (ConnectNetworkShim, err
 			name:       "default",
 			active:     true,
 			bridgeName: "virbr0",
+			dhcpLeases: []libvirt.NetworkDHCPLease{
+				{
+					Iface:      "virbr0",
+					ExpiryTime: time.Now(),
+					Type:       libvirt.IP_ADDR_TYPE_IPV4,
+					Mac:        "52:54:00:1c:7c:14",
+					IPaddr:     "192.168.122.58",
+					Hostname:   "nomad-0ea818bc",
+					Clientid:   "ff:08:24:45:0e:00:02:00:00:ab:11:35:ab:f3:c7:ac:54:9e:c8",
+				},
+			},
 		}, nil
 	case "routed":
 		return &ConnectNetworkMock{
 			name:       "routed",
 			active:     false,
 			bridgeName: "br0",
+			dhcpLeases: []libvirt.NetworkDHCPLease{},
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown network: %q", name)
@@ -52,8 +67,13 @@ type ConnectNetworkMock struct {
 	name       string
 	active     bool
 	bridgeName string
+	dhcpLeases []libvirt.NetworkDHCPLease
 }
 
 func (cnm *ConnectNetworkMock) IsActive() (bool, error) { return cnm.active, nil }
 
 func (cnm *ConnectNetworkMock) GetBridgeName() (string, error) { return cnm.bridgeName, nil }
+
+func (cnm *ConnectNetworkMock) GetDHCPLeases() ([]libvirt.NetworkDHCPLease, error) {
+	return cnm.dhcpLeases, nil
+}

--- a/libvirt/conn_shim.go
+++ b/libvirt/conn_shim.go
@@ -3,6 +3,8 @@
 
 package libvirt
 
+import "libvirt.org/go/libvirt"
+
 // ConnectShim is the shim interface that wraps libvirt connectivity. This
 // allows us to create a mock implementation for testing, as we cannot assume
 // we will always have expensive bare-metal hosts to run CI, especially on a
@@ -48,4 +50,10 @@ type ConnectNetworkShim interface {
 	// Also see:
 	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkGetBridgeName
 	GetBridgeName() (string, error)
+
+	// GetDHCPLeases returns an array of DHCP leases for the named network.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkGetDHCPLeases
+	GetDHCPLeases() ([]libvirt.NetworkDHCPLease, error)
 }

--- a/libvirt/net/net.go
+++ b/libvirt/net/net.go
@@ -4,9 +4,23 @@
 package net
 
 import (
+	stdnet "net"
+	"time"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-virt/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
+)
+
+var (
+	// defaultDHCPLeaseDiscoveryInterval is the default retry interval used
+	// when performing DHCP lease discovery.
+	defaultDHCPLeaseDiscoveryInterval = 2 * time.Second
+
+	// defaultDHCPLeaseDiscoveryTimeout is the default timeout period used when
+	// performing DHCP lease discovery. In the future we may want to make this
+	// configurable, but for now, it's a good default.
+	defaultDHCPLeaseDiscoveryTimeout = 30 * time.Second
 )
 
 // Controller implements to Net interface and is the main/only way in which the
@@ -14,6 +28,14 @@ import (
 type Controller struct {
 	logger  hclog.Logger
 	netConn libvirt.ConnectShim
+
+	dhcpLeaseDiscoveryInterval time.Duration
+	dhcpLeaseDiscoveryTimeout  time.Duration
+
+	// interfaceByIPGetter is the function that queries the host using the
+	// passed IP address and identifies the interface it is assigned to. It is
+	// a field within the controller to aid testing.
+	interfaceByIPGetter
 }
 
 // NewController returns a Controller which implements the net.Net interface
@@ -21,7 +43,16 @@ type Controller struct {
 // network system.
 func NewController(logger hclog.Logger, conn libvirt.ConnectShim) net.Net {
 	return &Controller{
-		logger:  logger.Named("net"),
-		netConn: conn,
+		dhcpLeaseDiscoveryInterval: defaultDHCPLeaseDiscoveryInterval,
+		dhcpLeaseDiscoveryTimeout:  defaultDHCPLeaseDiscoveryTimeout,
+		interfaceByIPGetter:        getInterfaceByIP,
+		logger:                     logger.Named("net"),
+		netConn:                    conn,
 	}
 }
+
+// interfaceByIPGetter is the function signature used to identify the host's
+// interface using a passed IP address. This is primarily used for testing,
+// where we don't know the host, and we want to ensure stability and
+// consistency when this is called.
+type interfaceByIPGetter func(ip stdnet.IP) (string, error)

--- a/libvirt/net/net_default.go
+++ b/libvirt/net/net_default.go
@@ -6,9 +6,22 @@
 package net
 
 import (
+	stdnet "net"
+
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 )
 
 func (c *Controller) Fingerprint(_ map[string]*structs.Attribute) {}
 
 func (c *Controller) Init() error { return nil }
+
+func (c *Controller) VMStartedBuild(_ *net.VMStartedBuildRequest) (*net.VMStartedBuildResponse, error) {
+	return nil, nil
+}
+
+func (c *Controller) VMTerminatedTeardown(_ *net.VMTerminatedTeardownRequest) (*net.VMTerminatedTeardownResponse, error) {
+	return nil, nil
+}
+
+func getInterfaceByIP(_ stdnet.IP) (string, error) { return "", nil }

--- a/libvirt/net/net_default_test.go
+++ b/libvirt/net/net_default_test.go
@@ -20,3 +20,28 @@ func TestController_Fingerprint(t *testing.T) {
 	mockController.Fingerprint(mockControllerAttrs)
 	must.Eq(t, map[string]*structs.Attribute{}, mockControllerAttrs)
 }
+
+func TestController_Init(t *testing.T) {
+	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
+	must.NoError(t, mockController.Init())
+}
+
+func TestController_PostStart(t *testing.T) {
+	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
+	resp, err := mockController.VMStartedBuild(nil)
+	must.NoError(t, err)
+	must.Nil(t, resp)
+}
+
+func TestController_PostStop(t *testing.T) {
+	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
+	resp, err := mockController.VMTerminatedTeardown(nil)
+	must.NoError(t, err)
+	must.Nil(t, resp)
+}
+
+func Test_getInterfaceByIP(t *testing.T) {
+	resp, err := getInterfaceByIP(nil)
+	must.NoError(t, err)
+	must.Eq(t, "", resp)
+}

--- a/libvirt/net/net_linux_test.go
+++ b/libvirt/net/net_linux_test.go
@@ -7,11 +7,18 @@ package net
 
 import (
 	"fmt"
+	stdnet "net"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
+	nomadstructs "github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 	"github.com/shoenig/test/must"
 )
@@ -59,33 +66,8 @@ func TestController_ensureIPTables(t *testing.T) {
 	must.SliceNotContains(t, filterChains, forwardIPTablesChainName)
 
 	// Add a cleanup function which will remove all the added iptables chain
-	// and rule entries. This avoids polluting the machine that runs the test,
-	// so our development machines do not require manual intervention after
-	// each test run.
-	//
-	// Any errors running the cleanup commands are logged, so developers can
-	// spot these and perform manual fixes. Manual fixes:
-	//  - sudo iptables -t filter -D FORWARD -j NOMAD_VT_FW
-	//  - sudo iptables -F NOMAD_VT_FW -t filter
-	//  - sudo iptables -X NOMAD_VT_FW -t filter
-	//  - sudo iptables -t nat -D PREROUTING -j NOMAD_VT_PRT
-	//  - sudo iptables -F NOMAD_VT_PRT -t nat
-	//  - sudo iptables -X NOMAD_VT_PRT -t nat
-	t.Cleanup(func() {
-		fn := func(e error) {
-			if e != nil {
-				t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
-			}
-		}
-
-		fn(ipt.Delete(iptablesNATTableName, "PREROUTING", []string{"-j", preroutingIPTablesChainName}...))
-		fn(ipt.ClearChain(iptablesNATTableName, preroutingIPTablesChainName))
-		fn(ipt.DeleteChain(iptablesNATTableName, preroutingIPTablesChainName))
-
-		fn(ipt.Delete(iptablesFilterTableName, "FORWARD", []string{"-j", forwardIPTablesChainName}...))
-		fn(ipt.ClearChain(iptablesFilterTableName, forwardIPTablesChainName))
-		fn(ipt.DeleteChain(iptablesFilterTableName, forwardIPTablesChainName))
-	})
+	// and rule entries.
+	t.Cleanup(func() { iptablesCleanup(t, ipt) })
 
 	mockController := &Controller{logger: hclog.NewNullLogger()}
 
@@ -137,4 +119,423 @@ func TestController_ensureIPTables(t *testing.T) {
 	filterRules, err = ipt.List(iptablesFilterTableName, "FORWARD")
 	must.NoError(t, err)
 	must.SliceContains(t, filterRules, "-A FORWARD -j "+forwardIPTablesChainName)
+}
+
+func TestController_VMStartedBuild(t *testing.T) {
+
+	mockController := &Controller{
+		dhcpLeaseDiscoveryInterval: 100 * time.Millisecond,
+		dhcpLeaseDiscoveryTimeout:  500 * time.Millisecond,
+		logger:                     hclog.NewNullLogger(),
+		netConn:                    &libvirt.ConnectMock{},
+		interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+	}
+
+	must.NoError(t, mockController.Init())
+
+	ipt, err := iptables.New()
+	must.NoError(t, err)
+
+	// Add a cleanup function which will remove all the added iptables chain
+	// and rule entries.
+	t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+	// Ensure passing a nil request object doesn't cause the function to panic.
+	nilRequestResp, err := mockController.VMStartedBuild(nil)
+	must.ErrorContains(t, err, "no request provided")
+	must.Nil(t, nilRequestResp)
+
+	// Ensure passing an empty request object doesn't cause the function to
+	// panic.
+	nilRequestResp, err = mockController.VMStartedBuild(&net.VMStartedBuildRequest{})
+	must.NoError(t, err)
+	must.Nil(t, nilRequestResp)
+
+	// Pass a request that doesn't contain any configured networks to ensure we
+	// correctly handle that.
+	emptyNetworkRequestResp, err := mockController.VMStartedBuild(&net.VMStartedBuildRequest{
+		NetConfig: &net.NetworkInterfacesConfig{},
+		Resources: &drivers.Resources{},
+	})
+	must.NoError(t, err)
+	must.Nil(t, emptyNetworkRequestResp)
+
+	// Test a correct and full request.
+	fullReq := net.VMStartedBuildRequest{
+		DomainName: "nomad-0ea818bc",
+		NetConfig: &net.NetworkInterfacesConfig{
+			{
+				Bridge: &net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh", "nomad"},
+				},
+			},
+		},
+		Resources: &drivers.Resources{
+			Ports: &nomadstructs.AllocatedPorts{
+				{
+					Label:  "ssh",
+					Value:  27494,
+					To:     22,
+					HostIP: "10.0.1.161",
+				},
+				{
+					Label:  "nomad",
+					Value:  27512,
+					To:     4646,
+					HostIP: "10.0.1.161",
+				},
+			},
+		},
+	}
+
+	fullReqResp, err := mockController.VMStartedBuild(&fullReq)
+	must.NoError(t, err)
+	must.NotNil(t, fullReqResp)
+	must.NotNil(t, fullReqResp.DriverNetwork)
+	must.NotNil(t, fullReqResp.TeardownSpec)
+
+	must.Eq(t, &drivers.DriverNetwork{IP: "192.168.122.58"}, fullReqResp.DriverNetwork)
+
+	expectedTeardownRules := [][]string{
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"22", "-j", "ACCEPT",
+		},
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:22",
+		},
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"4646", "-j", "ACCEPT",
+		},
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:4646",
+		},
+	}
+
+	must.EqFunc(t, expectedTeardownRules, fullReqResp.TeardownSpec.IPTablesRules, func(a, b [][]string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+
+		var found int
+
+		for _, ruleA := range a {
+			for _, ruleB := range b {
+				if !reflect.DeepEqual(ruleA, ruleB) {
+					continue
+				}
+				found++
+			}
+		}
+		return found == len(a)
+	})
+}
+
+func TestController_networkNameFromBridgeName(t *testing.T) {
+
+	// Create out controller which has a mocked connection with identified
+	// networks.
+	mockController := &Controller{
+		logger:  hclog.NewNullLogger(),
+		netConn: &libvirt.ConnectMock{},
+	}
+
+	// Query a non-existent network.
+	nonExistentResp, err := mockController.networkNameFromBridgeName("non-existent-bridge")
+	must.ErrorContains(t, err, "failed to find network with bridge")
+	must.Eq(t, nonExistentResp, "")
+
+	// Query a network which does exist.
+	virbr0Resp, err := mockController.networkNameFromBridgeName("virbr0")
+	must.NoError(t, err)
+	must.Eq(t, virbr0Resp, "default")
+
+	// Create a controller with a connection that does not have any identified
+	// networks. This allows us to ensure the behaviour is the same on hosts
+	// which have no networks, as one that do.
+	mockEmptyController := &Controller{
+		logger:  hclog.NewNullLogger(),
+		netConn: &libvirt.ConnectMockEmpty{},
+	}
+
+	mockEmptyResp, err := mockEmptyController.networkNameFromBridgeName("virbr0")
+	must.ErrorContains(t, err, "failed to find network with bridge")
+	must.Eq(t, mockEmptyResp, "")
+}
+
+func TestController_discoverDHCPLeaseIP(t *testing.T) {
+
+	// Create out controller which has a mocked connection with identified
+	// networks and low discovery time durations, so the tests do not take ages
+	// to run.
+	mockController := &Controller{
+		logger:                     hclog.NewNullLogger(),
+		netConn:                    &libvirt.ConnectMock{},
+		dhcpLeaseDiscoveryInterval: 100 * time.Millisecond,
+		dhcpLeaseDiscoveryTimeout:  500 * time.Millisecond,
+	}
+
+	defaultNet, err := mockController.netConn.LookupNetworkByName("default")
+	must.NoError(t, err)
+	must.NotNil(t, defaultNet)
+
+	// Query for a domain that does not have a lease entry and ensure the
+	// timeout is triggered.
+	nonExistentResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "non-existent-domain", "default")
+	must.ErrorContains(t, err, "timeout reached discovering DHCP lease")
+	must.Eq(t, nonExistentResp, "")
+
+	// Query for a domain which does have a lease.
+	existentResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-0ea818bc", "default")
+	must.NoError(t, err)
+	must.Eq(t, existentResp, "192.168.122.58")
+}
+
+func TestController_configureIPTables(t *testing.T) {
+
+	mockController := &Controller{
+		logger:              hclog.NewNullLogger(),
+		netConn:             &libvirt.ConnectMock{},
+		interfaceByIPGetter: func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+	}
+
+	// Create driver and network interface request arguments. The allocated
+	// ports includes a port not specified in the task config, to ensure this
+	// does not get configured.
+	driverReq := drivers.Resources{
+		Ports: &nomadstructs.AllocatedPorts{
+			{
+				Label:  "ssh",
+				Value:  27494,
+				To:     22,
+				HostIP: "10.0.1.161",
+			},
+			{
+				Label:  "nomad",
+				Value:  27512,
+				To:     4646,
+				HostIP: "10.0.1.161",
+			},
+			{
+				Label:  "http",
+				Value:  27513,
+				To:     80,
+				HostIP: "10.0.1.161",
+			},
+		},
+	}
+
+	netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+		Name:  "virbr0",
+		Ports: []string{"ssh", "nomad"},
+	}
+
+	// Init the controller, so we have the required iptables chains available.
+	must.NoError(t, mockController.Init())
+
+	ipt, err := iptables.New()
+	must.NoError(t, err)
+
+	// Add a cleanup function which will remove all the added iptables chain
+	// and rule entries.
+	t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+	// Execute the function, collecting the teardown rules and building our
+	// expected output.
+	actualTeardownRules, err := mockController.configureIPTables(
+		&driverReq, &netInterfaceReq, "192.168.122.58")
+	must.NoError(t, err)
+
+	expectedTeardownRules := [][]string{
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"22", "-j", "ACCEPT",
+		},
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:22",
+		},
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"4646", "-j", "ACCEPT",
+		},
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:4646",
+		},
+	}
+
+	// Perform the equality check ensuring the returned rules match exactly
+	// what we expected.
+	must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
+
+		if len(a) != len(b) {
+			return false
+		}
+
+		var found int
+
+		for _, ruleA := range a {
+			for _, ruleB := range b {
+				if !reflect.DeepEqual(ruleA, ruleB) {
+					continue
+				}
+				found++
+			}
+		}
+		return found == len(a)
+	})
+
+	// List the rules directly from the host to ensure we have also made
+	// changes there rather than just populate a return object.
+	//
+	// We can't use expectedTeardownRules as the iptables return includes
+	// bit length of the subnet mask.
+	expectedNATRules := [][]string{
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:22",
+		},
+		{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:4646",
+		},
+	}
+
+	natRules, err := ipt.List("nat", "NOMAD_VT_PRT")
+	must.NoError(t, err)
+	must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[0][1:], " "))
+	must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[1][1:], " "))
+
+	expectedFilterRules := [][]string{
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"22", "-j", "ACCEPT",
+		},
+		{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"4646", "-j", "ACCEPT",
+		},
+	}
+
+	filterRules, err := ipt.List("filter", "NOMAD_VT_FW")
+	must.NoError(t, err)
+	must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[0][1:], " "))
+	must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[1][1:], " "))
+}
+
+func TestController_VMTerminatedTeardown(t *testing.T) {
+
+	mockController := &Controller{logger: hclog.NewNullLogger()}
+
+	// Call the function with a nil argument, to ensure it handles this
+	// correctly and doesn't panic.
+	resp, err := mockController.VMTerminatedTeardown(nil)
+	must.NoError(t, err)
+	must.NotNil(t, resp)
+
+	// Create a couple of iptables entries we will use moving forward. They go
+	// into the default chains, rather than the custom driver ones, so we don't
+	// need to manage the init.
+	iptablesRules := [][]string{
+		{"filter", "FORWARD", "-d", "192.168.122.58", "-p", "tcp",
+			"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+			"22", "-j", "ACCEPT",
+		},
+		{"nat", "PREROUTING", "-d", "10.0.1.161", "-i", "enp126s0",
+			"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+			"--to-destination", "192.168.122.58:22",
+		},
+	}
+
+	// Create a teardown spec which has rules that do not exist currently on
+	// the host. It ensures we can loop through, without generating an error.
+	nonExistentRuleArgs := net.VMTerminatedTeardownRequest{
+		TeardownSpec: &net.TeardownSpec{
+			IPTablesRules: iptablesRules,
+		},
+	}
+	resp, err = mockController.VMTerminatedTeardown(&nonExistentRuleArgs)
+	must.NoError(t, err)
+	must.NotNil(t, resp)
+
+	// Grab a handle on iptables, so we can create a couple of test rules for
+	// deletion. The library and iptables uses a lock per write, so this won't
+	// conflict with calls to VMTerminatedTeardown.
+	ipt, err := iptables.New()
+	must.NoError(t, err)
+
+	// Add a cleanup function which will remove all the added iptables chain
+	// rule entries, in the event of a failure in the post stop failing to do
+	// this.
+	//
+	// Any errors running the cleanup commands are logged, so developers can
+	// spot these and perform manual fixes. To run a manual removal, execute
+	// "sudo iptables -D" followed by the arguments details in each of the
+	// arrays.
+	t.Cleanup(func() {
+		fn := func(e error) {
+			if e != nil {
+				t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
+			}
+		}
+		for _, rule := range iptablesRules {
+			fn(ipt.DeleteIfExists(rule[0], rule[1], rule[2:]...))
+		}
+	})
+
+	// Create some iptables rules, which are based on a real-world example.
+	for _, rule := range iptablesRules {
+		must.NoError(t, ipt.Append(rule[0], rule[1], rule[2:]...))
+	}
+
+	// Perform the post stop request and check that the entries have been
+	// removed by the process, as expected.
+	existentRuleArgs := net.VMTerminatedTeardownRequest{
+		TeardownSpec: &net.TeardownSpec{
+			IPTablesRules: iptablesRules,
+		},
+	}
+	resp, err = mockController.VMTerminatedTeardown(&existentRuleArgs)
+	must.NoError(t, err)
+	must.NotNil(t, resp)
+
+	for _, rule := range iptablesRules {
+		rules, err := ipt.List(rule[0], rule[1])
+		must.NoError(t, err)
+		must.SliceNotContains(t, rules, strings.Join(rule[2:], " "))
+	}
+}
+
+// iptablesCleanup can be used as a cleanup function which will remove all the
+// added iptables chain and rule entries. This avoids polluting the machine
+// that runs the test, so our development machines do not require manual
+// intervention after each test run.
+//
+// Any errors running the cleanup commands are logged, so developers can
+// spot these and perform manual fixes. Manual fixes:
+//   - sudo iptables -t filter -D FORWARD -j NOMAD_VT_FW
+//   - sudo iptables -F NOMAD_VT_FW -t filter
+//   - sudo iptables -X NOMAD_VT_FW -t filter
+//   - sudo iptables -t nat -D PREROUTING -j NOMAD_VT_PRT
+//   - sudo iptables -F NOMAD_VT_PRT -t nat
+//   - sudo iptables -X NOMAD_VT_PRT -t nat
+func iptablesCleanup(t *testing.T, ipt *iptables.IPTables) {
+	fn := func(e error) {
+		if e != nil {
+			t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
+		}
+	}
+
+	fn(ipt.Delete(iptablesNATTableName, "PREROUTING", []string{"-j", preroutingIPTablesChainName}...))
+	fn(ipt.ClearChain(iptablesNATTableName, preroutingIPTablesChainName))
+	fn(ipt.DeleteChain(iptablesNATTableName, preroutingIPTablesChainName))
+
+	fn(ipt.Delete(iptablesFilterTableName, "FORWARD", []string{"-j", forwardIPTablesChainName}...))
+	fn(ipt.ClearChain(iptablesFilterTableName, forwardIPTablesChainName))
+	fn(ipt.DeleteChain(iptablesFilterTableName, forwardIPTablesChainName))
 }

--- a/libvirt/net/net_test.go
+++ b/libvirt/net/net_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package net
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/shoenig/test/must"
+)
+
+func Test_NewController(t *testing.T) {
+	c := NewController(hclog.NewNullLogger(), nil).(*Controller)
+	must.Eq(t, c.dhcpLeaseDiscoveryInterval, defaultDHCPLeaseDiscoveryInterval)
+	must.Eq(t, c.dhcpLeaseDiscoveryTimeout, defaultDHCPLeaseDiscoveryTimeout)
+	must.NotNil(t, c.interfaceByIPGetter)
+}

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -4,11 +4,12 @@
 package net
 
 import (
+	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 )
 
 // Net is the interface that defines the virtualization network sub-system. It
-// should be the only link from the main driver and compute functionality, into
+// should be the only link from the main driver and 	compute functionality, into
 // the network. This helps encapsulate the logic making future development
 // easier, even allowing for this code to be moved into its own application if
 // desired.
@@ -27,6 +28,70 @@ type Net interface {
 	// a Nomad client's lifecycle. It should therefore be idempotent. Any error
 	// returned is considered fatal to the plugin.
 	Init() error
+
+	// VMStartedBuild performs any network configuration required once the
+	// driver has successfully started a VM. Any error returned will be
+	// considered terminal to the start of the VM and therefore halt any
+	// further progress and result in the task being restarted.
+	VMStartedBuild(*VMStartedBuildRequest) (*VMStartedBuildResponse, error)
+
+	// VMTerminatedTeardown performs all the network teardown required to clean
+	// the host and any systems of configuration specific to the task. If an
+	// error is encountered, Nomad will retry the stop/kill process, so all
+	// implementations must be able to support this and not enter death spirals
+	// when an error occurs.
+	VMTerminatedTeardown(*VMTerminatedTeardownRequest) (*VMTerminatedTeardownResponse, error)
+}
+
+// VMStartedBuildRequest is the request object used to ask the network
+// sub-system to perform its configuration, once a VM has been started.
+type VMStartedBuildRequest struct {
+	DomainName string
+	NetConfig  *NetworkInterfacesConfig
+	Resources  *drivers.Resources
+}
+
+// VMStartedBuildResponse is the response sent object once the network
+// sub-system has performed its configuration for a running VM.
+type VMStartedBuildResponse struct {
+
+	// DriverNetwork is the object returned to Nomad once the task is started
+	// and is used to populate service discovery. The network sub-system should
+	// fill in all details; the driver will not do this and simply pass the
+	// object straight onto Nomad.
+	DriverNetwork *drivers.DriverNetwork
+
+	// TeardownSpec contains a specification which will be stored in the task
+	// handle and used when stopping/killing the task. It should include
+	// information which either expedites the process or is critical to the
+	// process.
+	TeardownSpec *TeardownSpec
+}
+
+// VMTerminatedTeardownRequest is the request object used to ask the network
+// sub-system to perform its teardown of a VMs network configuration.
+type VMTerminatedTeardownRequest struct {
+	TeardownSpec *TeardownSpec
+}
+
+// VMTerminatedTeardownResponse is the response object returned when the
+// network sub-system has performed its teardown of a VMs network
+// configuration.
+type VMTerminatedTeardownResponse struct{}
+
+// TeardownSpec contains a specification which will be stored in the task
+// handle and used when stopping/killing the task. It should include
+// information which either expedites the process or is critical to the
+// process.
+type TeardownSpec struct {
+
+	// IPTablesRules specifies the rules used to build the initial VM
+	// networking. Each entry is a rule, the rule is a list of strings which
+	// mimics how iptables is called.
+	//   i[0] is the table name.
+	//   i[1] is the chain name.
+	//   i[2:] is the rule args.
+	IPTablesRules [][]string
 }
 
 const (


### PR DESCRIPTION
The net interface specifies new PostStart and PostStop functions which are responsible for adding and removing iptables rules for port mapping. The implementation discovers additional information from libvirt and the host in order to create the correct mapping.