### PR TITLE
storage: adjust storage pool provider fingerprint

### DIFF
--- a/providers/libvirt/storage/storage.go
+++ b/providers/libvirt/storage/storage.go
@@ -207,7 +207,7 @@ func (s *Storage) Fingerprint(attrs map[string]*structs.Attribute) {
 			vm.FingerprintAttributeKeyPrefix, name)
 
 		attrs[poolKey] = structs.NewStringAttribute(pool.Type())
-		attrs[poolKey+".provider"] = structs.NewStringAttribute(providerName)
+		attrs[poolKey+".provider."+providerName] = structs.NewBoolAttribute(true)
 		if s.defaultPool == pool {
 			attrs[poolKey+".default"] = structs.NewBoolAttribute(true)
 		}

--- a/providers/libvirt/storage/storage_test.go
+++ b/providers/libvirt/storage/storage_test.go
@@ -265,11 +265,11 @@ func TestStorage_Fingerprint(t *testing.T) {
 		s.Fingerprint(attrs)
 
 		expected := map[string]*structs.Attribute{
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool":          structs.NewStringAttribute("directory"),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.provider": structs.NewStringAttribute(providerName),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.default":  structs.NewBoolAttribute(true),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.aux-pool":           structs.NewStringAttribute("directory"),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.aux-pool.provider":  structs.NewStringAttribute(providerName),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool":                          structs.NewStringAttribute("directory"),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.provider." + providerName: structs.NewBoolAttribute(true),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.default":                  structs.NewBoolAttribute(true),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.aux-pool":                           structs.NewStringAttribute("directory"),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.aux-pool.provider." + providerName:  structs.NewBoolAttribute(true),
 		}
 
 		must.Eq(t, expected, attrs)
@@ -286,9 +286,9 @@ func TestStorage_Fingerprint(t *testing.T) {
 		s.Fingerprint(attrs)
 
 		expected := map[string]*structs.Attribute{
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool":          structs.NewStringAttribute("directory"),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.provider": structs.NewStringAttribute(providerName),
-			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.default":  structs.NewBoolAttribute(true),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool":                          structs.NewStringAttribute("directory"),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.provider." + providerName: structs.NewBoolAttribute(true),
+			vm.FingerprintAttributeKeyPrefix + ".storage_pool.main-pool.default":                  structs.NewBoolAttribute(true),
 		}
 
 		must.Eq(t, expected, attrs)


### PR DESCRIPTION
Updates the format of the storage pool provider in the fingerprint to allow for multiple providers on a single pool.