### PR TITLE
fix `make test` and test harness data race

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -94,7 +94,7 @@ test-tools: ## Install the tools used to run tests
 .PHONY: test
 test: ## Test the source code
 	@echo "==> Testing source code..."
-	@$(GO_TEST_CMD) -race -trimpath -cover ./... -run=1
+	$(GO_TEST_CMD) -race -trimpath -cover -count=1 ./...
 	@echo "==> Done"
 
 .PHONY: check-go-mod

--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -1194,7 +1194,9 @@ func ModifyMountFsAvailability(fn mountFsAvailabilityFn) {
 		logger.Warn("mount filesystem availability function override removed")
 	}
 
+	mountFsAvailabilityLock.Lock()
 	mountFsAvailabilityOverride = fn
+	mountFsAvailabilityLock.Unlock()
 }
 
 type mountFsAvailabilityFn func() (map[string]struct{}, error)
@@ -1202,4 +1204,7 @@ type mountFsAvailabilityFn func() (map[string]struct{}, error)
 // mountFsAvailabilityOverride is an override to manually set available guest
 // filesystem support. It is used for testing and can be set outside of the
 // package using the [ModifyMountFsAvailability] function.
-var mountFsAvailabilityOverride mountFsAvailabilityFn
+var (
+	mountFsAvailabilityOverride mountFsAvailabilityFn
+	mountFsAvailabilityLock     sync.Mutex
+)


### PR DESCRIPTION
I noticed while reviewing #189 that our unit tests weren't actually running.

It was due to `-run=1` not finding any tests with `1` in their name. I'm fairly sure that was meant to be `-count=1` to bypass cache.

The `-race` flag surfaced a data race on a package global. I still don't love the global, but wrapping it in a mutex is easy enough.