### PR TITLE
internal: isolate base error types

### DIFF
--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package errs
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// Base error types
+	ErrNotFound             = errors.New("not found")
+	ErrNotImplemented       = errors.New("not implemented")
+	ErrNotSupported         = errors.New("not supported")
+	ErrInvalidConfiguration = errors.New("invalid configuration")
+
+	ErrMissingAttribute = fmt.Errorf("%w - missing required attribute", ErrInvalidConfiguration)
+)

--- a/internal/shared/vm.go
+++ b/internal/shared/vm.go
@@ -4,7 +4,6 @@
 package vm
 
 import (
-	"errors"
 	"fmt"
 	"net/netip"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -33,17 +33,13 @@ var (
 	// should be at most 63 characters according to the RFC
 	validLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
 
-	ErrEmptyName            = errors.New("virtual machine name can not be empty")
-	ErrMissingImage         = errors.New("image path can not be empty")
-	ErrNotEnoughDisk        = errors.New("not enough disk space assigned to task")
-	ErrNoCPUS               = errors.New("no cpus configured, use resources.cores to assign cores in the job spec")
-	ErrNotEnoughMemory      = errors.New("not enough memory assigned to task")
-	ErrIncompleteOSVariant  = errors.New("provided os information is incomplete: arch and machine are mandatory ")
-	ErrInvalidHostName      = fmt.Errorf("a resource name must consist of lower case alphanumeric characters or '-', must start and end with an alphanumeric character and be less than %d characters", maxNameLength+1)
-	ErrNotFound             = errors.New("not found")
-	ErrNotImplemented       = errors.New("not implemented")
-	ErrNotSupported         = errors.New("feature is not supported")
-	ErrInvalidConfiguration = errors.New("invalid configuration")
+	ErrEmptyName           = fmt.Errorf("%w - virtual machine name can not be empty", errs.ErrInvalidConfiguration)
+	ErrMissingImage        = fmt.Errorf("%w - image path can not be empty", errs.ErrInvalidConfiguration)
+	ErrNotEnoughDisk       = fmt.Errorf("%w - not enough disk space assigned to task", errs.ErrInvalidConfiguration)
+	ErrNoCPUS              = fmt.Errorf("%w - no cpus configured, use resources.cores to assign cores in the job spec", errs.ErrInvalidConfiguration)
+	ErrNotEnoughMemory     = fmt.Errorf("%w - not enough memory assigned to task", errs.ErrInvalidConfiguration)
+	ErrIncompleteOSVariant = fmt.Errorf("%w - provided os information is incomplete: arch and machine are mandatory", errs.ErrInvalidConfiguration)
+	ErrInvalidHostName     = fmt.Errorf("%w - a resource name must consist of lower case alphanumeric characters or '-', must start and end with an alphanumeric character and be less than %d characters", errs.ErrInvalidConfiguration, maxNameLength+1)
 )
 
 type VMState string

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/providers"
 	"github.com/hashicorp/nomad-driver-virt/storage"
@@ -754,7 +755,7 @@ func (d *VirtDriverPlugin) RecoverTask(handle *drivers.TaskHandle) error {
 	taskVm, err := h.taskGetter.GetVM(h.name)
 	if err != nil {
 		defer cancel()
-		if errors.Is(err, vm.ErrNotFound) {
+		if errors.Is(err, errs.ErrNotFound) {
 			return drivers.ErrTaskNotFound
 		}
 

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/providers"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt"
@@ -964,7 +965,7 @@ func TestVirtDriver_Libvirt(t *testing.T) {
 
 	// Validate VM no longer exists
 	_, err = libvirtProvider.GetVM(vmName)
-	must.ErrorIs(t, err, vm.ErrNotFound)
+	must.ErrorIs(t, err, errs.ErrNotFound)
 
 	// Get fingerprint information
 	fCh, err := driver.Fingerprint(t.Context())

--- a/plugin/handle.go
+++ b/plugin/handle.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/virt"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
@@ -68,7 +69,7 @@ func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
 func (h *taskHandle) GetStats() (*drivers.TaskResourceUsage, error) {
 	virtvm, err := h.taskGetter.GetVM(h.name)
 	if err != nil {
-		if errors.Is(err, vm.ErrNotFound) {
+		if errors.Is(err, errs.ErrNotFound) {
 			return nil, fmt.Errorf("virt: task not found %s: %w", h.name, drivers.ErrTaskNotFound)
 		}
 		return nil, fmt.Errorf("virt: unable to get task %s stats: %w", h.name, err)
@@ -96,7 +97,7 @@ func (h *taskHandle) monitor(ctx context.Context, interval time.Duration, exitCh
 		select {
 		case <-ticker.C:
 			virtvm, err := h.taskGetter.GetVM(h.name)
-			if err != nil && !errors.Is(err, vm.ErrNotFound) {
+			if err != nil && !errors.Is(err, errs.ErrNotFound) {
 				h.logger.Error("virt: unable to get task state", "task", h.name, "error", err)
 				h.stateLock.Lock()
 				h.procState = drivers.TaskStateUnknown

--- a/plugin/handle_test.go
+++ b/plugin/handle_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	mock_virt "github.com/hashicorp/nomad-driver-virt/testutil/mock/virt"
 	"github.com/hashicorp/nomad/client/structs"
@@ -53,7 +54,7 @@ func Test_GetStats(t *testing.T) {
 		},
 		{
 			name:          "task_not_found_error",
-			info:          mock_virt.GetVM{Name: "test-vm", Err: vm.ErrNotFound},
+			info:          mock_virt.GetVM{Name: "test-vm", Err: errs.ErrNotFound},
 			expectedError: drivers.ErrTaskNotFound,
 		},
 	}

--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	libvirtnet "github.com/hashicorp/nomad-driver-virt/providers/libvirt/net"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
@@ -60,8 +61,8 @@ const (
 var (
 	ErrConnectionClosed = errors.New("libvirt connection is closed")
 	ErrDomainExists     = errors.New("the domain exists already")
-	ErrDomainNotFound   = fmt.Errorf("domain %w", vm.ErrNotFound)
-	ErrPoolNotFound     = fmt.Errorf("storage pool %w", vm.ErrNotFound)
+	ErrDomainNotFound   = fmt.Errorf("domain %w", errs.ErrNotFound)
+	ErrPoolNotFound     = fmt.Errorf("storage pool %w", errs.ErrNotFound)
 
 	// nomadDomainStates is a mapping of the libvirt domain state to local string constant
 	nomadDomainStates = map[libvirt.DomainState]string{
@@ -325,7 +326,7 @@ func (p *provider) CreateVM(config *vm.Config) error {
 	}
 
 	dom, err := p.getDomain(config.Name)
-	if err != nil && !errors.Is(err, vm.ErrNotFound) {
+	if err != nil && !errors.Is(err, errs.ErrNotFound) {
 		return err
 	}
 
@@ -693,7 +694,7 @@ func (p *provider) Fingerprint() (map[string]*structs.Attribute, error) {
 // implements virt.Virtualizer
 func (p *provider) SetupStorage(config *storage.Config) error {
 	if config == nil {
-		return fmt.Errorf("%w: missing storage pool configuration", vm.ErrInvalidConfiguration)
+		return fmt.Errorf("%w: missing storage pool configuration", errs.ErrInvalidConfiguration)
 	}
 
 	s, err := libvirt_storage.New(p.ctx, p.logger, p, config)
@@ -730,7 +731,7 @@ func (p *provider) GenerateMountCommands(mounts []*vm.MountFileConfig) ([]string
 		// if the mount is read-only, only 9p is supported (unless insecure mounts enabled).
 		if m.ReadOnly && !virtiofsRO {
 			if !p.mountFsAvailable(mountFs9p) {
-				return nil, fmt.Errorf("read-only virtiofs mount %w - libvirt version 11.0.0 or greater required", vm.ErrNotSupported)
+				return nil, fmt.Errorf("read-only virtiofs mount %w - libvirt version 11.0.0 or greater required", errs.ErrNotSupported)
 			}
 
 			cmds = append(cmds, p.generate9pMountCmds(m)...)
@@ -750,7 +751,7 @@ func (p *provider) GenerateMountCommands(mounts []*vm.MountFileConfig) ([]string
 		}
 
 		// If here then no support filesystem detected
-		return nil, fmt.Errorf("mounting %w - no supported filesystems available", vm.ErrNotSupported)
+		return nil, fmt.Errorf("mounting %w - no supported filesystems available", errs.ErrNotSupported)
 	}
 
 	return cmds, nil

--- a/providers/libvirt/libvirt_test.go
+++ b/providers/libvirt/libvirt_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/storage"
@@ -142,7 +143,7 @@ func TestStorage(t *testing.T) {
 
 			// Check that the volume does not exist
 			_, err = pool.GetVolume("test-vol")
-			must.ErrorIs(t, err, vm.ErrNotFound)
+			must.ErrorIs(t, err, errs.ErrNotFound)
 		})
 	})
 }
@@ -366,7 +367,7 @@ func Test_GenerateMountCommands(t *testing.T) {
 	t.Run("not available", func(t *testing.T) {
 		ld, _ := testNew(t, overrideFs())
 		_, err := ld.GenerateMountCommands(mounts())
-		must.ErrorIs(t, err, vm.ErrNotSupported)
+		must.ErrorIs(t, err, errs.ErrNotSupported)
 	})
 
 	t.Run("9p available", func(t *testing.T) {
@@ -480,7 +481,7 @@ func Test_GenerateMountCommands(t *testing.T) {
 				mnts[0].ReadOnly = true
 
 				_, err := ld.GenerateMountCommands(mnts)
-				must.ErrorIs(t, err, vm.ErrNotSupported)
+				must.ErrorIs(t, err, errs.ErrNotSupported)
 			})
 
 			t.Run("read-only not supported insecure mounts enabled", func(t *testing.T) {
@@ -539,7 +540,7 @@ func Test_GenerateMountCommands(t *testing.T) {
 			ld.libvirtVersion = 1
 
 			_, err := ld.GenerateMountCommands(mnts)
-			must.ErrorIs(t, err, vm.ErrNotSupported)
+			must.ErrorIs(t, err, errs.ErrNotSupported)
 		})
 	})
 }

--- a/providers/libvirt/storage/ceph.go
+++ b/providers/libvirt/storage/ceph.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/disks"
@@ -52,7 +52,7 @@ func newCephPool(ctx context.Context, logger hclog.Logger, l libvirtStorage, poo
 	}
 
 	p, err := l.FindStoragePool(poolName)
-	if err != nil && !errors.Is(err, vm.ErrNotFound) {
+	if err != nil && !errors.Is(err, errs.ErrNotFound) {
 		logger.Debug("unexpected error during pool lookup", "error", err)
 		return nil, err
 	}
@@ -167,12 +167,12 @@ func (c *ceph) ValidateDisk(disk *disks.Disk) error {
 	// Only raw format is supported for ceph volumes
 	if disk.Format != disks.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: format can only be raw for ceph volumes", disks.ErrInvalidConfiguration))
+			fmt.Errorf("%w: format can only be raw for ceph volumes", errs.ErrInvalidConfiguration))
 	}
 
 	if disk.Sparse != nil && !*disk.Sparse {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: sparse cannot be disabled for ceph volumes", disks.ErrInvalidConfiguration))
+			fmt.Errorf("%w: sparse cannot be disabled for ceph volumes", errs.ErrInvalidConfiguration))
 	}
 
 	return mErr.ErrorOrNil()

--- a/providers/libvirt/storage/ceph_test.go
+++ b/providers/libvirt/storage/ceph_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	mock_libvirt "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt"
@@ -44,7 +45,7 @@ func TestCeph_ValidateDisk(t *testing.T) {
 		t.Run("qcow2", func(t *testing.T) {
 			disk := &disks.Disk{Format: disks.DiskFormatQcow2}
 			err := pool.ValidateDisk(disk)
-			must.ErrorIs(t, err, disks.ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format can only be raw")
 		})
 	})
@@ -58,7 +59,7 @@ func TestCeph_ValidateDisk(t *testing.T) {
 		t.Run("disabled", func(t *testing.T) {
 			disk := &disks.Disk{Format: disks.DiskFormatRaw, Sparse: pointer.Of(false)}
 			err := pool.ValidateDisk(disk)
-			must.ErrorIs(t, err, disks.ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "sparse cannot be disabled")
 		})
 	})

--- a/providers/libvirt/storage/directory.go
+++ b/providers/libvirt/storage/directory.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/disks"
 	"libvirt.org/go/libvirtxml"
@@ -29,7 +29,7 @@ type directory struct {
 func newDirectoryPool(ctx context.Context, logger hclog.Logger, l libvirtStorage, poolName string, config storage.Directory, s storage.Storage) (*directory, error) {
 	logger = logger.Named("storage-pool").With("name", poolName)
 	p, err := l.FindStoragePool(poolName)
-	if err != nil && !errors.Is(err, vm.ErrNotFound) {
+	if err != nil && !errors.Is(err, errs.ErrNotFound) {
 		return nil, err
 	}
 
@@ -69,13 +69,13 @@ func (d *directory) ValidateDisk(disk *disks.Disk) error {
 	// Directory pool currently supports qcow2 and raw volumes
 	if disk.Format != disks.DiskFormatQcow2 && disk.Format != disks.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: format only supports raw or qcow2 for directory volumes", disks.ErrInvalidConfiguration))
+			fmt.Errorf("%w: format only supports raw or qcow2 for directory volumes", errs.ErrInvalidConfiguration))
 	}
 
 	// Disk chaining is only supported with qcow2 images.
 	if disk.Format != disks.DiskFormatQcow2 && disk.Chained {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: format must be qcow2 for chained directory volumes", disks.ErrInvalidConfiguration))
+			fmt.Errorf("%w: format must be qcow2 for chained directory volumes", errs.ErrInvalidConfiguration))
 	}
 
 	return mErr.ErrorOrNil()

--- a/providers/libvirt/storage/directory_test.go
+++ b/providers/libvirt/storage/directory_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	mock_libvirt "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt"
 	mock_libvirt_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt/storage"
@@ -46,7 +47,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 		t.Run("unknown", func(t *testing.T) {
 			disk := &disks.Disk{Format: "unknown"}
 			err := pool.ValidateDisk(disk)
-			must.ErrorIs(t, err, disks.ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format only supports")
 		})
 	})
@@ -60,7 +61,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 		t.Run("raw format", func(t *testing.T) {
 			disk := &disks.Disk{Format: disks.DiskFormatRaw, Chained: true}
 			err := pool.ValidateDisk(disk)
-			must.ErrorIs(t, err, disks.ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format must be qcow2")
 		})
 	})

--- a/providers/libvirt/storage/storage.go
+++ b/providers/libvirt/storage/storage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/storage"
@@ -29,10 +30,10 @@ const (
 )
 
 var (
-	ErrInvalidStorageConfiguration = fmt.Errorf("%w for storage", vm.ErrInvalidConfiguration)
-	ErrInvalidVolumeConfiguration  = fmt.Errorf("%w for volume", vm.ErrInvalidConfiguration)
-	ErrVolumeNotFound              = fmt.Errorf("volume %w", vm.ErrNotFound)
-	ErrPoolNotFound                = fmt.Errorf("pool %w", vm.ErrNotFound)
+	ErrInvalidStorageConfiguration = fmt.Errorf("%w for storage", errs.ErrInvalidConfiguration)
+	ErrInvalidVolumeConfiguration  = fmt.Errorf("%w for volume", errs.ErrInvalidConfiguration)
+	ErrVolumeNotFound              = fmt.Errorf("volume %w", errs.ErrNotFound)
+	ErrPoolNotFound                = fmt.Errorf("pool %w", errs.ErrNotFound)
 )
 
 // This interface defines what functions are needed from the libvirt provider.
@@ -307,7 +308,7 @@ func (s *Storage) VolumeToDisk(vol storage.Volume) (*libvirtxml.DomainDisk, erro
 			},
 		}
 	default:
-		return nil, fmt.Errorf("%w: unknown storage type - %s", vm.ErrNotImplemented, pool.Type())
+		return nil, fmt.Errorf("%w: unknown storage type - %s", errs.ErrNotImplemented, pool.Type())
 	}
 
 	return disk, nil

--- a/providers/libvirt/storage/storage_test.go
+++ b/providers/libvirt/storage/storage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	mock_libvirt "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt"
@@ -488,7 +489,7 @@ func TestStorage_VolumeToDisk(t *testing.T) {
 				TypeResult: "unknown",
 				NameResult: "test-pool",
 			},
-			err: vm.ErrNotImplemented,
+			err: errs.ErrNotImplemented,
 		},
 	}
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/virt"
@@ -218,7 +219,7 @@ func (p *providers) GetVM(name string) (*vm.Info, error) {
 
 		info, err := pv.GetVM(name)
 		if err != nil {
-			if !errors.Is(err, vm.ErrNotFound) {
+			if !errors.Is(err, errs.ErrNotFound) {
 				return nil, err
 			}
 
@@ -228,7 +229,7 @@ func (p *providers) GetVM(name string) (*vm.Info, error) {
 		return info, err
 	}
 
-	return nil, vm.ErrNotFound
+	return nil, errs.ErrNotFound
 }
 
 // GetProviderForVM will return the virt.Virtualizer responsible
@@ -245,7 +246,7 @@ func (p *providers) GetProviderForVM(ctx context.Context, name string) (virt.Vir
 
 		_, err = pv.GetVM(name)
 		if err != nil {
-			if !errors.Is(err, vm.ErrNotFound) {
+			if !errors.Is(err, errs.ErrNotFound) {
 				return nil, err
 			}
 
@@ -255,5 +256,5 @@ func (p *providers) GetProviderForVM(ctx context.Context, name string) (virt.Vir
 		return pv, nil
 	}
 
-	return nil, vm.ErrNotFound
+	return nil, errs.ErrNotFound
 }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	mock_virtualizers "github.com/hashicorp/nomad-driver-virt/testutil/mock/virt"
 	"github.com/hashicorp/nomad-driver-virt/virt"
@@ -79,7 +80,7 @@ func TestProviders(t *testing.T) {
 		t.Run("no providers", func(t *testing.T) {
 			p := New(ctx, logger)
 			v, err := p.GetVM("test")
-			must.ErrorIs(t, err, vm.ErrNotFound)
+			must.ErrorIs(t, err, errs.ErrNotFound)
 			must.Nil(t, v)
 		})
 
@@ -91,7 +92,7 @@ func TestProviders(t *testing.T) {
 
 			t.Run("when VM is not registered", func(t *testing.T) {
 				v, err := p.GetVM("test")
-				must.ErrorIs(t, err, vm.ErrNotFound)
+				must.ErrorIs(t, err, errs.ErrNotFound)
 				must.Nil(t, v)
 			})
 
@@ -109,7 +110,7 @@ func TestProviders(t *testing.T) {
 		t.Run("no providers", func(t *testing.T) {
 			p := New(ctx, logger)
 			v, err := p.GetProviderForVM(t.Context(), "test-vm")
-			must.ErrorIs(t, err, vm.ErrNotFound)
+			must.ErrorIs(t, err, errs.ErrNotFound)
 			must.Nil(t, v)
 		})
 
@@ -118,7 +119,7 @@ func TestProviders(t *testing.T) {
 			stubProvider(p, "test-virt", mock_virtualizers.NewStatic())
 			stubProvider(p, "other-virt", mock_virtualizers.NewStatic())
 			v, err := p.GetProviderForVM(t.Context(), "test-vm")
-			must.ErrorIs(t, err, vm.ErrNotFound)
+			must.ErrorIs(t, err, errs.ErrNotFound)
 			must.Nil(t, v)
 		})
 

--- a/testutil/mock/virt/static.go
+++ b/testutil/mock/virt/static.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	mock_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/storage"
@@ -105,7 +106,7 @@ func (s *StaticVirt) GetVM(string) (*vm.Info, error) {
 		return s.GetVMResult, nil
 	}
 
-	return nil, vm.ErrNotFound
+	return nil, errs.ErrNotFound
 }
 
 func (s *StaticVirt) GetNetworkInterfaces(string) ([]vm.NetworkInterface, error) {

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-driver-virt/internal/convert"
-	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/storage/image_tools"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -23,12 +23,10 @@ import (
 )
 
 var (
-	ErrInvalidConfiguration = errors.New("invalid configuration")
-	ErrMissingAttribute     = errors.New("missing required attribute")
-	ErrDisallowedPath       = errors.New("access to path is not allowed")
-	ErrPathNotFound         = errors.New("path not found")
-	ErrNoPrimary            = errors.New("no primary disk defined")
-	ErrMultiplePrimary      = errors.New("multiple primary disks defined")
+	ErrDisallowedPath  = fmt.Errorf("%w - access to path is not allowed", errs.ErrInvalidConfiguration)
+	ErrPathNotFound    = fmt.Errorf("%w - path not found", errs.ErrInvalidConfiguration)
+	ErrNoPrimary       = fmt.Errorf("%w - no primary disk defined", errs.ErrInvalidConfiguration)
+	ErrMultiplePrimary = fmt.Errorf("%w - multiple primary disks defined", errs.ErrInvalidConfiguration)
 
 	configSpec = hclspec.NewBlockSet("disk", hclspec.NewObject(map[string]*hclspec.Spec{
 		"pool":      hclspec.NewAttr("pool", "string", false),
@@ -164,34 +162,34 @@ func (d *Disk) ValidateNomadVolume() error {
 
 	if d.Format != "" && d.Format != DiskFormatRaw {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - format cannot be set when using Nomad volume", ErrInvalidConfiguration))
+			fmt.Errorf("%w - format cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Size != "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - size cannot be set when using Nomad volume", ErrInvalidConfiguration))
+			fmt.Errorf("%w - size cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Sparse != nil {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - sparse cannot be set when using Nomad volume", ErrInvalidConfiguration))
+			fmt.Errorf("%w - sparse cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Pool != "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - pool cannot be set when using Nomad volume", ErrInvalidConfiguration))
+			fmt.Errorf("%w - pool cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Chained {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - chained cannot be set when using Nomad volume", ErrInvalidConfiguration))
+			fmt.Errorf("%w - chained cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Source != nil {
 		if d.Source.Volume != "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%w - source.volume cannot be set when using Nomad volume", ErrInvalidConfiguration))
+				fmt.Errorf("%w - source.volume cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 		}
 	}
 
 	if d.blockDevicePath == "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - missing Nomad volume mount configuration", ErrInvalidConfiguration))
+			fmt.Errorf("%w - missing Nomad volume mount configuration", errs.ErrInvalidConfiguration))
 	}
 
 	return mErr.ErrorOrNil()
@@ -435,7 +433,7 @@ func (d Disks) Prepare(s storage.Storage) error {
 
 				vol, err := pool.GetVolume(disk.Source.identifier)
 				if err != nil {
-					if !errors.Is(err, vm.ErrNotFound) {
+					if !errors.Is(err, errs.ErrNotFound) {
 						return err
 					}
 
@@ -540,17 +538,17 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 		// Start with checking values that should be set for all disks.
 		if disk.BusType == "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: bus_type", errPrefix, ErrMissingAttribute))
+				fmt.Errorf("%s %w: bus_type", errPrefix, errs.ErrMissingAttribute))
 		}
 
 		if disk.Kind == "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: kind", errPrefix, ErrMissingAttribute))
+				fmt.Errorf("%s %w: kind", errPrefix, errs.ErrMissingAttribute))
 		}
 
 		if disk.Devname == "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: devname", errPrefix, ErrMissingAttribute))
+				fmt.Errorf("%s %w: devname", errPrefix, errs.ErrMissingAttribute))
 		}
 
 		// If a source image has been set, check that it exists and it's
@@ -566,11 +564,11 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 			}
 			if disk.Source.Format == "" {
 				mErr = multierror.Append(mErr,
-					fmt.Errorf("%s %w: source.format", errPrefix, ErrMissingAttribute))
+					fmt.Errorf("%s %w: source.format", errPrefix, errs.ErrMissingAttribute))
 			}
 			if disk.Source.Volume != "" {
 				mErr = multierror.Append(mErr,
-					fmt.Errorf("%s %w: storage.volume and storage.image are mutually exclusive", errPrefix, ErrInvalidConfiguration))
+					fmt.Errorf("%s %w: storage.volume and storage.image are mutually exclusive", errPrefix, errs.ErrInvalidConfiguration))
 			}
 		}
 
