### PR TITLE
docs: Fix artifact to show local task destination.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ job "python-server" {
 
       artifact {
         source      = "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-        destination = "focal-server-cloudimg-amd64.img"
+        destination = "local/focal-server-cloudimg-amd64.img"
         mode        = "file"
       }
 
       config {
-        image                 = "focal-server-cloudimg-amd64.img"
+        image                 = "local/focal-server-cloudimg-amd64.img"
         primary_disk_size     = 10000
         use_thin_copy         = true
         default_user_password = "password"
@@ -173,12 +173,12 @@ VM's OS.
   driver = "nomad-driver-virt"
       artifact {
         source      = "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-        destination = "focal-server-cloudimg-amd64.img"
+        destination = "local/focal-server-cloudimg-amd64.img"
         mode        = "file"
       } 
 
       config {
-        image                           = "focal-server-cloudimg-amd64.img"
+        image                           = "local/focal-server-cloudimg-amd64.img"
         primary_disk_size               = 9000
         use_thin_copy                   = true
         default_user_password           = "password"

--- a/examples/job.nomad.hcl
+++ b/examples/job.nomad.hcl
@@ -24,12 +24,12 @@ job "virt-example" {
 
       artifact {
         source      = "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-        destination = "focal-server-cloudimg-amd64.img"
+        destination = "local/focal-server-cloudimg-amd64.img"
         mode        = "file"
       } 
 
       config {
-        image                           = "focal-server-cloudimg-amd64.img"
+        image                           = "local/focal-server-cloudimg-amd64.img"
         primary_disk_size               = 26000
         use_thin_copy                   = true
         default_user_password           = "password"

--- a/examples/python.nomad.hcl
+++ b/examples/python.nomad.hcl
@@ -19,12 +19,12 @@ job "python-server" {
 
       artifact {
         source      = "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-        destination = "focal-server-cloudimg-amd64.img"
+        destination = "local/focal-server-cloudimg-amd64.img"
         mode        = "file"
       } 
 
       config {
-        image                 = "focal-server-cloudimg-amd64.img"
+        image                 = "local/focal-server-cloudimg-amd64.img"
         primary_disk_size     = 10000
         use_thin_copy         = true
         default_user_password = "password"


### PR DESCRIPTION
Without this, VMs will not start with the following error:

```
  msg=
  | rpc error: code = Unknown desc = virt: invalid configuration 2eeae670-095d-bfe2-d1d9-9e46bfcaa35f: 1 error occurred:
  | \t* base_image is not in the allowed paths
```

In the future we may also want to add the allocation dir to the allowed path default listing.