### PR TITLE
net: correctly return and handle started response with no network.

### DIFF
--- a/libvirt/net/net_default.go
+++ b/libvirt/net/net_default.go
@@ -17,11 +17,11 @@ func (c *Controller) Fingerprint(_ map[string]*structs.Attribute) {}
 func (c *Controller) Init() error { return nil }
 
 func (c *Controller) VMStartedBuild(_ *net.VMStartedBuildRequest) (*net.VMStartedBuildResponse, error) {
-	return nil, nil
+	return &net.VMStartedBuildResponse{}, nil
 }
 
 func (c *Controller) VMTerminatedTeardown(_ *net.VMTerminatedTeardownRequest) (*net.VMTerminatedTeardownResponse, error) {
-	return nil, nil
+	return &net.VMTerminatedTeardownResponse{}, nil
 }
 
 func getInterfaceByIP(_ stdnet.IP) (string, error) { return "", nil }

--- a/libvirt/net/net_default_test.go
+++ b/libvirt/net/net_default_test.go
@@ -26,18 +26,19 @@ func TestController_Init(t *testing.T) {
 	must.NoError(t, mockController.Init())
 }
 
-func TestController_PostStart(t *testing.T) {
+func TestController_VMStartedBuild(t *testing.T) {
 	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
 	resp, err := mockController.VMStartedBuild(nil)
 	must.NoError(t, err)
-	must.Nil(t, resp)
+	must.NotNil(t, resp)
+	must.Nil(t, resp.TeardownSpec)
 }
 
-func TestController_PostStop(t *testing.T) {
+func TestController_VMTerminatedTeardown(t *testing.T) {
 	mockController := NewController(hclog.NewNullLogger(), &libvirt.ConnectMock{})
 	resp, err := mockController.VMTerminatedTeardown(nil)
 	must.NoError(t, err)
-	must.Nil(t, resp)
+	must.NotNil(t, resp)
 }
 
 func Test_getInterfaceByIP(t *testing.T) {

--- a/libvirt/net/net_linux.go
+++ b/libvirt/net/net_linux.go
@@ -173,7 +173,7 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 		return nil, errors.New("net controller: no request provided")
 	}
 	if req.NetConfig == nil || req.Resources == nil {
-		return nil, nil
+		return &net.VMStartedBuildResponse{}, nil
 	}
 
 	// Dereference the network config and pull out the interface detail. The
@@ -185,7 +185,7 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 	// debugging which certainly caught me(jrasell) a few times in development.
 	if len(netConfig) == 0 {
 		c.logger.Debug("no network interface configured", "domain", req.DomainName)
-		return nil, nil
+		return &net.VMStartedBuildResponse{}, nil
 	}
 	netInterface := netConfig[0]
 

--- a/libvirt/net/net_linux_test.go
+++ b/libvirt/net/net_linux_test.go
@@ -149,7 +149,8 @@ func TestController_VMStartedBuild(t *testing.T) {
 	// panic.
 	nilRequestResp, err = mockController.VMStartedBuild(&net.VMStartedBuildRequest{})
 	must.NoError(t, err)
-	must.Nil(t, nilRequestResp)
+	must.NotNil(t, nilRequestResp)
+	must.Nil(t, nilRequestResp.TeardownSpec)
 
 	// Pass a request that doesn't contain any configured networks to ensure we
 	// correctly handle that.
@@ -158,7 +159,8 @@ func TestController_VMStartedBuild(t *testing.T) {
 		Resources: &drivers.Resources{},
 	})
 	must.NoError(t, err)
-	must.Nil(t, emptyNetworkRequestResp)
+	must.NotNil(t, emptyNetworkRequestResp)
+	must.Nil(t, emptyNetworkRequestResp.TeardownSpec)
 
 	// Test a correct and full request.
 	fullReq := net.VMStartedBuildRequest{

--- a/virt/driver.go
+++ b/virt/driver.go
@@ -670,7 +670,11 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHand
 		return nil, nil, fmt.Errorf("virt: failed to build task network: %w", err)
 	}
 
-	h.netTeardown = netBuildResp.TeardownSpec
+	// If the VM did not include any network configuration, there will not be a
+	// teardown spec.
+	if netBuildResp.TeardownSpec != nil {
+		h.netTeardown = netBuildResp.TeardownSpec
+	}
 
 	d.logger.Info("task started successfully", "taskName", taskName)
 


### PR DESCRIPTION
It is possible operators do not configure a network for a VM driver task. In this case, the plugin should correctly handle the response from the network controller.

Along with the main fix, the change updates the controller responses, so that an object is returned when there isn't an error. This is because returning nil,nil is a weird pattern in Go and catches people out; even the person that wrote it.