### PR TITLE
net: reserve DHCP address once assigned

### DIFF
--- a/libvirt/conn_mock.go
+++ b/libvirt/conn_mock.go
@@ -81,6 +81,18 @@ func (cm *ConnectMock) LookupNetworkByName(name string) (ConnectNetworkShim, err
 					Clientid:   "ff:08:24:45:0e:00:02:00:00:ab:11:35:ab:f3:c7:ac:54:9e:bb",
 				},
 			},
+			xmlDesc: `<network>
+  <name>default</name>
+  <uuid>dd8fe884-6c02-601e-7551-cca97df1c5df</uuid>
+  <forward mode='nat'/>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+      <host mac="00:11:22:33:44:55" name="test-hostname" ip="192.168.122.45" />
+    </dhcp>
+  </ip>
+</network>`,
 		}, nil
 	case "routed":
 		return &ConnectNetworkMock{
@@ -113,6 +125,7 @@ type ConnectNetworkMock struct {
 	active     bool
 	bridgeName string
 	dhcpLeases []libvirt.NetworkDHCPLease
+	xmlDesc    string
 }
 
 func (cnm *ConnectNetworkMock) IsActive() (bool, error) { return cnm.active, nil }
@@ -121,4 +134,12 @@ func (cnm *ConnectNetworkMock) GetBridgeName() (string, error) { return cnm.brid
 
 func (cnm *ConnectNetworkMock) GetDHCPLeases() ([]libvirt.NetworkDHCPLease, error) {
 	return cnm.dhcpLeases, nil
+}
+
+func (cnm *ConnectNetworkMock) GetXMLDesc(flags libvirt.NetworkXMLFlags) (string, error) {
+	return cnm.xmlDesc, nil
+}
+
+func (cnm *ConnectNetworkMock) Update(cmd libvirt.NetworkUpdateCommand, section libvirt.NetworkUpdateSection, parentIndex int, xml string, flags libvirt.NetworkUpdateFlags) error {
+	return nil
 }

--- a/libvirt/conn_shim.go
+++ b/libvirt/conn_shim.go
@@ -56,4 +56,16 @@ type ConnectNetworkShim interface {
 	// Also see:
 	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkGetDHCPLeases
 	GetDHCPLeases() ([]libvirt.NetworkDHCPLease, error)
+
+	// Update the definition of an existing network, either its live running state, its persistent configuration, or both.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkUpdate
+	Update(cmd libvirt.NetworkUpdateCommand, section libvirt.NetworkUpdateSection, parentIndex int, xml string, flags libvirt.NetworkUpdateFlags) error
+
+	// Provide an XML description of the network.
+	//
+	// Also see:
+	// https://libvirt.org/html/libvirt-libvirt-network.html#virNetworkGetXMLDesc
+	GetXMLDesc(flags libvirt.NetworkXMLFlags) (string, error)
 }

--- a/libvirt/net/net_linux.go
+++ b/libvirt/net/net_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 	lv "libvirt.org/go/libvirt"
+	"libvirt.org/go/libvirtxml"
 )
 
 const (
@@ -200,9 +201,15 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 		return nil, fmt.Errorf("failed to lookup network: %w", err)
 	}
 
-	ipAddr, err := c.discoverDHCPLeaseIP(network, req.Hostname, networkName, req.Hwaddrs)
+	ipAddr, macAddr, err := c.discoverDHCPLeaseIP(network, req.Hostname, networkName, req.Hwaddrs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover IP address: %w", err)
+	}
+
+	// Register the IP to the domain to ensure it does not change.
+	dhcpEntry, err := c.reserveIP(network, ipAddr, req.Hostname, macAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register IP address: %w", err)
 	}
 
 	teardownRules, err := c.configureIPTables(req.Resources, netInterface.Bridge, ipAddr)
@@ -215,9 +222,37 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 			IP: ipAddr,
 		},
 		TeardownSpec: &net.TeardownSpec{
-			IPTablesRules: teardownRules,
+			IPTablesRules:   teardownRules,
+			DHCPReservation: dhcpEntry,
+			Network:         networkName,
 		},
 	}, nil
