### PR TITLE
network: allow localhost port forwards

### DIFF
--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -712,6 +712,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 	// If the VM did not include any network configuration, there will not be a
 	// teardown spec.
 	if netBuildResp.TeardownSpec != nil {
+		driverState.NetTeardown = netBuildResp.TeardownSpec
 		h.netTeardown = netBuildResp.TeardownSpec
 	}
 

--- a/providers/libvirt/net/iptables.go
+++ b/providers/libvirt/net/iptables.go
@@ -18,6 +18,7 @@ type IPTables interface {
 	DeleteIfExists(table, chain string, rulespec ...string) error
 	Insert(table, chain string, pos int, rulespec ...string) error
 	ListChains(table string) ([]string, error)
+	List(table, chain string) ([]string, error)
 	NewChain(table, chain string) error
 }
 

--- a/providers/libvirt/net/net.go
+++ b/providers/libvirt/net/net.go
@@ -5,7 +5,6 @@ package net
 
 import (
 	stdnet "net"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -32,7 +31,9 @@ type Controller struct {
 	dhcpLeaseDiscoveryInterval time.Duration
 	dhcpLeaseDiscoveryTimeout  time.Duration
 
-	init sync.Once
+	// routeLocalnetTemplate is a template for creating the path to the kernel
+	// runtime configuration for device localnet routing.
+	routeLocalnetTemplate string
 
 	// interfaceByIPGetter is the function that queries the host using the
 	// passed IP address and identifies the interface it is assigned to. It is
@@ -46,6 +47,10 @@ type Controller struct {
 	// iptablesInterfaceGetter is the function that returns an interface
 	// for IPTables.
 	iptablesInterfaceGetter
+
+	// routingIngerfaceByIPGetter is the function that queries the host using
+	// the passed IP address and identifies the interface used to reach it.
+	routingInterfaceByIPGetter
 }
 
 // NewController returns a Controller which implements the net.Net interface
@@ -60,6 +65,8 @@ func NewController(logger hclog.Logger, conn shims.Connect) *Controller {
 		iptablesInterfaceGetter:    newIPTables,
 		logger:                     logger.Named("net"),
 		netConn:                    conn,
+		routingInterfaceByIPGetter: getRoutingInterfaceByIP,
+		routeLocalnetTemplate:      routeLocalnetPathTemplate,
 	}
 }
 
@@ -76,3 +83,7 @@ type ipByInterfaceGetter func(name string) (stdnet.IP, error)
 // iptablesInterfaceGetter is the function that returns an interface
 // for IPTables.
 type iptablesInterfaceGetter func() (IPTables, error)
+
+// routingInterfaceByIPGetter is the function signature used to identify
+// the host interface used for an IP address.
+type routingInterfaceByIPGetter func(ip string) (string, error)

--- a/providers/libvirt/net/net_linux.go
+++ b/providers/libvirt/net/net_linux.go
@@ -9,8 +9,11 @@ import (
 	"errors"
 	"fmt"
 	stdnet "net"
+	"net/netip"
+	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -29,6 +32,12 @@ import (
 )
 
 const (
+	// postroutingIPTablesChainName is the IPTables chain name used by the
+	// driver for postrouting rules. This is currently used for entries within
+	// the nat table specifically for handling the special case of loopback
+	// addresses.
+	postroutingIPTablesChainName = "NOMAD_VT_PST"
+
 	// preroutingIPTablesChainName is the IPTables chain name used by the
 	// driver for prerouting rules. This is currently used for entries within
 	// the nat table.
@@ -38,6 +47,11 @@ const (
 	// for forwarding rules. This is currently used for entries within the
 	// filter table.
 	forwardIPTablesChainName = "NOMAD_VT_FW"
+
+	// outputIPTablesChainName is the IPTables chain name used by the driver
+	// for output rules. This is currently used for entries within the nat
+	// table specifically for handling the special case of loopback addresses.
+	outputIPTablesChainName = "NOMAD_VT_OUT"
 
 	// iptablesNATTableName is the name of the nat table within iptables.
 	iptablesNATTableName = "nat"
@@ -51,10 +65,20 @@ const (
 
 	// dhcpServerPort is the port the DHCP server is listening on.
 	dhcpServerPort = "67"
+
+	// routeLocalnetPathTemplate is the template for generating the path to check for device specific routing support.
+	routeLocalnetPathTemplate = "/proc/sys/net/ipv4/conf/%s/route_localnet"
+
+	// routeLocalnetGlobalName is the name of the global kernel configuration for localnet routing.
+	routeLocalnetGlobalName = "all"
 )
 
-// initLock is used to prevent multiple controller.Init's running at once
+// initLock is used to prevent multiple controller.Init's running at once.
 var initLock sync.Mutex
+
+// loopbackForwardsLock is used to prevent multiple loopback forwards enablements
+// and loopback device enablements from running at once.
+var loopbackForwardsLock sync.Mutex
 
 // Copy returns a new copy of the controller.
 func (c *Controller) Copy(conn shims.Connect) *Controller {
@@ -66,8 +90,9 @@ func (c *Controller) Copy(conn shims.Connect) *Controller {
 		iptablesInterfaceGetter:    c.iptablesInterfaceGetter,
 		logger:                     c.logger,
 		netConn:                    conn,
+		routingInterfaceByIPGetter: c.routingInterfaceByIPGetter,
+		routeLocalnetTemplate:      c.routeLocalnetTemplate,
 	}
-
 }
 
 func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
@@ -406,6 +431,125 @@ func (c *Controller) discoverDHCPLeaseIP(
 	}
 }
 
+// enableLoopbackPortForwards validates that the host system is configured for routing
+// localnet packets and adds the required chains.
+func (c *Controller) enableLoopbackPortForwards() error {
+	loopbackForwardsLock.Lock()
+	defer loopbackForwardsLock.Unlock()
+
+	ipt, err := c.iptablesInterfaceGetter()
+	if err != nil {
+		return err
+	}
+
+	// Add the output chain if it does not exist.
+	outputCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, outputIPTablesChainName)
+	if err != nil {
+		return err
+	}
+	if outputCreated {
+		if err := ipt.Insert(iptablesNATTableName, "OUTPUT", 1, []string{"-j", outputIPTablesChainName}...); err != nil {
+			return err
+		}
+
+		c.logger.Info("successfully created NAT output iptables chain", "name", outputIPTablesChainName)
+	}
+
+	// Add the postrouting chain if it does not exist.
+	postroutingCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, postroutingIPTablesChainName)
+	if err != nil {
+		return err
+	}
+	if postroutingCreated {
+		if err := ipt.Insert(iptablesNATTableName, "POSTROUTING", 1, []string{"-j", postroutingIPTablesChainName}...); err != nil {
+			return err
+		}
+
+		c.logger.Info("successfully created NAT postrouting iptables chain", "name", postroutingIPTablesChainName)
+	}
+
+	// Log a warning that loopback port forwarding is being enabled.
+	c.logger.Warn("port forwarding for the local loopback is enabled")
+	return nil
+}
+
+// loopbackPortForwardsSupported returns if the host has been configured for routing localnet packets.
+// NOTE: The global configuration overrides device specific configuration.
+func (c *Controller) loopbackPortForwardsSupported(device string) bool {
+	for _, configName := range []string{routeLocalnetGlobalName, device} {
+		tmpl := c.routeLocalnetTemplate
+		if tmpl == "" {
+			tmpl = routeLocalnetPathTemplate
+		}
+
+		cfgPath := fmt.Sprintf(tmpl, configName)
+		content, err := os.ReadFile(cfgPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
+			c.logger.Error("read failed for device loopback support check", "path", cfgPath, "error", err)
+			return false
+		}
+
+		if strings.TrimSpace(string(content)) == "1" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// loopbackPortForwardsEnabled checks if port forwards are enabled for the loopback device.
+func (c *Controller) loopbackPortForwardsEnabled(ipt IPTables) bool {
+	chains, err := ipt.ListChains(iptablesNATTableName)
+	if err != nil {
+		c.logger.Error("could not list table chains", "table", iptablesNATTableName,
+			"chain", postroutingIPTablesChainName, "error", err)
+		return false
+	}
+
+	return slices.Contains(chains, postroutingIPTablesChainName)
+}
+
+// enableLoopbackForDevice will add the required rule to the postrouting chain
+// for the device to handle port forwards from the loopback device.
+func (c *Controller) enableLoopbackForDevice(ipt IPTables, device string) error {
+	loopbackForwardsLock.Lock()
+	defer loopbackForwardsLock.Unlock()
+
+	// Create the required rule.
+	rule := []string{
+		"-o", device,
+		"-m", "addrtype",
+		"--src-type", "LOCAL",
+		"--dst-type", "UNICAST",
+		"-j", "MASQUERADE",
+	}
+
+	// Check if the rule already exists.
+	existingRules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
+	if err != nil {
+		return fmt.Errorf("failed to list postrouting rules: %w", err)
+	}
+
+	for _, existingRule := range existingRules {
+		// Match the suffix of the existing rule since chain information is not included
+		// in the new rule.
+		if strings.HasSuffix(existingRule, strings.Join(rule, " ")) {
+			return nil
+		}
+	}
+
+	// Still here, then add the rule.
+	if err := ipt.Append(iptablesNATTableName, postroutingIPTablesChainName, rule...); err != nil {
+		return fmt.Errorf("failed to add loopback rule for device: %w", err)
+	}
+
+	return nil
+}
+
 // configureIPTables is responsible for adding the iptables entries to enable
 // port mapping. The function will perform this action for all configured ports
 // within the network interface configuration.
@@ -458,47 +602,104 @@ func (c *Controller) configureIPTables(
 		// Generate our NAT preroute arguments to include the table and chain
 		// information. This allows us to store all the detail within the
 		// teardownRules easily.
-		preRouteArgs := []string{
-			iptablesNATTableName,
-			preroutingIPTablesChainName,
-			"-d", reservedPort.HostIP,
-			"-i", iface,
-			"-p", "tcp",
-			"-m", "tcp",
-			"--dport", strconv.Itoa(reservedPort.Value),
-			"-j", "DNAT",
-			"--to-destination", fmt.Sprintf("%s:%v", ip, reservedPort.To),
+		var preRouteArgs []string
+
+		hostIP, err := netip.ParseAddr(reservedPort.HostIP)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse host IP address: %w", err)
 		}
 
-		if err := ipt.Append(preRouteArgs[0], preRouteArgs[1], preRouteArgs[2:]...); err != nil {
-			return nil, err
+		// If the host IP provided is a loopback, it needs to be picked up on the
+		// output chain and redirected to the VM. This is a special case and which
+		// requires the host to be properly configured.
+		if hostIP.IsLoopback() {
+			// Find the interface that the destination address is attached.
+			dstIface, ok := interfaceMapping[ip]
+			if !ok {
+				dstIface, err = c.routingInterfaceByIPGetter(ip)
+				if err != nil {
+					return nil, fmt.Errorf("failed to identify IP interface: %w", err)
+				}
+
+				interfaceMapping[ip] = dstIface
+			}
+
+			// Check if loopback port forwarding is even available before starting.
+			if !c.loopbackPortForwardsSupported(dstIface) {
+				c.logger.Error(fmt.Sprintf("loopback port forwarding requires kernel runtime configuration - net.ipv4.conf.%s.route_localnet=1", dstIface))
+				return nil, fmt.Errorf("loopback port forwarding not enabled for device - %s", dstIface)
+			}
+
+			// Ensure loopback port forwarding is setup
+			if err := c.enableLoopbackPortForwards(); err != nil {
+				return nil, fmt.Errorf("failed to enable loopback port forwarding: %w", err)
+			}
+
+			// Enable the device to handle requests from the loopback device.
+			if err := c.enableLoopbackForDevice(ipt, dstIface); err != nil {
+				return nil, err
+			}
+
+			preRouteArgs = []string{
+				iptablesNATTableName,
+				outputIPTablesChainName,
+				"-s", reservedPort.HostIP,
+				"-o", iface,
+				"-p", "tcp",
+				"-m", "tcp",
+				"--dport", strconv.Itoa(reservedPort.Value),
+				"-j", "DNAT",
+				"--to-destination", fmt.Sprintf("%s:%v", ip, reservedPort.To),
+			}
+
+			if err := ipt.Append(preRouteArgs[0], preRouteArgs[1], preRouteArgs[2:]...); err != nil {
+				return nil, err
+			}
+
+			c.logger.Debug("configured nat output chain for localhost", "args", preRouteArgs)
+			teardownRules = append(teardownRules, preRouteArgs)
+		} else {
+			preRouteArgs = []string{
+				iptablesNATTableName,
+				preroutingIPTablesChainName,
+				"-d", reservedPort.HostIP,
+				"-i", iface,
+				"-p", "tcp",
+				"-m", "tcp",
+				"--dport", strconv.Itoa(reservedPort.Value),
+				"-j", "DNAT",
+				"--to-destination", fmt.Sprintf("%s:%v", ip, reservedPort.To),
+			}
+
+			if err := ipt.Append(preRouteArgs[0], preRouteArgs[1], preRouteArgs[2:]...); err != nil {
+				return nil, err
+			}
+
+			c.logger.Debug("configured nat prerouting chain", "args", preRouteArgs)
+			teardownRules = append(teardownRules, preRouteArgs)
+
+			// Generate our filter forward arguments to include the table and chain
+			// information. This allows us to store all the detail within the
+			// teardownRules easily.
+			filterArgs := []string{
+				iptablesFilterTableName,
+				forwardIPTablesChainName,
+				"-d", ip,
+				"-p", "tcp",
+				"-m", "state",
+				"--state", "NEW",
+				"-m", "tcp",
+				"--dport", strconv.Itoa(reservedPort.To),
+				"-j", "ACCEPT",
+			}
+
+			if err := ipt.Append(filterArgs[0], filterArgs[1], filterArgs[2:]...); err != nil {
+				return nil, err
+			}
+
+			c.logger.Debug("configured filter forward chain", "args", filterArgs)
+			teardownRules = append(teardownRules, filterArgs)
 		}
-
-		c.logger.Debug("configured nat prerouting chain", "args", preRouteArgs)
-		teardownRules = append(teardownRules, preRouteArgs)
-
-		// Generate our filter forward arguments to include the table and chain
-		// information. This allows us to store all the detail within the
-		// teardownRules easily.
-		filterArgs := []string{
-			iptablesFilterTableName,
-			forwardIPTablesChainName,
-			"-d", ip,
-			"-p", "tcp",
-			"-m", "state",
-			"--state", "NEW",
-			"-m", "tcp",
-			"--dport", strconv.Itoa(reservedPort.To),
-			"-j", "ACCEPT",
-		}
-
-		if err := ipt.Append(filterArgs[0], filterArgs[1], filterArgs[2:]...); err != nil {
-			return nil, err
-		}
-
-		c.logger.Debug("configured filter forward chain", "args", filterArgs)
-		teardownRules = append(teardownRules, filterArgs)
-
 		// The process made a change to the system, so log the critical
 		// information that might be useful to operators.
 		c.logger.Info("successfully configured port forwarding rules",
@@ -507,6 +708,34 @@ func (c *Controller) configureIPTables(
 	}
 
 	return teardownRules, nil
+}
+
+// getRoutingInterfaceByIP returns the name of the interface that can be used
+// to reach the provided address.
+func getRoutingInterfaceByIP(ip string) (string, error) {
+	interfaces, err := stdnet.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	checkAddr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range interfaces {
+		if addrs, err := iface.Addrs(); err == nil {
+			for _, addr := range addrs {
+				if prefix, err := netip.ParsePrefix(addr.String()); err == nil {
+					if prefix.Contains(checkAddr) {
+						return iface.Name, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find interface for IP %q", ip)
 }
 
 // getInterfaceByIP is a helper function which identifies which host network

--- a/providers/libvirt/net/net_linux_test.go
+++ b/providers/libvirt/net/net_linux_test.go
@@ -8,6 +8,8 @@ package net
 import (
 	"fmt"
 	stdnet "net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -561,278 +563,501 @@ func TestController_discoverDHCPLeaseIP(t *testing.T) {
 	must.Eq(t, mac, "11:22:11:22:11:22")
 }
 
+// NOTE: stopping here. all the other loopback related tests are completed below. just
+// need to add in the full blown bits here to do the actual loopback forward thing.
 func TestController_configureIPTables(t *testing.T) {
 	t.Run("mocked", func(t *testing.T) {
-		mockIptables := iptables_mock.New(t).Expect(
-			iptables_mock.ListChains{Table: "nat"},
-			iptables_mock.NewChain{Table: "nat", Chain: "NOMAD_VT_PRT"},
-			iptables_mock.Insert{
-				Table:    "nat",
-				Chain:    "PREROUTING",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_PRT"},
-			},
-			iptables_mock.ListChains{Table: "filter"},
-			iptables_mock.NewChain{Table: "filter", Chain: "NOMAD_VT_FW"},
-			iptables_mock.Insert{
-				Table:    "filter",
-				Chain:    "FORWARD",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_FW"},
-			},
-			iptables_mock.Append{
-				Table: "nat",
-				Chain: "NOMAD_VT_PRT",
-				RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-					"--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22",
-				},
-			},
-			iptables_mock.Append{
-				Table: "filter",
-				Chain: "NOMAD_VT_FW",
-				RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-					"-m", "tcp", "--dport", "22", "-j", "ACCEPT",
-				},
-			},
-			iptables_mock.Append{
-				Table: "nat",
-				Chain: "NOMAD_VT_PRT",
-				RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-					"--dport", "27512", "-j", "DNAT", "--to-destination", "192.168.122.58:4646",
-				},
-			},
-			iptables_mock.Append{
-				Table: "filter",
-				Chain: "NOMAD_VT_FW",
-				RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-					"-m", "tcp", "--dport", "4646", "-j", "ACCEPT",
-				},
-			},
-		)
+		t.Run("loopback", func(t *testing.T) {
+			t.Run("not enabled", func(t *testing.T) {
+				mockIptables := iptables_mock.New(t)
+				defer mockIptables.AssertExpectations()
 
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			netConn:                 &libvirt_mock.StaticConnect{},
-			interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-			iptablesInterfaceGetter: func() (IPTables, error) { return mockIptables, nil },
-		}
-
-		// Create driver and network interface request arguments. The allocated
-		// ports includes a port not specified in the task config, to ensure this
-		// does not get configured.
-		driverReq := drivers.Resources{
-			Ports: &nomadstructs.AllocatedPorts{
-				{
-					Label:  "ssh",
-					Value:  27494,
-					To:     22,
-					HostIP: "10.0.1.161",
-				},
-				{
-					Label:  "nomad",
-					Value:  27512,
-					To:     4646,
-					HostIP: "10.0.1.161",
-				},
-				{
-					Label:  "http",
-					Value:  27513,
-					To:     80,
-					HostIP: "10.0.1.161",
-				},
-			},
-		}
-
-		netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-			Name:  "virbr0",
-			Ports: []string{"ssh", "nomad"},
-		}
-
-		// Init the controller, so we have the required iptables chains available.
-		must.NoError(t, controller.Init())
-
-		// Execute the function, collecting the teardown rules and building our
-		// expected output.
-		actualTeardownRules, err := controller.configureIPTables(
-			&driverReq, &netInterfaceReq, "192.168.122.58")
-		must.NoError(t, err)
-
-		expectedTeardownRules := [][]string{
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"4646", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:4646",
-			},
-		}
-
-		// Perform the equality check ensuring the returned rules match exactly
-		// what we expected.
-		must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
-
-			if len(a) != len(b) {
-				return false
-			}
-
-			var found int
-
-			for _, ruleA := range a {
-				for _, ruleB := range b {
-					if !reflect.DeepEqual(ruleA, ruleB) {
-						continue
-					}
-					found++
+				controller := &Controller{
+					logger:                     hclog.NewNullLogger(),
+					netConn:                    &libvirt_mock.StaticConnect{},
+					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+					iptablesInterfaceGetter:    func() (IPTables, error) { return mockIptables, nil },
+					routingInterfaceByIPGetter: func(string) (string, error) { return "lo", nil },
+					routeLocalnetTemplate:      routeLocalnetFile(t, false),
 				}
-			}
-			return found == len(a)
+
+				driverReq := drivers.Resources{
+					Ports: &nomadstructs.AllocatedPorts{
+						{
+							Label:  "ssh",
+							Value:  27494,
+							To:     22,
+							HostIP: "127.0.0.1",
+						},
+					},
+				}
+
+				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh"},
+				}
+
+				_, err := controller.configureIPTables(
+					&driverReq, &netInterfaceReq, "192.168.122.58")
+				must.ErrorContains(t, err, "loopback port forwarding not enabled")
+			})
+
+			t.Run("enabled", func(t *testing.T) {
+				mockIptables := iptables_mock.New(t).Expect(
+					iptables_mock.ListChains{Table: iptablesNATTableName},
+					iptables_mock.NewChain{Table: iptablesNATTableName, Chain: outputIPTablesChainName},
+					iptables_mock.Insert{
+						Table:    iptablesNATTableName,
+						Chain:    "OUTPUT",
+						Pos:      1,
+						RuleSpec: []string{"-j", outputIPTablesChainName},
+					},
+					iptables_mock.ListChains{Table: iptablesNATTableName},
+					iptables_mock.NewChain{Table: iptablesNATTableName, Chain: postroutingIPTablesChainName},
+					iptables_mock.Insert{
+						Table:    iptablesNATTableName,
+						Chain:    "POSTROUTING",
+						Pos:      1,
+						RuleSpec: []string{"-j", postroutingIPTablesChainName},
+					},
+					iptables_mock.List{Table: iptablesNATTableName, Chain: postroutingIPTablesChainName},
+					iptables_mock.Append{
+						Table:    iptablesNATTableName,
+						Chain:    postroutingIPTablesChainName,
+						RuleSpec: []string{"-o", "virbr0", "-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST", "-j", "MASQUERADE"},
+					},
+					iptables_mock.Append{
+						Table:    iptablesNATTableName,
+						Chain:    outputIPTablesChainName,
+						RuleSpec: []string{"-s", "127.0.0.1", "-o", "lo", "-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"},
+					},
+				)
+				defer mockIptables.AssertExpectations()
+
+				controller := &Controller{
+					logger:                     hclog.NewNullLogger(),
+					netConn:                    &libvirt_mock.StaticConnect{},
+					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "lo", nil },
+					iptablesInterfaceGetter:    func() (IPTables, error) { return mockIptables, nil },
+					routingInterfaceByIPGetter: func(string) (string, error) { return "virbr0", nil },
+					routeLocalnetTemplate:      routeLocalnetFile(t, true),
+				}
+
+				driverReq := drivers.Resources{
+					Ports: &nomadstructs.AllocatedPorts{
+						{
+							Label:  "ssh",
+							Value:  27494,
+							To:     22,
+							HostIP: "127.0.0.1",
+						},
+					},
+				}
+
+				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh"},
+				}
+
+				teardown, err := controller.configureIPTables(
+					&driverReq, &netInterfaceReq, "192.168.122.58")
+				must.NoError(t, err)
+				expectedTeardown := []string{iptablesNATTableName, outputIPTablesChainName, "-s", "127.0.0.1", "-o", "lo", "-p", "tcp",
+					"-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"}
+				must.Eq(t, [][]string{expectedTeardown}, teardown)
+			})
 		})
 
-		mockIptables.AssertExpectations()
+		t.Run("comprehensive", func(t *testing.T) {
+			mockIptables := iptables_mock.New(t).Expect(
+				iptables_mock.ListChains{Table: "nat"},
+				iptables_mock.NewChain{Table: "nat", Chain: "NOMAD_VT_PRT"},
+				iptables_mock.Insert{
+					Table:    "nat",
+					Chain:    "PREROUTING",
+					Pos:      1,
+					RuleSpec: []string{"-j", "NOMAD_VT_PRT"},
+				},
+				iptables_mock.ListChains{Table: "filter"},
+				iptables_mock.NewChain{Table: "filter", Chain: "NOMAD_VT_FW"},
+				iptables_mock.Insert{
+					Table:    "filter",
+					Chain:    "FORWARD",
+					Pos:      1,
+					RuleSpec: []string{"-j", "NOMAD_VT_FW"},
+				},
+				iptables_mock.Append{
+					Table: "nat",
+					Chain: "NOMAD_VT_PRT",
+					RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
+						"--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22",
+					},
+				},
+				iptables_mock.Append{
+					Table: "filter",
+					Chain: "NOMAD_VT_FW",
+					RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
+						"-m", "tcp", "--dport", "22", "-j", "ACCEPT",
+					},
+				},
+				iptables_mock.Append{
+					Table: "nat",
+					Chain: "NOMAD_VT_PRT",
+					RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
+						"--dport", "27512", "-j", "DNAT", "--to-destination", "192.168.122.58:4646",
+					},
+				},
+				iptables_mock.Append{
+					Table: "filter",
+					Chain: "NOMAD_VT_FW",
+					RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
+						"-m", "tcp", "--dport", "4646", "-j", "ACCEPT",
+					},
+				},
+			)
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				netConn:                 &libvirt_mock.StaticConnect{},
+				interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+				iptablesInterfaceGetter: func() (IPTables, error) { return mockIptables, nil },
+			}
+
+			// Create driver and network interface request arguments. The allocated
+			// ports includes a port not specified in the task config, to ensure this
+			// does not get configured.
+			driverReq := drivers.Resources{
+				Ports: &nomadstructs.AllocatedPorts{
+					{
+						Label:  "ssh",
+						Value:  27494,
+						To:     22,
+						HostIP: "10.0.1.161",
+					},
+					{
+						Label:  "nomad",
+						Value:  27512,
+						To:     4646,
+						HostIP: "10.0.1.161",
+					},
+					{
+						Label:  "http",
+						Value:  27513,
+						To:     80,
+						HostIP: "10.0.1.161",
+					},
+				},
+			}
+
+			netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+				Name:  "virbr0",
+				Ports: []string{"ssh", "nomad"},
+			}
+
+			// Init the controller, so we have the required iptables chains available.
+			must.NoError(t, controller.Init())
+
+			// Execute the function, collecting the teardown rules and building our
+			// expected output.
+			actualTeardownRules, err := controller.configureIPTables(
+				&driverReq, &netInterfaceReq, "192.168.122.58")
+			must.NoError(t, err)
+
+			expectedTeardownRules := [][]string{
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"22", "-j", "ACCEPT",
+				},
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:22",
+				},
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"4646", "-j", "ACCEPT",
+				},
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:4646",
+				},
+			}
+
+			// Perform the equality check ensuring the returned rules match exactly
+			// what we expected.
+			must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
+
+				if len(a) != len(b) {
+					return false
+				}
+
+				var found int
+
+				for _, ruleA := range a {
+					for _, ruleB := range b {
+						if !reflect.DeepEqual(ruleA, ruleB) {
+							continue
+						}
+						found++
+					}
+				}
+				return found == len(a)
+			})
+
+			mockIptables.AssertExpectations()
+		})
 	})
 
 	t.Run("direct", func(t *testing.T) {
 		testutil.RequireIPTables(t)
 
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			netConn:                 &libvirt_mock.StaticConnect{},
-			interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-			iptablesInterfaceGetter: newIPTables,
-		}
-
-		// Create driver and network interface request arguments. The allocated
-		// ports includes a port not specified in the task config, to ensure this
-		// does not get configured.
-		driverReq := drivers.Resources{
-			Ports: &nomadstructs.AllocatedPorts{
-				{
-					Label:  "ssh",
-					Value:  27494,
-					To:     22,
-					HostIP: "10.0.1.161",
-				},
-				{
-					Label:  "nomad",
-					Value:  27512,
-					To:     4646,
-					HostIP: "10.0.1.161",
-				},
-				{
-					Label:  "http",
-					Value:  27513,
-					To:     80,
-					HostIP: "10.0.1.161",
-				},
-			},
-		}
-
-		netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-			Name:  "virbr0",
-			Ports: []string{"ssh", "nomad"},
-		}
-
-		// Init the controller, so we have the required iptables chains available.
-		must.NoError(t, controller.Init())
-
-		ipt, err := iptables.New()
-		must.NoError(t, err)
-
-		// Add a cleanup function which will remove all the added iptables chain
-		// and rule entries.
-		t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-		// Execute the function, collecting the teardown rules and building our
-		// expected output.
-		actualTeardownRules, err := controller.configureIPTables(
-			&driverReq, &netInterfaceReq, "192.168.122.58")
-		must.NoError(t, err)
-
-		expectedTeardownRules := [][]string{
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"4646", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:4646",
-			},
-		}
-
-		// Perform the equality check ensuring the returned rules match exactly
-		// what we expected.
-		must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
-
-			if len(a) != len(b) {
-				return false
-			}
-
-			var found int
-
-			for _, ruleA := range a {
-				for _, ruleB := range b {
-					if !reflect.DeepEqual(ruleA, ruleB) {
-						continue
-					}
-					found++
+		t.Run("loopback", func(t *testing.T) {
+			t.Run("not enabled", func(t *testing.T) {
+				controller := &Controller{
+					logger:                     hclog.NewNullLogger(),
+					netConn:                    &libvirt_mock.StaticConnect{},
+					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+					iptablesInterfaceGetter:    newIPTables,
+					routingInterfaceByIPGetter: func(string) (string, error) { return "lo", nil },
+					routeLocalnetTemplate:      routeLocalnetFile(t, false),
 				}
-			}
-			return found == len(a)
+				// Init the controller, so we have the required iptables chains available.
+				must.NoError(t, controller.Init())
+				ipt, err := iptables.New()
+				must.NoError(t, err)
+
+				// Add a cleanup function which will remove all the added iptables chain
+				// and rule entries along with resetting the loopback init.
+				t.Cleanup(func() {
+					iptablesCleanup(t, ipt)
+				})
+
+				driverReq := drivers.Resources{
+					Ports: &nomadstructs.AllocatedPorts{
+						{
+							Label:  "ssh",
+							Value:  27494,
+							To:     22,
+							HostIP: "127.0.0.1",
+						},
+					},
+				}
+
+				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh"},
+				}
+
+				_, err = controller.configureIPTables(
+					&driverReq, &netInterfaceReq, "192.168.122.58")
+				must.ErrorContains(t, err, "loopback port forwarding not enabled")
+
+				chains, err := ipt.ListChains(iptablesNATTableName)
+				must.NoError(t, err)
+				must.SliceNotContains(t, chains, outputIPTablesChainName)
+				must.SliceNotContains(t, chains, postroutingIPTablesChainName)
+			})
+
+			t.Run("enabled", func(t *testing.T) {
+				controller := &Controller{
+					logger:                     hclog.NewNullLogger(),
+					netConn:                    &libvirt_mock.StaticConnect{},
+					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "lo", nil },
+					iptablesInterfaceGetter:    newIPTables,
+					routingInterfaceByIPGetter: func(string) (string, error) { return "virbr0", nil },
+					routeLocalnetTemplate:      routeLocalnetFile(t, true),
+				}
+				// Init the controller, so we have the required iptables chains available.
+				must.NoError(t, controller.Init())
+				ipt, err := iptables.New()
+				must.NoError(t, err)
+
+				// Add a cleanup function which will remove all the added iptables chain
+				// and rule entries along with resetting the loopback init.
+				t.Cleanup(func() {
+					iptablesCleanup(t, ipt)
+				})
+
+				driverReq := drivers.Resources{
+					Ports: &nomadstructs.AllocatedPorts{
+						{
+							Label:  "ssh",
+							Value:  27494,
+							To:     22,
+							HostIP: "127.0.0.1",
+						},
+					},
+				}
+
+				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh"},
+				}
+
+				teardown, err := controller.configureIPTables(
+					&driverReq, &netInterfaceReq, "192.168.122.58")
+				must.NoError(t, err)
+				expectedTeardown := []string{iptablesNATTableName, outputIPTablesChainName, "-s", "127.0.0.1", "-o", "lo", "-p", "tcp",
+					"-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"}
+				must.Eq(t, [][]string{expectedTeardown}, teardown)
+
+				// Validate that the expected chains for localnet routing exist
+				chains, err := ipt.ListChains(iptablesNATTableName)
+				must.NoError(t, err)
+				must.SliceContains(t, chains, outputIPTablesChainName)
+				must.SliceContains(t, chains, postroutingIPTablesChainName)
+
+				// Validate the routing is applied for the device
+				rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
+				must.NoError(t, err)
+				expectedRules := []string{
+					"-N NOMAD_VT_PST",
+					"-A NOMAD_VT_PST -o virbr0 -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE",
+				}
+				must.Eq(t, expectedRules, rules)
+
+				// Validate the rule exists
+				rules, err = ipt.List(iptablesNATTableName, outputIPTablesChainName)
+				must.NoError(t, err)
+				expectedRules = []string{
+					"-N NOMAD_VT_OUT",
+					"-A NOMAD_VT_OUT -s 127.0.0.1/32 -o lo -p tcp -m tcp --dport 27494 -j DNAT --to-destination 192.168.122.58:22",
+				}
+				must.Eq(t, expectedRules, rules)
+			})
 		})
 
