### PR TITLE
libvirt: fix ceph secret creation

### DIFF
--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -990,7 +990,7 @@ func (p *provider) SetCephSecret(name, credential string) (string, error) {
 		return "", err
 	}
 
-	if err := secret.SetValue([]byte(credential), libvirtNoFlags); err != nil {
+	if err := secret.SetValue(decodedCred, libvirtNoFlags); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
When creating the ceph secret use the decoded credential value. 

When updating the secret, the correct decoded value is being used. This resulted in errors when a ceph pool was created with a message about failing to connect to the monitors. A subsequent run would be successful due to the secret being updated with the correct value. 