### PR TITLE
Sync the default plugin data directory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Ensure that Nomad can find the plugin, see [plugin_dir](https://www.nomadproject
   * **password** - Password for the [connection authentication](https://libvirt.org/auth.html).
 
 * **data_dir** - The plugin will create VM configuration files and intermediate files in
-  this directory. If not defined it will default to `/opt/virt`.
+  this directory. If not defined it will default to `/var/lib/virt`.
 * **image_paths** - Specifies the host paths the QEMU driver is allowed to load images from. If not defined, it defaults to the plugin data_dir directory and alloc directory.
 
 ```hcl

--- a/virt/config.go
+++ b/virt/config.go
@@ -22,11 +22,7 @@ var (
 			"user":     hclspec.NewAttr("user", "string", false),
 			"password": hclspec.NewAttr("password", "string", false),
 		})),
-
-		"data_dir": hclspec.NewDefault(
-			hclspec.NewAttr("data_dir", "string", false),
-			hclspec.NewLiteral(`"/var/lib/virt"`),
-		),
+		"data_dir":     hclspec.NewAttr("data_dir", "string", false),
 		"image_paths": hclspec.NewAttr("image_paths", "list(string)", false),
 	})
 

--- a/virt/config.go
+++ b/virt/config.go
@@ -25,7 +25,7 @@ var (
 
 		"data_dir": hclspec.NewDefault(
 			hclspec.NewAttr("data_dir", "string", false),
-			hclspec.NewLiteral(`"/opt/virt"`),
+			hclspec.NewLiteral(`"/var/lib/virt"`),
 		),
 		"image_paths": hclspec.NewAttr("image_paths", "list(string)", false),
 	})


### PR DESCRIPTION
The default value for `data_dir` was different in the plugin configuration and the driver package.