+}
+
+// reserveIP reserves an IP address with the DHCP server for a specific domain
+// based on MAC address and hostname.
+func (c *Controller) reserveIP(network libvirt.ConnectNetworkShim, ipAddr, hostname, mac string) (string, error) {
+	reservation := libvirtxml.NetworkDHCPHost{
+		IP:   ipAddr,
+		MAC:  mac,
+		Name: hostname,
+	}
+
+	c.logger.Debug("adding dhcp reservation", "reservation", reservation)
+
+	entry, err := reservation.Marshal()
+	if err != nil {
+		return "", err
+	}
+
+	err = network.Update(lv.NETWORK_UPDATE_COMMAND_ADD_LAST, lv.NETWORK_SECTION_IP_DHCP_HOST,
+		-1, entry, lv.NETWORK_UPDATE_AFFECT_LIVE|lv.NETWORK_UPDATE_AFFECT_CONFIG)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to update network: %w", err)
+	}
+
+	return entry, nil
 }
 
 // networkNameFromBridgeName translates the name of a bridge network interface
@@ -254,7 +289,7 @@ func (c *Controller) networkNameFromBridgeName(name string) (string, error) {
 // network. The function includes a ticker in order to poll for the information
 // as this can take several seconds to become available.
 func (c *Controller) discoverDHCPLeaseIP(
-	network libvirt.ConnectNetworkShim, hostname, netName string, hwaddrs []string) (string, error) {
+	network libvirt.ConnectNetworkShim, hostname, netName string, hwaddrs []string) (ipAddr string, macAddr string, err error) {
 
 	ticker := time.NewTicker(c.dhcpLeaseDiscoveryInterval)
 	defer ticker.Stop()
@@ -327,9 +362,12 @@ func (c *Controller) discoverDHCPLeaseIP(
 				return a.ExpiryTime.Compare(b.ExpiryTime)
 			})
 
-			return matches[len(matches)-1].IPaddr, nil
+			lease := matches[len(matches)-1]
+
+			return lease.IPaddr, lease.Mac, nil
+
 		case <-timeout.C:
-			return "", fmt.Errorf("timeout reached discovering DHCP lease for %q", hostname)
+			return "", "", fmt.Errorf("timeout reached discovering DHCP lease for %q", hostname)
 		}
 	}
 }
@@ -498,5 +536,64 @@ func (c *Controller) VMTerminatedTeardown(req *net.VMTerminatedTeardownRequest) 
 		}
 	}
 
+	// Remove the DHCP IP reservation
+	if err := c.removeIPReservation(req.TeardownSpec.Network, req.TeardownSpec.DHCPReservation); err != nil {
+		mErr.Errors = append(
+			mErr.Errors,
+			fmt.Errorf("failed to update network for IP reservation removal: %w", err))
+	}
+
 	return &net.VMTerminatedTeardownResponse{}, mErr.ErrorOrNil()
