### PR TITLE
config: add validation of plugin configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-set v0.1.14
+	github.com/hashicorp/go-set/v3 v3.0.1
 	github.com/hashicorp/nomad v1.11.3
 	github.com/shoenig/test v1.13.0
 	libvirt.org/go/libvirt v1.12002.0
@@ -75,7 +76,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3 // indirect
 	github.com/hashicorp/go-set/v2 v2.1.0 // indirect
-	github.com/hashicorp/go-set/v3 v3.0.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -6,6 +6,8 @@ package errs
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"strings"
 )
 
 var (
@@ -17,3 +19,63 @@ var (
 
 	ErrMissingAttribute = fmt.Errorf("%w - missing required attribute", ErrInvalidConfiguration)
 )
+
+// options are optional arguments used by helper functions.
+type options struct {
+	prefix string // prefix for error message
+	suffix string // suffix for error message
+}
+
+type optionFn func(*options)
+
+// WithPrefix adds the provided prefix to generated error messages.
+func WithPrefix(prefix string) optionFn {
+	return func(o *options) { o.prefix = prefix }
+}
+
+// WithSuffix adds the provided suffix to generated error messages.
+func WithSuffix(suffix string) optionFn {
+	return func(o *options) { o.suffix = suffix }
+}
+
+// MissingAttribute returns a wrapped ErrMissingAttribute error which includes
+// the attribute name if the value is empty.
+func MissingAttribute(attrName string, value any, opts ...optionFn) error {
+	// Inspect the value and return if it was provided.
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Pointer:
+		if !rv.IsNil() {
+			return nil
+		}
+	case reflect.String, reflect.Slice, reflect.Map:
+		if rv.Len() != 0 {
+			return nil
+		}
+	default:
+		return fmt.Errorf("%w - uncheckable attribute %s = %v (%T)", ErrNotSupported, attrName, value, value)
+	}
+
+	// The attribute is missing so set any passed options.
+	o := &options{}
+	for _, fn := range opts {
+		fn(o)
+	}
+
+	// Construct the error message.
+	tmpl := []string{"%w:"}
+	args := []any{ErrMissingAttribute}
+	if o.prefix != "" {
+		tmpl = append(tmpl, "%s")
+		args = append(args, o.prefix)
+	}
+	tmpl = append(tmpl, "%s")
+	args = append(args, attrName)
+	if o.suffix != "" {
+		tmpl = append(tmpl, "%s")
+		args = append(args, o.suffix)
+	}
+
+	// Create and return the error.
+	return fmt.Errorf(strings.Join(tmpl, " "), args...)
+}