-		// List the rules directly from the host to ensure we have also made
-		// changes there rather than just populate a return object.
-		//
-		// We can't use expectedTeardownRules as the iptables return includes
-		// bit length of the subnet mask.
-		expectedNATRules := [][]string{
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:4646",
-			},
-		}
+		t.Run("comprehensive", func(t *testing.T) {
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				netConn:                 &libvirt_mock.StaticConnect{},
+				interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
+				iptablesInterfaceGetter: newIPTables,
+			}
 
-		natRules, err := ipt.List("nat", "NOMAD_VT_PRT")
-		must.NoError(t, err)
-		must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[0][1:], " "))
-		must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[1][1:], " "))
+			// Create driver and network interface request arguments. The allocated
+			// ports includes a port not specified in the task config, to ensure this
+			// does not get configured.
+			driverReq := drivers.Resources{
+				Ports: &nomadstructs.AllocatedPorts{
+					{
+						Label:  "ssh",
+						Value:  27494,
+						To:     22,
+						HostIP: "10.0.1.161",
+					},
+					{
+						Label:  "nomad",
+						Value:  27512,
+						To:     4646,
+						HostIP: "10.0.1.161",
+					},
+					{
+						Label:  "http",
+						Value:  27513,
+						To:     80,
+						HostIP: "10.0.1.161",
+					},
+				},
+			}
 