+}
+
+// removeIPReservation removes the DHCP IP reservation if it exists.
+func (c *Controller) removeIPReservation(networkName, reservation string) error {
+	if reservation == "" {
+		return nil
+	}
+
+	network, err := c.netConn.LookupNetworkByName(networkName)
+	if err != nil {
+		return fmt.Errorf("failed to find network %q: %w", networkName, err)
+	}
+
+	exists, err := c.ipReservationExists(network, reservation)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		c.logger.Debug("ip reservation not found", "reservation", reservation)
+
+		return nil
+	}
+
+	err = network.Update(lv.NETWORK_UPDATE_COMMAND_DELETE, lv.NETWORK_SECTION_IP_DHCP_HOST, -1,
+		reservation, lv.NETWORK_UPDATE_AFFECT_LIVE|lv.NETWORK_UPDATE_AFFECT_CONFIG)
+
+	return err
+}
+
+// ipReservationExists checks if the DHCP reservation currently exists.
+func (c *Controller) ipReservationExists(network libvirt.ConnectNetworkShim, reservation string) (bool, error) {
+	res := &libvirtxml.NetworkDHCPHost{}
+	if err := res.Unmarshal(reservation); err != nil {
+		return false, fmt.Errorf("could not parse IP reservation: %w", err)
+	}
+
+	networkCfg := &libvirtxml.Network{}
+	networkDoc, err := network.GetXMLDesc(0)
+	if err = networkCfg.Unmarshal(networkDoc); err != nil {
+		return false, err
+	}
+
+	for _, ip := range networkCfg.IPs {
+		for _, host := range ip.DHCP.Hosts {
+			if host.IP == res.IP && host.MAC == res.MAC && host.Name == res.Name {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/libvirt/net/net_linux_test.go
+++ b/libvirt/net/net_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 	"github.com/shoenig/test/must"
+	"libvirt.org/go/libvirtxml"
 )
 
 func TestController_Fingerprint(t *testing.T) {
@@ -289,40 +290,53 @@ func TestController_discoverDHCPLeaseIP(t *testing.T) {
 
 	// Query for a domain that does not have a lease entry and ensure the
 	// timeout is triggered.
-	nonExistentResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "non-existent-domain",
+	nonExistentResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "non-existent-domain",
 		"default", []string{"00:00:00:00:00:00"})
 	must.ErrorContains(t, err, "timeout reached discovering DHCP lease")
 	must.Eq(t, nonExistentResp, "")
+	must.Eq(t, mac, "")
 
 	// Query for a domain which does have a lease.
-	existentResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-0ea818bc",
+	existentResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-0ea818bc",
 		"default", []string{"52:54:00:1c:7c:14"})
 	must.NoError(t, err)
 	must.Eq(t, existentResp, "192.168.122.58")
+	must.Eq(t, mac, "52:54:00:1c:7c:14")
+
+	// Query for a domain which does have a lease using multiple MAC addresses.
+	existentResp, mac, err = mockController.discoverDHCPLeaseIP(defaultNet, "nomad-0ea818bc",
+		"default", []string{"11:11:11:11:11:11", "52:54:00:1c:7c:14", "22:22:22:22:22:22"})
+	must.NoError(t, err)
+	must.Eq(t, existentResp, "192.168.122.58")
+	must.Eq(t, mac, "52:54:00:1c:7c:14")
 
 	// Query for a domain with several matching leases.
-	multiResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-3edc43aa",
+	multiResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-3edc43aa",
 		"default", []string{"11:22:33:44:55:66"})
 	must.NoError(t, err)
 	must.Eq(t, multiResp, "192.168.122.65")
+	must.Eq(t, mac, "11:22:33:44:55:66")
 
 	// Query for domain with matching expired lease.
-	expiredResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-eabba892",
+	expiredResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "nomad-eabba892",
 		"default", []string{"66:55:44:33:22:11"})
 	must.ErrorContains(t, err, "timeout reached discovering DHCP lease")
 	must.Eq(t, expiredResp, "")
+	must.Eq(t, mac, "")
 
 	// Query for domain with matching MAC address only.
-	macOnlyResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "different-hostname",
+	macOnlyResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "different-hostname",
 		"default", []string{"52:54:00:1c:7c:14"})
 	must.ErrorContains(t, err, "timeout reached discovering DHCP lease")
 	must.Eq(t, macOnlyResp, "")
+	must.Eq(t, mac, "")
 
 	// Query for domain with matching MAC address and empty hostname on lease.
