### PR TITLE
fingerprint: remove active/inactive domains attributes

### DIFF
--- a/virt/driver.go
+++ b/virt/driver.go
@@ -288,8 +288,8 @@ func (d *VirtDriverPlugin) buildFingerprint() *drivers.Fingerprint {
 	attrs["driver.virt"] = structs.NewBoolAttribute(true)
 	attrs["driver.virt.libvirt.version"] = structs.NewIntAttribute(int64(virtInfo.LibvirtVersion), "")
 	attrs["driver.virt.emulator.version"] = structs.NewIntAttribute(int64(virtInfo.EmulatorVersion), "")
-	attrs["driver.virt.active"] = structs.NewIntAttribute(int64(virtInfo.RunningDomains), "")
-	attrs["driver.virt.inactive"] = structs.NewIntAttribute(int64(virtInfo.InactiveDomains), "bytes")
+	attrs["driver.virt.domains.active"] = structs.NewIntAttribute(int64(virtInfo.RunningDomains), "")
+	attrs["driver.virt.domains.inactive"] = structs.NewIntAttribute(int64(virtInfo.InactiveDomains), "")
 
 	d.networkController.Fingerprint(attrs)
 

--- a/virt/driver.go
+++ b/virt/driver.go
@@ -288,8 +288,6 @@ func (d *VirtDriverPlugin) buildFingerprint() *drivers.Fingerprint {
 	attrs["driver.virt"] = structs.NewBoolAttribute(true)
 	attrs["driver.virt.libvirt.version"] = structs.NewIntAttribute(int64(virtInfo.LibvirtVersion), "")
 	attrs["driver.virt.emulator.version"] = structs.NewIntAttribute(int64(virtInfo.EmulatorVersion), "")
-	attrs["driver.virt.domains.active"] = structs.NewIntAttribute(int64(virtInfo.RunningDomains), "")
-	attrs["driver.virt.domains.inactive"] = structs.NewIntAttribute(int64(virtInfo.InactiveDomains), "")
 
 	d.networkController.Fingerprint(attrs)
 


### PR DESCRIPTION
The `driver.virt.active` and `driver.virt.inactive` attributes reflect the number of VMs running. But this data is already available to the Nomad servers via `Node.UpdateStatus` RPCs. Sending it as part of a periodic fingerprint will cause Nomad client nodes to update their fingerprints regularly, kicking off new evaluations for all the jobs on the node.

---

Note to reviewers: this PR originally had this description:
> The `driver.virt.inactive` attribute was being incorrectly suffixed with "bytes". The names of the fingerprinted fields for the number of active and inactive domains are potentially confusing, as they don't refer to what about the driver is active or inactive. Adjust the name to include `domains` in such a way that active and inactive domains will sort together.

But then I realized the extra evals we'd be creating. If I'm misunderstanding the purpose of these attributes then I'd suggest we at least take the first commit in this PR.