--- a/internal/errs/errors_test.go
+++ b/internal/errs/errors_test.go
@@ -1,0 +1,127 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package errs
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestMissingAttribute(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		value       any
+		attrName    string
+		options     []optionFn
+		errContains string // checks for substring in error message
+		errContent  string // checks exact error message
+		errIs       error  // target error for matching
+		noErr       bool   // no error is expected
+	}{
+		{
+			desc:     "ok - string",
+			value:    "1",
+			attrName: "test.value",
+			noErr:    true,
+		},
+		{
+			desc:     "ok - pointer",
+			value:    &struct{}{},
+			attrName: "test.value",
+			noErr:    true,
+		},
+		{
+			desc:     "ok - slice",
+			value:    []string{"test"},
+			attrName: "test.value",
+			noErr:    true,
+		},
+		{
+			desc:     "ok - map",
+			value:    map[string]string{"test": "test"},
+			attrName: "test.value",
+			noErr:    true,
+		},
+		{
+			desc:     "missing - string",
+			value:    "",
+			attrName: "test.value",
+		},
+		{
+			desc:     "missing - pointer",
+			value:    (*struct{})(nil),
+			attrName: "test.value",
+		},
+		{
+			desc:     "missing - slice",
+			value:    []string{},
+			attrName: "test.value",
+		},
+		{
+			desc:     "missing - map",
+			value:    make(map[string]string, 0),
+			attrName: "test.value",
+		},
+		{
+			desc:        "unsupported",
+			value:       1,
+			attrName:    "test.value",
+			errIs:       ErrNotSupported,
+			errContains: "uncheckable attribute test.value = 1 (int)",
+		},
+		{
+			desc:       "missing - message",
+			value:      "",
+			attrName:   "test.value",
+			errContent: "invalid configuration - missing required attribute: test.value",
+		},
+		{
+			desc:       "missing - prefix",
+			value:      "",
+			attrName:   "test.value",
+			options:    []optionFn{WithPrefix("test-prefix -")},
+			errContent: "invalid configuration - missing required attribute: test-prefix - test.value",
+		},
+		{
+			desc:       "missing - suffix",
+			value:      "",
+			attrName:   "test.value",
+			options:    []optionFn{WithSuffix("- test-suffix")},
+			errContent: "invalid configuration - missing required attribute: test.value - test-suffix",
+		},
+		{
+			desc:       "missing - prefix and suffix",
+			value:      "",
+			attrName:   "test.value",
+			options:    []optionFn{WithPrefix("test-prefix -"), WithSuffix("- test-suffix")},
+			errContent: "invalid configuration - missing required attribute: test-prefix - test.value - test-suffix",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := MissingAttribute(tc.attrName, tc.value, tc.options...)
+			if tc.noErr {
+				must.NoError(t, err)
+				return
+			}
+
+			chkErr := tc.errIs
+			if chkErr == nil {
+				chkErr = ErrMissingAttribute
+			}
+
+			must.ErrorIs(t, err, chkErr)
+
+			if tc.errContains != "" {
+				must.ErrorContains(t, err, tc.errContains)
+			}
+
+			if tc.errContent != "" {
+				must.Eq(t, err.Error(), tc.errContent)
+			}
+		})
+	}
+}

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -168,6 +168,11 @@ func (d *VirtDriverPlugin) SetConfig(cfg *base.Config) error {
 	// Apply any required configuration updates
 	d.config.Compat()
 
+	// Validate the configuration
+	if err := d.config.Validate(); err != nil {
+		return err
+	}
+
 	// Save the Nomad agent configuration
 	if cfg.AgentConfig != nil {
 		d.nomadConfig = cfg.AgentConfig.Driver

--- a/providers/libvirt/config.go
+++ b/providers/libvirt/config.go
@@ -4,6 +4,8 @@
 package libvirt
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
 
@@ -11,11 +13,10 @@ import (
 var configSpec = hclspec.NewBlock("libvirt", false, hclspec.NewObject(map[string]*hclspec.Spec{
 	"uri": hclspec.NewDefault(
 		hclspec.NewAttr("uri", "string", false),
-		hclspec.NewLiteral(`"qemu:///system"`),
+		hclspec.NewLiteral(fmt.Sprintf(`"%s"`, defaultURI)),
 	),
 	"user":                           hclspec.NewAttr("user", "string", false),
 	"password":                       hclspec.NewAttr("password", "string", false),
-	"default":                        hclspec.NewAttr("default", "bool", false),
 	"allow_insecure_readonly_mounts": hclspec.NewAttr("allow_insecure_readonly_mounts", "bool", false),
 }))
 
@@ -29,6 +30,11 @@ type Config struct {
 	URI                 string `codec:"uri"`
 	User                string `codec:"user"`
 	Password            string `codec:"password"`
-	Default             bool   `codec:"default"`
 	AllowInsecureMounts bool   `codec:"allow_insecure_readonly_mounts"`
+}
+
+// Validate validates the libvirt configuration.
+func (c *Config) Validate() error {
+	// NOTE: Nothing to validate currently.
+	return nil
 }

--- a/providers/libvirt/config.go
+++ b/providers/libvirt/config.go
@@ -13,7 +13,7 @@ import (
 var configSpec = hclspec.NewBlock("libvirt", false, hclspec.NewObject(map[string]*hclspec.Spec{
 	"uri": hclspec.NewDefault(
 		hclspec.NewAttr("uri", "string", false),
-		hclspec.NewLiteral(fmt.Sprintf(`"%s"`, defaultURI)),
+		hclspec.NewLiteral(fmt.Sprintf("%q", defaultURI)),
 	),
 	"user":                           hclspec.NewAttr("user", "string", false),
 	"password":                       hclspec.NewAttr("password", "string", false),

--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -56,6 +56,8 @@ const (
 	DomainCrashed     = "crashed"
 	DomainPMSuspended = "pmsuspended"
 	DomainShutOff     = "shutoff"
+
+	Name = "libvirt" // Name of the provider.
 )
 
 var (

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -98,18 +98,19 @@ func (p *providers) Setup(config *virt.Config) error {
 		}
 
 		// Add the dispenser for the libvirt provider
-		dispensers["libvirt"] = func(ctx context.Context) (virt.Virtualizer, error) {
+		dispensers[libvirt.Name] = func(ctx context.Context) (virt.Virtualizer, error) {
 			return lv.Copy(ctx), nil
-		}
-
-		// If marked as the default, set it
-		if config.Provider.Libvirt.Default {
-			p.defaultDispenser = dispensers["libvirt"]
 		}
 	}
 
 	if len(dispensers) == 0 {
 		return ErrNoProvidersEnabled
+	}
+
+	if config.Provider.Default != "" {
+		if dispenser, ok := dispensers[config.Provider.Default]; ok {
+			p.defaultDispenser = dispenser
+		}
 	}
 
 	// If no default was defined, set one

--- a/storage/config.go
+++ b/storage/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
@@ -41,40 +42,33 @@ func (c *Config) Validate() error {
 	var mErr *multierror.Error
 
 	// Track names to flag duplicates.
-	names := map[string]struct{}{}
+	names := set.New[string](0)
 
 	// Validate the directory storage pools.
 	for n, dir := range c.Directory {
-		names[n] = struct{}{}
-
-		if err := dir.Validate(); err != nil {
-			mErr = multierror.Append(mErr, err)
-		}
+		names.Insert(n)
+		mErr = multierror.Append(mErr, dir.Validate())
 	}
 
 	// Validate the ceph storage pools.
 	for n, ceph := range c.Ceph {
-		if _, ok := names[n]; ok {
+		if !names.Insert(n) {
 			mErr = multierror.Append(mErr,
 				fmt.Errorf("%w: storage pool name already defined - %s",
 					errs.ErrInvalidConfiguration, n))
 		}
-		names[n] = struct{}{}
-
-		if err := ceph.Validate(); err != nil {
-			mErr = multierror.Append(mErr, err)
-		}
+		mErr = multierror.Append(mErr, ceph.Validate())
 	}
 
 	// Must have at least one pool defined.
-	if len(names) == 0 {
+	if names.Empty() {
 		mErr = multierror.Append(mErr,
 			fmt.Errorf("%w: no storage pools defined", errs.ErrInvalidConfiguration))
 	}
 
 	// Check the default pool is defined if set.
 	if c.Default != "" {
-		if _, ok := names[c.Default]; !ok {
+		if !names.Contains(c.Default) {
 			mErr = multierror.Append(mErr,
 				fmt.Errorf("%w: default storage pool is unknown - %s",
 					errs.ErrInvalidConfiguration, c.Default))
@@ -93,10 +87,8 @@ type Directory struct {
 func (d Directory) Validate() error {
 	var mErr *multierror.Error
 
-	if d.Path == "" {
-		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: storage_pool.directory.path", errs.ErrMissingAttribute))
-	}
+	mErr = multierror.Append(mErr,
+		errs.MissingAttribute("storage_pool.directory.path", d.Path))
 
 	return mErr.ErrorOrNil()
 }
@@ -112,25 +104,12 @@ type Ceph struct {
 func (c Ceph) Validate() error {
 	var mErr *multierror.Error
 
-	if c.Pool == "" {
-		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: storage_pool.ceph.pool", errs.ErrMissingAttribute))
-	}
-
-	if len(c.Hosts) == 0 {
-		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: storage_pool.ceph.hosts", errs.ErrMissingAttribute))
-	}
-
-	if c.Authentication.Username == "" {
-		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: storage_pool.ceph.authentication.username", errs.ErrMissingAttribute))
-	}
-
-	if c.Authentication.Secret == "" {
-		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w: storage_pool.ceph.authentication.secret", errs.ErrMissingAttribute))
-	}
+	mErr = multierror.Append(mErr,
+		errs.MissingAttribute("storage_pool.ceph.pool", c.Pool),
+		errs.MissingAttribute("storage_pool.ceph.hosts", c.Hosts),
+		errs.MissingAttribute("storage_pool.ceph.authentication.username", c.Authentication.Username),
+		errs.MissingAttribute("storage_pool.ceph.authentication.secret", c.Authentication.Secret),
+	)
 
 	return mErr.ErrorOrNil()
 }

--- a/storage/config.go
+++ b/storage/config.go
@@ -3,7 +3,13 @@
 
 package storage
 
-import "github.com/hashicorp/nomad/plugins/shared/hclspec"
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
+	"github.com/hashicorp/nomad/plugins/shared/hclspec"
+)
 
 var configSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 	"default": hclspec.NewAttr("default", "string", false),
@@ -30,9 +36,69 @@ type Config struct {
 	Ceph map[string]Ceph `codec:"ceph"`
 }
 
+// Validate validates the storage configuration.
+func (c *Config) Validate() error {
+	var mErr *multierror.Error
+
+	// Track names to flag duplicates.
+	names := map[string]struct{}{}
+
+	// Validate the directory storage pools.
+	for n, dir := range c.Directory {
+		names[n] = struct{}{}
+
+		if err := dir.Validate(); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	// Validate the ceph storage pools.
+	for n, ceph := range c.Ceph {
+		if _, ok := names[n]; ok {
+			mErr = multierror.Append(mErr,
+				fmt.Errorf("%w: storage pool name already defined - %s",
+					errs.ErrInvalidConfiguration, n))
+		}
+		names[n] = struct{}{}
+
+		if err := ceph.Validate(); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	// Must have at least one pool defined.
+	if len(names) == 0 {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: no storage pools defined", errs.ErrInvalidConfiguration))
+	}
+
+	// Check the default pool is defined if set.
+	if c.Default != "" {
+		if _, ok := names[c.Default]; !ok {
+			mErr = multierror.Append(mErr,
+				fmt.Errorf("%w: default storage pool is unknown - %s",
+					errs.ErrInvalidConfiguration, c.Default))
+		}
+	}
+
+	return mErr.ErrorOrNil()
+}
+
 // Directory provides configuration for local directory storage pools
 type Directory struct {
 	Path string `codec:"path"` // Local path of the storage pool
+}
+
+// Validate validates the directory pool configuration.
+func (d Directory) Validate() error {
+	var mErr *multierror.Error
+
+	if d.Path == "" {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: storage_pool.directory.path", errs.ErrMissingAttribute))
+	}
+
+	return mErr.ErrorOrNil()
 }
 
 // Ceph provides configuration for ceph rbd storage pools
@@ -40,6 +106,33 @@ type Ceph struct {
 	Pool           string         `codec:"pool"`           // Name of the ceph storage pool
 	Hosts          []string       `codec:"hosts"`          // List of ceph hosts
 	Authentication Authentication `codec:"authentication"` // Autentication for ceph connection
+}
+
+// Validate validates the ceph pool configuration.
+func (c Ceph) Validate() error {
+	var mErr *multierror.Error
+
+	if c.Pool == "" {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: storage_pool.ceph.pool", errs.ErrMissingAttribute))
+	}
+
+	if len(c.Hosts) == 0 {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: storage_pool.ceph.hosts", errs.ErrMissingAttribute))
+	}
+
+	if c.Authentication.Username == "" {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: storage_pool.ceph.authentication.username", errs.ErrMissingAttribute))
+	}
+
+	if c.Authentication.Secret == "" {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: storage_pool.ceph.authentication.secret", errs.ErrMissingAttribute))
+	}
+
+	return mErr.ErrorOrNil()
 }
 
 // Authentication provides credentials

--- a/storage/config_test.go
+++ b/storage/config_test.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/shoenig/test/must"
 )
@@ -105,4 +106,193 @@ config {
 		parser.ParseHCL(t, validHcl, &config)
 		must.Eq(t, expected, config)
 	})
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		config      *Config
+		errContains string
+		errType     error
+	}{
+		{
+			desc: "ok",
+			config: &Config{
+				Directory: map[string]Directory{
+					"pool": {Path: "/dev/null"},
+				},
+			},
+		},
+		{
+			desc:        "error - no pools",
+			config:      &Config{},
+			errContains: "no storage pools",
+			errType:     errs.ErrInvalidConfiguration,
+		},
+		{
+			desc:        "error - bad default",
+			config:      &Config{Default: "some-pool"},
+			errContains: "default storage pool is unknown - some-pool",
+			errType:     errs.ErrInvalidConfiguration,
+		},
+		{
+			desc: "error - duplicate names",
+			config: &Config{
+				Directory: map[string]Directory{
+					"test-pool": {},
+				},
+				Ceph: map[string]Ceph{
+					"test-pool": {},
+				},
+			},
+			errContains: "already defined - test-pool",
+			errType:     errs.ErrInvalidConfiguration,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.errContains == "" && tc.errType == nil {
+				must.NoError(t, err)
+			}
+
+			if tc.errContains != "" {
+				must.ErrorContains(t, err, tc.errContains)
+			}
+
+			if tc.errType != nil {
+				must.ErrorIs(t, err, tc.errType)
+			}
+		})
+	}
+}
+
+func TestDirectory_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		config      Directory
+		errContains string
+		errType     error
+	}{
+		{
+			desc:   "ok",
+			config: Directory{Path: "/dev/null"},
+		},
+		{
+			desc:        "error - no path",
+			config:      Directory{},
+			errContains: "storage_pool.directory.path",
+			errType:     errs.ErrMissingAttribute,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.errContains == "" && tc.errType == nil {
+				must.NoError(t, err)
+			}
+
+			if tc.errContains != "" {
+				must.ErrorContains(t, err, tc.errContains)
+			}
+
+			if tc.errType != nil {
+				must.ErrorIs(t, err, tc.errType)
+			}
+		})
+	}
+}
+
+func TestCeph_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc        string
+		config      Ceph
+		errContains string
+		errType     error
+	}{
+		{
+			desc: "ok",
+			config: Ceph{
+				Pool:  "test-pool",
+				Hosts: []string{"locahost:3300"},
+				Authentication: Authentication{
+					Username: "test-user",
+					Secret:   "test-key",
+				},
+			},
+		},
+		{
+			desc: "error - missing pool",
+			config: Ceph{
+				Hosts: []string{"locahost:3300"},
+				Authentication: Authentication{
+					Username: "test-user",
+					Secret:   "test-key",
+				},
+			},
+			errContains: "storage_pool.ceph.pool",
+			errType:     errs.ErrMissingAttribute,
+		},
+		{
+			desc: "error - missing hosts",
+			config: Ceph{
+				Pool: "test-pool",
+				Authentication: Authentication{
+					Username: "test-user",
+					Secret:   "test-key",
+				},
+			},
+			errContains: "storage_pool.ceph.hosts",
+			errType:     errs.ErrMissingAttribute,
+		},
+		{
+			desc: "error - missing username",
+			config: Ceph{
+				Pool:  "test-pool",
+				Hosts: []string{"locahost:3300"},
+				Authentication: Authentication{
+					Secret: "test-key",
+				},
+			},
+			errContains: "storage_pool.ceph.authentication.username",
+			errType:     errs.ErrMissingAttribute,
+		},
+		{
+			desc: "error - missing secret",
+			config: Ceph{
+				Pool:  "test-pool",
+				Hosts: []string{"locahost:3300"},
+				Authentication: Authentication{
+					Username: "test-user",
+				},
+			},
+			errContains: "storage_pool.ceph.authentication.secret",
+			errType:     errs.ErrMissingAttribute,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.errContains == "" && tc.errType == nil {
+				must.NoError(t, err)
+			}
+
+			if tc.errContains != "" {
+				must.ErrorContains(t, err, tc.errContains)
+			}
+
+			if tc.errType != nil {
+				must.ErrorIs(t, err, tc.errType)
+			}
+		})
+	}
 }

--- a/virt/config.go
+++ b/virt/config.go
@@ -126,13 +126,10 @@ func (c *Config) Validate() error {
 
 	var mErr *multierror.Error
 
-	if err := c.Provider.Validate(); err != nil {
-		mErr = multierror.Append(mErr, err)
-	}
-
-	if err := c.StoragePools.Validate(); err != nil {
-		mErr = multierror.Append(mErr, err)
-	}
+	mErr = multierror.Append(mErr,
+		c.Provider.Validate(),
+		c.StoragePools.Validate(),
+	)
 
 	return mErr.ErrorOrNil()
 }

--- a/virt/config.go
+++ b/virt/config.go
@@ -4,9 +4,14 @@
 package virt
 
 import (
+	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/disks"
@@ -59,6 +64,11 @@ var (
 			"machine": hclspec.NewAttr("machine", "string", false),
 		})),
 	})
+
+	// validProviders is a list of valid provider names.
+	validProviders = []string{
+		libvirt.Name,
+	}
 )
 
 func ConfigSpec() *hclspec.Spec {
@@ -107,6 +117,27 @@ type Config struct {
 	StoragePools *storage.Config `codec:"storage_pools"`
 }
 
+// Validate validates the configuration and sets default values.
+func (c *Config) Validate() error {
+	// If no provider configuration is set, default the libvirt provider.
+	if c.Provider == nil {
+		c.Provider = &Provider{Libvirt: &libvirt.Config{}}
+	}
+
+	var mErr *multierror.Error
+
+	if err := c.Provider.Validate(); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	if err := c.StoragePools.Validate(); err != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+// Compat sets appropriate configuration using deprecated options.
 func (c *Config) Compat() {
 	if c.Emulator != nil {
 		if c.Provider == nil {
@@ -154,5 +185,30 @@ func (c *Config) Compat() {
 
 // Provider contains provider specific configuration
 type Provider struct {
+	Default string          `codec:"default"`
 	Libvirt *libvirt.Config `codec:"libvirt"`
+}
+
+// Validate validates the provider configuration.
+func (p *Provider) Validate() error {
+	var mErr *multierror.Error
+
+	if p.Libvirt == nil {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: no providers defined", errs.ErrInvalidConfiguration))
+	}
+
+	if p.Default != "" && slices.Contains(validProviders, p.Default) {
+		mErr = multierror.Append(mErr,
+			fmt.Errorf("%w: unknown default provider (supported: %s)",
+				errs.ErrInvalidConfiguration, strings.Join(validProviders, ", ")))
+	}
+
+	if p.Libvirt != nil {
+		if err := p.Libvirt.Validate(); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	return mErr.ErrorOrNil()
 }

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -536,20 +536,11 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 		}
 
 		// Start with checking values that should be set for all disks.
-		if disk.BusType == "" {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: bus_type", errPrefix, errs.ErrMissingAttribute))
-		}
-
-		if disk.Kind == "" {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: kind", errPrefix, errs.ErrMissingAttribute))
-		}
-
-		if disk.Devname == "" {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: devname", errPrefix, errs.ErrMissingAttribute))
-		}
+		mErr = multierror.Append(mErr,
+			errs.MissingAttribute("bus_type", disk.BusType, errs.WithPrefix(errPrefix)),
+			errs.MissingAttribute("kind", disk.Kind, errs.WithPrefix(errPrefix)),
+			errs.MissingAttribute("devname", disk.Devname, errs.WithPrefix(errPrefix)),
+		)
 
 		// If a source image has been set, check that it exists and it's
 		// located at an accessible location.
@@ -562,14 +553,13 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 				mErr = multierror.Append(mErr,
 					fmt.Errorf("%s %w: %s", errPrefix, ErrDisallowedPath, disk.Source.Image))
 			}
-			if disk.Source.Format == "" {
-				mErr = multierror.Append(mErr,
-					fmt.Errorf("%s %w: source.format", errPrefix, errs.ErrMissingAttribute))
-			}
 			if disk.Source.Volume != "" {
 				mErr = multierror.Append(mErr,
 					fmt.Errorf("%s %w: storage.volume and storage.image are mutually exclusive", errPrefix, errs.ErrInvalidConfiguration))
 			}
+
+			mErr = multierror.Append(mErr,
+				errs.MissingAttribute("source.format", disk.Source.Format, errs.WithPrefix(errPrefix)))
 		}
 
 		// If the disk is backed by a Nomad volume, validate that attributes which
@@ -582,15 +572,10 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 			continue
 		}
 
-		if disk.Format == "" {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: format", errPrefix, errs.ErrMissingAttribute))
-		}
-
-		if disk.Size == "" {
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s %w: size", errPrefix, errs.ErrMissingAttribute))
-		}
+		mErr = multierror.Append(mErr,
+			errs.MissingAttribute("format", disk.Format, errs.WithPrefix(errPrefix)),
+			errs.MissingAttribute("size", disk.Size, errs.WithPrefix(errPrefix)),
+		)
 
 		// If a size for the disk is set, check that the value is a size.
 		if disk.Size != "" && !convert.ValidBytesString(disk.Size) {


### PR DESCRIPTION
Adds validation to the plugin configuration to surface issues before performing setup. Modifies the default provider setting to be an attribute within the providers block mimicking the storage pool configuration.

Built off #197 to utilize isolated base errors.