### PR TITLE
net: link driver to net controller for initial functionality.

### DIFF
--- a/internal/shared/domain.go
+++ b/internal/shared/domain.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
 )
 
 const (
@@ -67,7 +68,6 @@ type Config struct {
 	BaseImage         string
 	DiskFmt           string
 	PrimaryDiskSize   uint64
-	NetworkInterfaces []string
 	HostName          string
 	Timezone          *time.Location
 	Mounts            []MountFileConfig
@@ -77,6 +77,8 @@ type Config struct {
 	CMDs              []string
 	BOOTCMDs          []string
 	CIUserData        string
+
+	NetworkInterfaces net.NetworkInterfacesConfig
 }
 
 func (dc *Config) Validate(allowedPaths []string) error {
@@ -114,6 +116,10 @@ func (dc *Config) Validate(allowedPaths []string) error {
 
 	if dc.HostName != "" && !IsValidLabel(dc.HostName) {
 		mErr = multierror.Append(mErr, ErrInvalidHostName)
+	}
+
+	if err := dc.NetworkInterfaces.Validate(); err != nil {
+		mErr = multierror.Append(mErr, err)
 	}
 
 	return mErr.ErrorOrNil()

--- a/libvirt/domain_config.go
+++ b/libvirt/domain_config.go
@@ -80,19 +80,21 @@ func parseConfiguration(config *domain.Config, cloudInitPath string) (string, er
 	}
 
 	interfaces := []libvirtxml.DomainInterface{}
-	for _, ni := range config.NetworkInterfaces {
-		i := libvirtxml.DomainInterface{
-			Source: &libvirtxml.DomainInterfaceSource{
-				Bridge: &libvirtxml.DomainInterfaceSourceBridge{
-					Bridge: ni,
-				},
-			},
-			Model: &libvirtxml.DomainInterfaceModel{
-				Type: defaultInterfaceModel,
-			},
+	if config.NetworkInterfaces != nil {
+		for _, networkInterface := range config.NetworkInterfaces {
+			if networkInterface.Bridge != nil {
+				interfaces = append(interfaces, libvirtxml.DomainInterface{
+					Source: &libvirtxml.DomainInterfaceSource{
+						Bridge: &libvirtxml.DomainInterfaceSourceBridge{
+							Bridge: networkInterface.Bridge.Name,
+						},
+					},
+					Model: &libvirtxml.DomainInterfaceModel{
+						Type: defaultInterfaceModel,
+					},
+				})
+			}
 		}
-
-		interfaces = append(interfaces, i)
 	}
 
 	vcpus := &libvirtxml.DomainVCPU{

--- a/libvirt/libvirt.go
+++ b/libvirt/libvirt.go
@@ -99,7 +99,7 @@ func WithCIController(ci CloudInit) Option {
 	}
 }
 
-func newConnection(uri string, user string, pass string) (*libvirt.Connect, error) {
+func NewConnection(uri string, user string, pass string) (*libvirt.Connect, error) {
 	if user == "" {
 		return libvirt.NewConnect(uri)
 	}
@@ -177,7 +177,7 @@ func New(ctx context.Context, logger hclog.Logger, options ...Option) (*driver, 
 		return nil, fmt.Errorf("libvirt: unable to create data dir: %w", err)
 	}
 
-	conn, err := newConnection(d.uri, d.user, d.password)
+	conn, err := NewConnection(d.uri, d.user, d.password)
 	if err != nil {
 		return nil, err
 	}

--- a/virt/driver.go
+++ b/virt/driver.go
@@ -14,10 +14,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	domain "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	virtnet "github.com/hashicorp/nomad-driver-virt/libvirt/net"
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -97,6 +100,15 @@ type VirtDriverPlugin struct {
 	signalShutdown context.CancelFunc
 	logger         hclog.Logger
 	dataDir        string
+
+	// networkController is the backend controller interface for the network
+	// subsystem.
+	networkController net.Net
+
+	// networkInit indicates whether the network subsystem has had its init
+	// function called. While the function should be idempotent, this helps
+	// avoid unnecessary calls and work.
+	networkInit atomic.Bool
 }
 
 // NewPlugin returns a new driver plugin
@@ -113,6 +125,7 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 		tasks:          newTaskStore(),
 		signalShutdown: cancel,
 		logger:         logger,
+		networkInit:    atomic.Bool{},
 	}
 }
 
@@ -161,6 +174,27 @@ func (d *VirtDriverPlugin) SetConfig(cfg *base.Config) error {
 
 	d.virtualizer = v
 	d.taskGetter = v
+
+	// Generate a new libvirt connection for the network controller.
+	//
+	// TODO(jrasell): the compute and network should use the same connection,
+	// so we should refactor the connection setup in a future change.
+	libvirtConnection, err := libvirt.NewConnection(config.Emulator.URI, config.Emulator.User, config.Emulator.Password)
+	if err != nil {
+		return fmt.Errorf("virt: failed to create network libvirt connection: %w", err)
+	}
+
+	// Generate the new network controller and perform the initialization if
+	// this is required.
+	d.networkController = virtnet.NewController(d.logger, libvirt.NewConnect(libvirtConnection))
+
+	if !d.networkInit.Load() {
+		if err := d.networkController.Init(); err != nil {
+			return fmt.Errorf("virt: failed to init network controller: %w", err)
+		} else {
+			d.networkInit.Store(true)
+		}
+	}
 
 	return nil
 }
@@ -222,6 +256,8 @@ func (d *VirtDriverPlugin) buildFingerprint() *drivers.Fingerprint {
 	attrs["driver.virt.emulator.version"] = structs.NewIntAttribute(int64(virtInfo.EmulatorVersion), "")
 	attrs["driver.virt.active"] = structs.NewIntAttribute(int64(virtInfo.RunningDomains), "")
 	attrs["driver.virt.inactive"] = structs.NewIntAttribute(int64(virtInfo.InactiveDomains), "bytes")
+
+	d.networkController.Fingerprint(attrs)
 
 	fp := &drivers.Fingerprint{
 		Attributes:        attrs,
@@ -296,6 +332,14 @@ func (d *VirtDriverPlugin) DestroyTask(taskID string, force bool) error {
 	err := d.virtualizer.DestroyDomain(taskName)
 	if err != nil {
 		return fmt.Errorf("virt: unable to destroy task %s: %w", taskID, err)
+	}
+
+	// Build our network request to send now that the VM has been destroyed.
+	netTeardownReq := net.VMTerminatedTeardownRequest{
+		TeardownSpec: handle.netTeardown,
+	}
+	if _, err := d.networkController.VMTerminatedTeardown(&netTeardownReq); err != nil {
+		return fmt.Errorf("virt: failed to destroy task network: %w", err)
 	}
 
 	d.tasks.Delete(taskName)
@@ -533,6 +577,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHand
 		Password:          driverConfig.DefaultUserPassword,
 		SSHKey:            driverConfig.DefaultUserSSHKey,
 		Files:             []domain.File{createEnvsFile(cfg.Env)},
+		NetworkInterfaces: driverConfig.NetworkInterfacesConfig,
 	}
 
 	if err := dc.Validate(allowedPaths); err != nil {
@@ -542,6 +587,21 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHand
 	if err := d.virtualizer.CreateDomain(dc); err != nil {
 		return nil, nil, fmt.Errorf("virt: failed to start task %s: %w", cfg.AllocID, err)
 	}
+
+	// Build our network request to send now that the VM has been started. The
+	// response will contain our teardown spec, which gets stored in the task
+	// handle, so we can easily perform deletions.
+	netBuildReq := net.VMStartedBuildRequest{
+		DomainName: hostname,
+		NetConfig:  &driverConfig.NetworkInterfacesConfig,
+		Resources:  cfg.Resources,
+	}
+
+	netBuildResp, err := d.networkController.VMStartedBuild(&netBuildReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("virt: failed to build task network: %w", err)
+	}
+	h.netTeardown = netBuildResp.TeardownSpec
 
 	d.logger.Info("task started successfully", "taskName", taskName)
 

--- a/virt/handle.go
+++ b/virt/handle.go
@@ -11,6 +11,7 @@ import (
 
 	domain "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/libvirt"
+	"github.com/hashicorp/nomad-driver-virt/virt/net"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/structs"
@@ -38,6 +39,10 @@ type taskHandle struct {
 	exitResult  *drivers.ExitResult
 
 	taskGetter DomainGetter
+
+	// netTeardown is the specification used to delete all the network
+	// configuration associated to a VM.
+	netTeardown *net.TeardownSpec
 }
 
 func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
@@ -151,5 +156,4 @@ func fillStats(info *domain.Info) *structs.TaskResourceUsage {
 			},
 		},
 	}
-
 }


### PR DESCRIPTION
The network controller provides fingerprinting, iptables setup, VM start and stop configuration handling. This commit links the main driver code, to the network controller, so that network functionality is now present in the driver for VM tasks.

A followup PR will be raised to handle restoration of the teardown spec within the taskhandle. This is used when destroying a VM for removing the IPTables entries.