@@ -586,12 +584,12 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 
 		if disk.Format == "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: format", errPrefix, ErrMissingAttribute))
+				fmt.Errorf("%s %w: format", errPrefix, errs.ErrMissingAttribute))
 		}
 
 		if disk.Size == "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: size", errPrefix, ErrMissingAttribute))
+				fmt.Errorf("%s %w: size", errPrefix, errs.ErrMissingAttribute))
 		}
 
 		// If a size for the disk is set, check that the value is a size.
@@ -602,7 +600,7 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 
 		if disk.Chained && (disk.Source == nil || (disk.Source.Volume == "" && disk.Source.Image == "")) {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: chained cannot be enabled without a source", errPrefix, ErrInvalidConfiguration))
+				fmt.Errorf("%s %w: chained cannot be enabled without a source", errPrefix, errs.ErrInvalidConfiguration))
 		}
 
 		// Load the storage pool for this disk and apply any custom validation if

--- a/virt/disks/config_test.go
+++ b/virt/disks/config_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	mock_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/storage"
 	mock_image_tools "github.com/hashicorp/nomad-driver-virt/testutil/mock/storage/image_tools"
@@ -358,7 +358,7 @@ func TestDisk(t *testing.T) {
 					p := mock_storage.NewMockPool(t)
 					defer p.AssertExpectations()
 					p.Expect(
-						mock_storage.GetVolume{Name: volName, Err: vm.ErrNotFound},
+						mock_storage.GetVolume{Name: volName, Err: errs.ErrNotFound},
 						mock_storage.AddVolume{
 							Name: volName,
 							Opts: storage.Options{
@@ -396,49 +396,49 @@ func TestDisk(t *testing.T) {
 		t.Run("set format", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Format: "not-raw"}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format")
 		})
 
 		t.Run("set size", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Size: "2GB"}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "size")
 		})
 
 		t.Run("sparse enabled", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Sparse: pointer.Of(true)}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "sparse")
 		})
 
 		t.Run("set pool", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Pool: "some-pool"}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "pool")
 		})
 
 		t.Run("chained enabled", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Chained: true}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "chained")
 		})
 
 		t.Run("set source", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume", blockDevicePath: "/dev/null", Source: &Source{Volume: "other-volume"}}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "source.volume")
 		})
 
 		t.Run("unset device path", func(t *testing.T) {
 			d := Disk{VolumeName: "nomad-volume"}
 			err := d.ValidateNomadVolume()
-			must.ErrorIs(t, err, ErrInvalidConfiguration)
+			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "missing Nomad volume")
 		})
 	})


### PR DESCRIPTION
Move base error types out of the shared internal vm package and isolate within their own package.