-		expectedFilterRules := [][]string{
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"4646", "-j", "ACCEPT",
-			},
-		}
+			netInterfaceReq := net.NetworkInterfaceBridgeConfig{
+				Name:  "virbr0",
+				Ports: []string{"ssh", "nomad"},
+			}
 
-		filterRules, err := ipt.List("filter", "NOMAD_VT_FW")
-		must.NoError(t, err)
-		must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[0][1:], " "))
-		must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[1][1:], " "))
+			// Init the controller, so we have the required iptables chains available.
+			must.NoError(t, controller.Init())
+
+			ipt, err := iptables.New()
+			must.NoError(t, err)
+
+			// Add a cleanup function which will remove all the added iptables chain
+			// and rule entries.
+			t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+			// Execute the function, collecting the teardown rules and building our
+			// expected output.
+			actualTeardownRules, err := controller.configureIPTables(
+				&driverReq, &netInterfaceReq, "192.168.122.58")
+			must.NoError(t, err)
+
+			expectedTeardownRules := [][]string{
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"22", "-j", "ACCEPT",
+				},
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:22",
+				},
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"4646", "-j", "ACCEPT",
+				},
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:4646",
+				},
+			}
+
+			// Perform the equality check ensuring the returned rules match exactly
+			// what we expected.
+			must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
+
+				if len(a) != len(b) {
+					return false
+				}
+
+				var found int
+
+				for _, ruleA := range a {
+					for _, ruleB := range b {
+						if !reflect.DeepEqual(ruleA, ruleB) {
+							continue
+						}
+						found++
+					}
+				}
+				return found == len(a)
+			})
+
+			// List the rules directly from the host to ensure we have also made
+			// changes there rather than just populate a return object.
+			//
+			// We can't use expectedTeardownRules as the iptables return includes
+			// bit length of the subnet mask.
+			expectedNATRules := [][]string{
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:22",
+				},
+				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
+					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
+					"--to-destination", "192.168.122.58:4646",
+				},
+			}
+
+			natRules, err := ipt.List("nat", "NOMAD_VT_PRT")
+			must.NoError(t, err)
+			must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[0][1:], " "))
+			must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[1][1:], " "))
+
+			expectedFilterRules := [][]string{
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"22", "-j", "ACCEPT",
+				},
+				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
+					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
+					"4646", "-j", "ACCEPT",
+				},
+			}
+
+			filterRules, err := ipt.List("filter", "NOMAD_VT_FW")
+			must.NoError(t, err)
+			must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[0][1:], " "))
+			must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[1][1:], " "))
+		})
 	})
 }
 
