### PR TITLE
docs: update examples to use python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ job "python-server" {
         primary_disk_size     = 10000
         use_thin_copy         = true
         default_user_password = "password"
-        cmds                  = ["python -m http.server 8000"]
+        cmds                  = ["python3 -m http.server 8000"]
 
         network_interface {
           bridge {

--- a/examples/python.nomad.hcl
+++ b/examples/python.nomad.hcl
@@ -28,7 +28,7 @@ job "python-server" {
         primary_disk_size     = 10000
         use_thin_copy         = true
         default_user_password = "password"
-        cmds                  = ["python -m http.server 8000"]
+        cmds                  = ["python3 -m http.server 8000"]
 
         network_interface {
           bridge {


### PR DESCRIPTION
The Ubuntu Focal image used in the examples doesn't have a binary named `python`, just `python3`.