### PR TITLE
net: release DHCP lease on teardown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/go-iptables v0.8.0
 	github.com/diskfs/go-diskfs v1.7.0
 	github.com/docker/distribution v2.8.3+incompatible
+	github.com/gopacket/gopacket v1.4.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-set v0.1.14

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopacket/gopacket v1.4.0 h1:cr1OlFpzksCkZHNO0eLjaSSOrMQnpPXg0j6qHIY3y2U=
+github.com/gopacket/gopacket v1.4.0/go.mod h1:EpvsxINeehp5qj4YMKMLf2/dekdhKn2IIAO/ZOifS7o=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/libvirt/net/net.go
+++ b/libvirt/net/net.go
@@ -35,6 +35,10 @@ type Controller struct {
 	// passed IP address and identifies the interface it is assigned to. It is
 	// a field within the controller to aid testing.
 	interfaceByIPGetter
+
+	// ipByInterfaceGetter is the function that queries the host using the
+	// passed interface name and identifies the IP address assigned to it.
+	ipByInterfaceGetter
 }
 
 // NewController returns a Controller which implements the net.Net interface
@@ -45,6 +49,7 @@ func NewController(logger hclog.Logger, conn libvirt.ConnectShim) *Controller {
 		dhcpLeaseDiscoveryInterval: defaultDHCPLeaseDiscoveryInterval,
 		dhcpLeaseDiscoveryTimeout:  defaultDHCPLeaseDiscoveryTimeout,
 		interfaceByIPGetter:        getInterfaceByIP,
+		ipByInterfaceGetter:        getIPByInterface,
 		logger:                     logger.Named("net"),
 		netConn:                    conn,
 	}
@@ -55,3 +60,7 @@ func NewController(logger hclog.Logger, conn libvirt.ConnectShim) *Controller {
 // where we don't know the host, and we want to ensure stability and
 // consistency when this is called.
 type interfaceByIPGetter func(ip stdnet.IP) (string, error)
+
+// ipByInterfaceGetter is the function that queries the host using the
+// passed interface name and identifies the IP address assigned to it.
+type ipByInterfaceGetter func(name string) (stdnet.IP, error)


### PR DESCRIPTION
When performing the network teardown, make a best effort to remove
the DHCP lease that was assigned to the VM. There is no direct API
for removing a DHCP lease, but it can be accomplished by constructing
a custom release packet and sending it to the DHCP server. Since
the lease removal is only best effort, any errors that are encountered
are simply logged.

The crafting of a DHCP release packet was found in the [dhcp release](https://github.com/imp/dnsmasq/blob/770bce967cfc9967273d0acfb3ea018fb7b17522/contrib/lease-tools/dhcp_release.c#L258) 
tool.

Fixes #68