@@ -989,7 +1214,7 @@ func TestController_VMTerminatedTeardown(t *testing.T) {
 	})
 }
 
-func Test_removeIPReservation(t *testing.T) {
+func TestController_removeIPReservation(t *testing.T) {
 	controller := &Controller{
 		logger:  hclog.NewNullLogger(),
 		netConn: &libvirt_mock.StaticConnect{},
@@ -1044,7 +1269,7 @@ func Test_removeIPReservation(t *testing.T) {
 	}
 }
 
-func Test_ipReservationExists(t *testing.T) {
+func TestController_ipReservationExists(t *testing.T) {
 	controller := &Controller{
 		logger:  hclog.NewNullLogger(),
 		netConn: &libvirt_mock.StaticConnect{},
@@ -1105,7 +1330,7 @@ func Test_ipReservationExists(t *testing.T) {
 	}
 }
 
-func Test_releaseDHCPLease(t *testing.T) {
+func TestController_releaseDHCPLease(t *testing.T) {
 	controller := &Controller{
 		logger:              hclog.NewNullLogger(),
 		netConn:             &libvirt_mock.StaticConnect{},
@@ -1175,6 +1400,328 @@ func Test_releaseDHCPLease(t *testing.T) {
 	}
 }
 
+func TestController_enableLoopbackForDevice(t *testing.T) {
+	deviceName := "test-dev"
+	expectedRule := fmt.Sprintf("-A %s -o %s -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE", postroutingIPTablesChainName, deviceName)
+
+	t.Run("mocked", func(t *testing.T) {
+		t.Run("added", func(t *testing.T) {
+			ipt := iptables_mock.New(t).Expect(
+				iptables_mock.List{
+					Table: iptablesNATTableName,
+					Chain: postroutingIPTablesChainName,
+				},
+				iptables_mock.Append{
+					Table: iptablesNATTableName,
+					Chain: postroutingIPTablesChainName,
+					RuleSpec: []string{
+						"-o", deviceName,
+						"-m", "addrtype",
+						"--src-type", "LOCAL",
+						"--dst-type", "UNICAST",
+						"-j", "MASQUERADE",
+					},
+				},
+			)
+			defer ipt.AssertExpectations()
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+			}
+
+			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
+		})
+
+		t.Run("already exists", func(t *testing.T) {
+			ipt := iptables_mock.New(t).Expect(
+				iptables_mock.List{
+					Table:  iptablesNATTableName,
+					Chain:  postroutingIPTablesChainName,
+					Result: []string{expectedRule},
+				},
+			)
+			defer ipt.AssertExpectations()
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+			}
+
+			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		testutil.RequireIPTables(t)
+
+		t.Run("added", func(t *testing.T) {
+			ipt, err := iptables.New()
+			must.NoError(t, err)
+			t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+				routeLocalnetTemplate:   routeLocalnetFile(t, true),
+			}
+			controller.enableLoopbackPortForwards()
+			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
+
+			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
+
+			rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
+			must.NoError(t, err)
+			must.SliceContains(t, rules, expectedRule)
+		})
+
+		t.Run("already exists", func(t *testing.T) {
+			ipt, err := iptables.New()
+			must.NoError(t, err)
+			t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+				routeLocalnetTemplate:   routeLocalnetFile(t, true),
+			}
+			controller.enableLoopbackPortForwards()
+			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
+
+			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
+
+			rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
+			must.NoError(t, err)
+			must.SliceContains(t, rules, expectedRule)
+
+			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
+
+			newRules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
+			must.Eq(t, rules, newRules)
+		})
+	})
+}
+
+func TestController_enableLoopbackPortForwards(t *testing.T) {
+	t.Run("mocked", func(t *testing.T) {
+		ipt := iptables_mock.New(t).Expect(
+			iptables_mock.ListChains{
+				Table:  iptablesNATTableName,
+				Result: []string{preroutingIPTablesChainName},
+			},
+			iptables_mock.NewChain{
+				Table: iptablesNATTableName,
+				Chain: outputIPTablesChainName,
+			},
+			iptables_mock.Insert{
+				Table:    iptablesNATTableName,
+				Chain:    "OUTPUT",
+				Pos:      1,
+				RuleSpec: []string{"-j", outputIPTablesChainName},
+			},
+			iptables_mock.ListChains{
+				Table: iptablesNATTableName,
+				Result: []string{
+					preroutingIPTablesChainName,
+					outputIPTablesChainName,
+				},
+			},
+			iptables_mock.NewChain{
+				Table: iptablesNATTableName,
+				Chain: postroutingIPTablesChainName,
+			},
+			iptables_mock.Insert{
+				Table:    iptablesNATTableName,
+				Chain:    "POSTROUTING",
+				Pos:      1,
+				RuleSpec: []string{"-j", postroutingIPTablesChainName},
+			},
+		)
+		defer ipt.AssertExpectations()
+
+		controller := &Controller{
+			logger:                  hclog.NewNullLogger(),
+			iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+			routeLocalnetTemplate:   routeLocalnetFile(t, true),
+		}
+		controller.enableLoopbackPortForwards()
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		testutil.RequireIPTables(t)
+
+		ipt, err := iptables.New()
+		must.NoError(t, err)
+		t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+		controller := &Controller{
+			logger:                  hclog.NewNullLogger(),
+			iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+			routeLocalnetTemplate:   routeLocalnetFile(t, true),
+		}
+		controller.enableLoopbackPortForwards()
+
+		chains, err := ipt.ListChains(iptablesNATTableName)
+		must.NoError(t, err)
+		must.SliceContains(t, chains, outputIPTablesChainName)
+		must.SliceContains(t, chains, postroutingIPTablesChainName)
+	})
+}
+
+func TestController_loopbackPortForwardsEnabled(t *testing.T) {
+	t.Run("mocked", func(t *testing.T) {
+		t.Run("not enabled", func(t *testing.T) {
+			ipt := iptables_mock.New(t).Expect(
+				iptables_mock.ListChains{
+					Table: iptablesNATTableName,
+					Result: []string{
+						preroutingIPTablesChainName,
+						forwardIPTablesChainName,
+					},
+				},
+			)
+			defer ipt.AssertExpectations()
+
+			controller := &Controller{logger: hclog.NewNullLogger()}
+			must.False(t, controller.loopbackPortForwardsEnabled(ipt))
+		})
+
+		t.Run("enabled", func(t *testing.T) {
+			ipt := iptables_mock.New(t).Expect(
+				iptables_mock.ListChains{
+					Table: iptablesNATTableName,
+					Result: []string{
+						preroutingIPTablesChainName,
+						postroutingIPTablesChainName,
+						forwardIPTablesChainName,
+					},
+				},
+			)
+			defer ipt.AssertExpectations()
+
+			controller := &Controller{logger: hclog.NewNullLogger()}
+			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		testutil.RequireIPTables(t)
+
+		t.Run("not enabled", func(t *testing.T) {
+			ipt, err := iptables.New()
+			must.NoError(t, err)
+
+			controller := &Controller{logger: hclog.NewNullLogger()}
+			must.False(t, controller.loopbackPortForwardsEnabled(ipt))
+		})
+
+		t.Run("enabled", func(t *testing.T) {
+			ipt, err := iptables.New()
+			must.NoError(t, err)
+			t.Cleanup(func() { iptablesCleanup(t, ipt) })
+
+			controller := &Controller{
+				logger:                  hclog.NewNullLogger(),
+				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
+				routeLocalnetTemplate:   routeLocalnetFile(t, true),
+			}
+			controller.enableLoopbackPortForwards()
+			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
+		})
+	})
+}
+
+func TestController_loopbackPortForwardsSupported(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		deviceContent string // empty string will result in no file
+		globalContent string // empty string will result in no file
+		result        bool
+	}{
+		{
+			desc:          "global only enabled",
+			globalContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global only disabled",
+			globalContent: "0",
+			result:        false,
+		},
+		{
+			desc:          "device only route localnet enabled",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "device only route localnet disabled",
+			deviceContent: "0",
+			result:        false,
+		},
+		{
+			desc:          "global enabled device enabled",
+			globalContent: "1",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global enabled device disabled",
+			globalContent: "1",
+			deviceContent: "0",
+			result:        true,
+		},
+		{
+			desc:          "global disabled device enabled",
+			globalContent: "0",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global disabled device disabled",
+			globalContent: "0",
+			deviceContent: "0",
+			result:        false,
+		},
+		{
+			desc:   "all route localnet missing",
+			result: false,
+		},
+	}
+
+	deviceName := "test-dev"
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tdir := t.TempDir()
+			tmpl := filepath.Join(tdir, "/%s_route_localnet")
+			devPath := fmt.Sprintf(tmpl, deviceName)
+			globalPath := fmt.Sprintf(tmpl, routeLocalnetGlobalName)
+			if tc.globalContent != "" {
+				f, err := os.Create(globalPath)
+				must.NoError(t, err)
+				_, err = f.WriteString(tc.globalContent)
+				must.NoError(t, err)
+				f.Close()
+			}
+
+			if tc.deviceContent != "" {
+				f, err := os.Create(devPath)
+				must.NoError(t, err)
+				_, err = f.WriteString(tc.deviceContent)
+				must.NoError(t, err)
+				f.Close()
+			}
+
+			controller := &Controller{
+				logger:                hclog.NewNullLogger(),
+				routeLocalnetTemplate: tmpl,
+			}
+
+			must.Eq(t, tc.result, controller.loopbackPortForwardsSupported(deviceName))
+		})
+	}
+}
+
 // iptablesCleanup can be used as a cleanup function which will remove all the
 // added iptables chain and rule entries. This avoids polluting the machine
 // that runs the test, so our development machines do not require manual
@@ -1188,6 +1735,12 @@ func Test_releaseDHCPLease(t *testing.T) {
 //   - sudo iptables -t nat -D PREROUTING -j NOMAD_VT_PRT
 //   - sudo iptables -F NOMAD_VT_PRT -t nat
 //   - sudo iptables -X NOMAD_VT_PRT -t nat
+//   - sudo iptables -t nat -D POSTROUTING -j NOMAD_VT_PST
+//   - sudo iptables -F NOMAD_VT_PST -t nat
+//   - sudo iptables -X NOMAD_VT_PST -t nat
+//   - sudo iptables -t nat -D POSTROUTING -j NOMAD_VT_OUT
+//   - sudo iptables -F NOMAD_VT_OUT -t nat
+//   - sudo iptables -X NOMAD_VT_OUT -t nat
 func iptablesCleanup(t *testing.T, ipt *iptables.IPTables) {
 	fn := func(e error) {
 		if e != nil {
@@ -1202,4 +1755,28 @@ func iptablesCleanup(t *testing.T, ipt *iptables.IPTables) {
 	fn(ipt.Delete(iptablesFilterTableName, "FORWARD", []string{"-j", forwardIPTablesChainName}...))
 	fn(ipt.ClearChain(iptablesFilterTableName, forwardIPTablesChainName))
 	fn(ipt.DeleteChain(iptablesFilterTableName, forwardIPTablesChainName))
+
+	fn(ipt.Delete(iptablesNATTableName, "POSTROUTING", []string{"-j", postroutingIPTablesChainName}...))
+	fn(ipt.ClearChain(iptablesNATTableName, postroutingIPTablesChainName))
+	fn(ipt.DeleteChain(iptablesNATTableName, postroutingIPTablesChainName))
+
+	fn(ipt.Delete(iptablesNATTableName, "OUTPUT", []string{"-j", outputIPTablesChainName}...))
+	fn(ipt.ClearChain(iptablesNATTableName, outputIPTablesChainName))
+	fn(ipt.DeleteChain(iptablesNATTableName, outputIPTablesChainName))
+}
+
+func routeLocalnetFile(t *testing.T, enabled bool) string {
+	content := "0"
+	if enabled {
+		content = "1"
+	}
+	tmpl := filepath.Join(t.TempDir(), "%s_route_localnet")
+	path := fmt.Sprintf(tmpl, routeLocalnetGlobalName)
+	f, err := os.Create(path)
+	must.NoError(t, err)
+	_, err = f.WriteString(content)
+	must.NoError(t, err)
+	f.Close()
+
+	return tmpl
 }

--- a/testutil/mock/iptables/iptables.go
+++ b/testutil/mock/iptables/iptables.go
@@ -50,6 +50,13 @@ type Insert struct {
 	Err          error
 }
 
+type List struct {
+	Table  string
+	Chain  string
+	Result []string
+	Err    error
+}
+
 type ListChains struct {
 	Table  string
 	Result []string
@@ -68,6 +75,7 @@ type mockIPTables struct {
 	deleteChains   []DeleteChain
 	deleteIfExists []DeleteIfExists
 	inserts        []Insert
+	lists          []List
 	listChains     []ListChains
 	newChains      []NewChain
 	t              must.T
@@ -90,6 +98,8 @@ func (m *mockIPTables) Expect(calls ...any) *mockIPTables {
 			m.ExpectDeleteIfExists(c)
 		case Insert:
 			m.ExpectInsert(c)
+		case List:
+			m.ExpectList(c)
 		case ListChains:
 			m.ExpectListChains(c)
 		case NewChain:
@@ -153,6 +163,15 @@ func (m *mockIPTables) ExpectInsert(ins Insert) *mockIPTables {
 	defer m.m.Unlock()
 
 	m.inserts = append(m.inserts, ins)
+	return m
+}
+
+// ExpectList adds an expected List call.
+func (m *mockIPTables) ExpectList(list List) *mockIPTables {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.lists = append(m.lists, list)
 	return m
 }
 
@@ -305,6 +324,28 @@ func (m *mockIPTables) Insert(table, chain string, pos int, rulespec ...string) 
 	return call.Err
 }
 
+func (m *mockIPTables) List(table, chain string) ([]string, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.lists,
+		must.Sprintf("Unexpected call to List - List(%q, %q)", table, chain))
+	call := m.lists[0]
+	m.lists = m.lists[1:]
+	received := List{
+		Table:  table,
+		Chain:  chain,
+		Result: call.Result,
+		Err:    call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("List received incorrect arguments"))
+
+	return call.Result, call.Err
+}
+
 func (m *mockIPTables) ListChains(table string) ([]string, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -362,6 +403,8 @@ func (m *mockIPTables) AssertExpectations() {
 		must.Sprintf("DeleteIfExists expecting %d more invocations", len(m.deleteIfExists)))
 	must.SliceEmpty(m.t, m.inserts,
 		must.Sprintf("Insert expecting %d more invocations", len(m.inserts)))
+	must.SliceEmpty(m.t, m.lists,
+		must.Sprintf("List expecting %d more invocations", len(m.lists)))
 	must.SliceEmpty(m.t, m.listChains,
 		must.Sprintf("ListChains expecting %d more invocations", len(m.listChains)))
 	must.SliceEmpty(m.t, m.newChains,


### PR DESCRIPTION
Allow port forwards to the loopback device. Requires the host system to be properly configured to allow routing of localnet packets. 