-	macOnlyNoHostnameResp, err := mockController.discoverDHCPLeaseIP(defaultNet, "custom-hostname",
+	macOnlyNoHostnameResp, mac, err := mockController.discoverDHCPLeaseIP(defaultNet, "custom-hostname",
 		"default", []string{"11:22:11:22:11:22"})
 	must.NoError(t, err)
 	must.Eq(t, macOnlyNoHostnameResp, "192.168.122.99")
+	must.Eq(t, mac, "11:22:11:22:11:22")
 }
 
 func TestController_configureIPTables(t *testing.T) {
@@ -460,7 +474,10 @@ func TestController_configureIPTables(t *testing.T) {
 
 func TestController_VMTerminatedTeardown(t *testing.T) {
 
-	mockController := &Controller{logger: hclog.NewNullLogger()}
+	mockController := &Controller{
+		logger:  hclog.NewNullLogger(),
+		netConn: &libvirt.ConnectMock{},
+	}
 
 	// Call the function with a nil argument, to ensure it handles this
 	// correctly and doesn't panic.
@@ -487,6 +504,7 @@ func TestController_VMTerminatedTeardown(t *testing.T) {
 	nonExistentRuleArgs := net.VMTerminatedTeardownRequest{
 		TeardownSpec: &net.TeardownSpec{
 			IPTablesRules: iptablesRules,
+			Network:       "default",
 		},
 	}
 	resp, err = mockController.VMTerminatedTeardown(&nonExistentRuleArgs)
@@ -528,6 +546,7 @@ func TestController_VMTerminatedTeardown(t *testing.T) {
 	existentRuleArgs := net.VMTerminatedTeardownRequest{
 		TeardownSpec: &net.TeardownSpec{
 			IPTablesRules: iptablesRules,
+			Network:       "default",
 		},
 	}
 	resp, err = mockController.VMTerminatedTeardown(&existentRuleArgs)
@@ -538,6 +557,117 @@ func TestController_VMTerminatedTeardown(t *testing.T) {
 		rules, err := ipt.List(rule[0], rule[1])
 		must.NoError(t, err)
 		must.SliceNotContains(t, rules, strings.Join(rule[2:], " "))
+	}
+}
+
+func Test_removeIPReservation(t *testing.T) {
+	mockController := &Controller{
+		logger:  hclog.NewNullLogger(),
+		netConn: &libvirt.ConnectMock{},
+	}
+
+	testCases := []struct {
+		desc        string
+		network     string
+		reservation *libvirtxml.NetworkDHCPHost
+		err         string
+	}{
+		{
+			desc:    "reservation does not exist",
+			network: "default",
+			reservation: &libvirtxml.NetworkDHCPHost{
+				IP:   "127.0.0.1",
+				MAC:  "00:00:00:11:11:11",
+				Name: "testing",
+			},
+		},
+		{
+			desc:    "reservation exists",
+			network: "default",
+			reservation: &libvirtxml.NetworkDHCPHost{
+				IP:   "192.168.122.45",
+				MAC:  "00:11:22:33:44:55",
+				Name: "test-hostname",
+			},
+		},
+		{
+			desc:    "network does not exist",
+			network: "does-not-exist",
+			reservation: &libvirtxml.NetworkDHCPHost{
+				IP:   "192.168.122.45",
+				MAC:  "00:11:22:33:44:55",
+				Name: "test-hostname",
+			},
+			err: "failed to find network",
+		},
+	}
+
+	for _, tc := range testCases {
+		entry, err := tc.reservation.Marshal()
+		must.NoError(t, err)
+
+		err = mockController.removeIPReservation(tc.network, entry)
+		if tc.err != "" {
+			println("looked up network", tc.network)
+			must.ErrorContains(t, err, tc.err)
+		} else {
+			must.NoError(t, err)
+		}
+	}
+}
+
+func Test_ipReservationExists(t *testing.T) {
+	mockController := &Controller{
+		logger:  hclog.NewNullLogger(),
+		netConn: &libvirt.ConnectMock{},
+	}
+
+	testCases := []struct {
+		desc           string
+		reservation    *libvirtxml.NetworkDHCPHost
+		reservationRaw string
+		exists         bool
+		err            string
+	}{
+		{
+			desc: "reservation does not exist",
+			reservation: &libvirtxml.NetworkDHCPHost{
+				IP:   "127.0.0.1",
+				MAC:  "00:00:00:11:11:11",
+				Name: "testing",
+			},
+		},
+		{
+			desc: "reservation exists",
+			reservation: &libvirtxml.NetworkDHCPHost{
+				IP:   "192.168.122.45",
+				MAC:  "00:11:22:33:44:55",
+				Name: "test-hostname",
+			},
+			exists: true,
+		},
+		{
+			desc:           "invalid reservation",
+			reservationRaw: "-",
+			exists:         false,
+			err:            "could not parse",
+		},
+	}
+
+	network, err := mockController.netConn.LookupNetworkByName("default")
+	must.NoError(t, err)
+
+	for _, tc := range testCases {
+		entry, err := tc.reservation.Marshal()
+		must.NoError(t, err)
+
+		exists, err := mockController.ipReservationExists(network, entry)
+		must.Eq(t, tc.exists, exists)
+		if tc.err != "" {
+			must.ErrorContains(t, err, tc.err)
+		} else {
+			must.NoError(t, err)
+		}
 	}
 }
 

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -74,6 +74,14 @@ type TeardownSpec struct {
 	//   i[1] is the chain name.
 	//   i[2:] is the rule args.
 	IPTablesRules [][]string
+
+	// DHCPReservation specifies the reservation string used for registering
+	// a DHCP address for a domain.
+	DHCPReservation string
+
+	// Network is the name of the network used and which provided the
+	// DHCP lease.
+	Network string
 }
 
 // IsActiveString converts the boolean response from the IsActive call of


### PR DESCRIPTION
Once the DHCP address has been discovered add a reservation so
the address is statically tied to the domain. Reservation information
is added to the teardown spec so it can be removed when the domain
is destroyed.
