### PR TITLE
libvirt: allow insecure readonly virtiofs host mounts

### DIFF
--- a/providers/libvirt/config.go
+++ b/providers/libvirt/config.go
@@ -13,9 +13,10 @@ var configSpec = hclspec.NewBlock("libvirt", false, hclspec.NewObject(map[string
 		hclspec.NewAttr("uri", "string", false),
 		hclspec.NewLiteral(`"qemu:///system"`),
 	),
-	"user":     hclspec.NewAttr("user", "string", false),
-	"password": hclspec.NewAttr("password", "string", false),
-	"default":  hclspec.NewAttr("default", "bool", false),
+	"user":                           hclspec.NewAttr("user", "string", false),
+	"password":                       hclspec.NewAttr("password", "string", false),
+	"default":                        hclspec.NewAttr("default", "bool", false),
+	"allow_insecure_readonly_mounts": hclspec.NewAttr("allow_insecure_readonly_mounts", "bool", false),
 }))
 
 // ConfigSpec returns the HCL spec for the libvirt provider configuration.
@@ -25,8 +26,9 @@ func ConfigSpec() *hclspec.Spec {
 
 // Configuration supported by this provider.
 type Config struct {
-	URI      string `codec:"uri"`
-	User     string `codec:"user"`
-	Password string `codec:"password"`
-	Default  bool   `codec:"default"`
+	URI                 string `codec:"uri"`
+	User                string `codec:"user"`
+	Password            string `codec:"password"`
+	Default             bool   `codec:"default"`
+	AllowInsecureMounts bool   `codec:"allow_insecure_readonly_mounts"`
 }

--- a/providers/libvirt/domain_config.go
+++ b/providers/libvirt/domain_config.go
@@ -59,8 +59,14 @@ func (p *provider) parseConfiguration(config *vm.Config) (string, error) {
 		if m.Driver == mountFsVirtiofs {
 			mnt.AccessMode = virtiofsSecurityMode
 			mnt.Driver = &libvirtxml.DomainFilesystemDriver{
-				Type:  mountFsVirtiofs,
+				Type:  "virtiofs",
 				Queue: virtiofsQueueSize,
+			}
+
+			// If insecure read-only mounts are allowed, then disable the
+			// read-only setting.
+			if p.insecureReadonlyMounts {
+				mnt.ReadOnly = nil
 			}
 		}
 

--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -104,6 +104,12 @@ type provider struct {
 	libvirtVersion   uint32
 	m                sync.Mutex
 
+	// insecureReadonlyMounts can be used to allow virtiofs to be used for read-only host
+	// mounts even if unsupported by libvirt. This relies on the mount command only for
+	// making the mount read-only, which is not secure due to the ability to remount
+	// and remove the read-only option.
+	insecureReadonlyMounts bool
+
 	availableMountFsOverride map[string]struct{} // used for testing
 }
 
@@ -114,15 +120,16 @@ func (p *provider) Copy(ctx context.Context) *provider {
 
 	ctx, cancel := context.WithCancel(ctx)
 	dCopy := &provider{
-		ctx:              ctx,
-		cancel:           cancel,
-		closed:           p.closed,
-		uri:              p.uri,
-		logger:           p.logger,
-		user:             p.user,
-		password:         p.password,
-		availableMountFs: p.availableMountFs,
-		libvirtVersion:   p.libvirtVersion,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		closed:                 p.closed,
+		uri:                    p.uri,
+		logger:                 p.logger,
+		user:                   p.user,
+		password:               p.password,
+		availableMountFs:       p.availableMountFs,
+		libvirtVersion:         p.libvirtVersion,
+		insecureReadonlyMounts: p.insecureReadonlyMounts,
 	}
 	dCopy.storage = p.storage.Copy(ctx, dCopy)
 	dCopy.networking = p.networking.Copy(dCopy)
@@ -148,6 +155,9 @@ func WithConfig(c *Config) Option {
 		}
 		if c.Password != "" {
 			p.password = c.Password
+		}
+		if c.AllowInsecureMounts {
+			p.insecureReadonlyMounts = true
 		}
 	}
 }
@@ -709,8 +719,15 @@ func (p *provider) GenerateMountCommands(mounts []*vm.MountFileConfig) ([]string
 	cmds := []string{}
 	// read-only volumes are not supported in libvirt until 11.0.0
 	virtiofsRO := p.requiresLibvirtVersion("11.0.0")
+	// if virtiofs does not support read-only mounts, check if insecure
+	// mounts have been enabled to bypass the version restriction.
+	if !virtiofsRO && p.insecureReadonlyMounts {
+		p.logger.Warn("configuration allows insecure read-only host mounts")
+		virtiofsRO = true
+	}
+
 	for _, m := range mounts {
-		// if the mount is read-only, only 9p is supportep.
+		// if the mount is read-only, only 9p is supported (unless insecure mounts enabled).
 		if m.ReadOnly && !virtiofsRO {
 			if !p.mountFsAvailable(mountFs9p) {
 				return nil, fmt.Errorf("read-only virtiofs mount %w - libvirt version 11.0.0 or greater required", vm.ErrNotSupported)
@@ -1043,9 +1060,14 @@ func (p *provider) mountFsAvailable(name string) bool {
 func (p *provider) generateVirtiofsMountCmds(m *vm.MountFileConfig) []string {
 	m.Driver = mountFsVirtiofs
 
+	var readonly string
+	if m.ReadOnly {
+		readonly = " -o ro"
+	}
+
 	return []string{
 		fmt.Sprintf(`mkdir -p "%s"`, m.Destination),
-		fmt.Sprintf(`mountpoint -q "%s" || mount -t virtiofs %s "%s"`, m.Destination, m.Tag, m.Destination),
+		fmt.Sprintf(`mountpoint -q "%s" || mount -t virtiofs%s %s "%s"`, m.Destination, readonly, m.Tag, m.Destination),
 	}
 }
 
@@ -1053,9 +1075,13 @@ func (p *provider) generateVirtiofsMountCmds(m *vm.MountFileConfig) []string {
 func (p *provider) generate9pMountCmds(m *vm.MountFileConfig) []string {
 	m.Driver = mountFs9p
 
+	var readonly string
+	if m.ReadOnly {
+		readonly = ",ro"
+	}
 	return []string{
 		fmt.Sprintf(`mkdir -p "%s"`, m.Destination),
-		fmt.Sprintf(`mountpoint -q "%s" || mount -t 9p -o trans=virtio %s "%s"`, m.Destination, m.Tag, m.Destination),
+		fmt.Sprintf(`mountpoint -q "%s" || mount -t 9p -o trans=virtio%s %s "%s"`, m.Destination, readonly, m.Tag, m.Destination),
 	}
 }
 

--- a/providers/libvirt/libvirt_test.go
+++ b/providers/libvirt/libvirt_test.go
@@ -406,6 +406,115 @@ func Test_GenerateMountCommands(t *testing.T) {
 		}, result)
 	})
 
+	t.Run("read-only", func(t *testing.T) {
+		t.Run("9p and virtiofs are available", func(t *testing.T) {
+			t.Run("virtiofs read-only supported", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFs9p, mountFsVirtiofs))
+				// Force libvirt version to supported version
+				ld.libvirtVersion = genVersion("12.0.0")
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				result, err := ld.GenerateMountCommands(mnts)
+				must.NoError(t, err)
+				must.Eq(t, []string{
+					`mkdir -p "/test"`,
+					`mountpoint -q "/test" || mount -t virtiofs -o ro test-tag "/test"`,
+				}, result)
+			})
+
+			t.Run("virtiofs read-only not supported", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFs9p, mountFsVirtiofs))
+				// Force libvirt version to unsupported version
+				ld.libvirtVersion = genVersion("1.0.0")
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				result, err := ld.GenerateMountCommands(mnts)
+				must.NoError(t, err)
+				must.Eq(t, []string{
+					`mkdir -p "/test"`,
+					`mountpoint -q "/test" || mount -t 9p -o trans=virtio,ro test-tag "/test"`,
+				}, result)
+			})
+
+			t.Run("virtiofs read-only not supported insecure mounts enabled", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFs9p, mountFsVirtiofs))
+				// Force libvirt version to unsupported version
+				ld.libvirtVersion = genVersion("1.0.0")
+				// Allow insecure read-only host mounts
+				ld.insecureReadonlyMounts = true
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				result, err := ld.GenerateMountCommands(mnts)
+				must.NoError(t, err)
+				must.Eq(t, []string{
+					`mkdir -p "/test"`,
+					`mountpoint -q "/test" || mount -t virtiofs -o ro test-tag "/test"`,
+				}, result)
+			})
+		})
+
+		t.Run("virtiofs only available", func(t *testing.T) {
+			t.Run("read-only supported", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFsVirtiofs))
+				// Force libvirt version to supported version
+				ld.libvirtVersion = genVersion("12.0.0")
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				result, err := ld.GenerateMountCommands(mnts)
+				must.NoError(t, err)
+				must.Eq(t, []string{
+					`mkdir -p "/test"`,
+					`mountpoint -q "/test" || mount -t virtiofs -o ro test-tag "/test"`,
+				}, result)
+			})
+
+			t.Run("read-only not supported", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFsVirtiofs))
+				// Force libvirt version to unsupported version
+				ld.libvirtVersion = genVersion("1.0.0")
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				_, err := ld.GenerateMountCommands(mnts)
+				must.ErrorIs(t, err, vm.ErrNotSupported)
+			})
+
+			t.Run("read-only not supported insecure mounts enabled", func(t *testing.T) {
+				ld, _ := testNew(t, overrideFs(mountFsVirtiofs))
+				// Force libvirt version to unsupported version
+				ld.libvirtVersion = genVersion("1.0.0")
+				// Allow insecure read-only host mounts
+				ld.insecureReadonlyMounts = true
+				mnts := mounts()
+				mnts[0].ReadOnly = true
+
+				result, err := ld.GenerateMountCommands(mnts)
+				must.NoError(t, err)
+				must.Eq(t, []string{
+					`mkdir -p "/test"`,
+					`mountpoint -q "/test" || mount -t virtiofs -o ro test-tag "/test"`,
+				}, result)
+			})
+		})
+
+		t.Run("9p only available", func(t *testing.T) {
+			ld, _ := testNew(t, overrideFs(mountFs9p))
+			mnts := mounts()
+			mnts[0].ReadOnly = true
+
+			result, err := ld.GenerateMountCommands(mnts)
+			must.NoError(t, err)
+			must.Eq(t, []string{
+				`mkdir -p "/test"`,
+				`mountpoint -q "/test" || mount -t 9p -o trans=virtio,ro test-tag "/test"`,
+			}, result)
+		})
+	})
+
 	t.Run("read-only mount without virtiofs support", func(t *testing.T) {
 		// Make mount read-only
 		mnts := mounts()
@@ -420,7 +529,7 @@ func Test_GenerateMountCommands(t *testing.T) {
 			must.NoError(t, err)
 			must.Eq(t, []string{
 				`mkdir -p "/test"`,
-				`mountpoint -q "/test" || mount -t 9p -o trans=virtio test-tag "/test"`,
+				`mountpoint -q "/test" || mount -t 9p -o trans=virtio,ro test-tag "/test"`,
 			}, result)
 		})
 


### PR DESCRIPTION
Libvirt supports read-only host mounts using virtiofs starting with version 11. On some older systems where 9pfs is not available, this results in the inability to start a task due to lack of support for read-only host mounts.

This change allows the operator to configure the agent to allow using virtiofs to mount read-only host mounts without the read-only configuration and rely instead on the read-only mount option executed by the guest.

Fixes #128