### PR TITLE
libvirt: check connection before usage within driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## UNRELEASED
 
+BUG FIXES:
+
+* libvirt: Automatically reconnect when required [GH-129](https://github.com/hashicorp/nomad-driver-virt/pull/129)
+
+IMPROVEMENTS:
+
 * build: Update Nomad verison to 1.10.0 [GH-111](https://github.com/hashicorp/nomad-driver-virt/pull/111)
 * build: Update Go to 1.24.2 [GH-111](https://github.com/hashicorp/nomad-driver-virt/pull/111)
 

--- a/virt/driver.go
+++ b/virt/driver.go
@@ -649,7 +649,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHand
 		taskConfig: cfg,
 		procState:  drivers.TaskStateRunning,
 		startedAt:  time.Now().Round(time.Millisecond),
-		logger:     d.logger.Named("handle").With(cfg.AllocID),
+		logger:     d.logger.Named("handle").With("alloc-id", cfg.AllocID),
 		taskGetter: d.taskGetter,
 		name:       taskName,
 	}
@@ -728,7 +728,7 @@ func (d *VirtDriverPlugin) RecoverTask(handle *drivers.TaskHandle) error {
 
 	h := &taskHandle{
 		name:        domainNameFromTaskID(handle.Config.ID),
-		logger:      d.logger.Named("handle").With(handle.Config.AllocID),
+		logger:      d.logger.Named("handle").With("alloc-id", handle.Config.AllocID),
 		taskConfig:  taskState.TaskConfig,
 		startedAt:   taskState.StartedAt,
 		taskGetter:  d.taskGetter,

--- a/virt/handle.go
+++ b/virt/handle.go
@@ -91,7 +91,7 @@ func (h *taskHandle) monitor(ctx context.Context, exitCh chan<- *drivers.ExitRes
 		case <-ticker.C:
 			domain, err := h.taskGetter.GetDomain(h.name)
 			if err != nil {
-				h.logger.Error("virt: unable to get task's %s state: %w", h.name, err)
+				h.logger.Error("virt: unable to get task state", "task", h.name, "error", err)
 				h.stateLock.Lock()
 				h.procState = drivers.TaskStateUnknown
 				h.stateLock.Unlock()


### PR DESCRIPTION
When using the libvirt connection, check that the connection is
alive before usage. If it is not, or the check errors, build
a new connection. This prevents the plugin from entering an
unrecoverable state if the connection is unexpectedly closed
or reset.

Fixes #104
