### PR TITLE
driver: fix fingerprint test

### DIFF
--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -985,5 +985,5 @@ func TestVirtDriver_Libvirt(t *testing.T) {
 	// Check that storage pools are included
 	must.Eq(t, "directory", *print.Attributes["driver.virt.storage_pool.default-pool"].String)
 	must.True(t, *print.Attributes["driver.virt.storage_pool.default-pool.default"].Bool)
-	must.Eq(t, "libvirt", *print.Attributes["driver.virt.storage_pool.default-pool.provider"].String)
+	must.True(t, *print.Attributes["driver.virt.storage_pool.default-pool.provider.libvirt"].Bool)
 }


### PR DESCRIPTION
Fingerprint test within the driver was not updated with changes included in commit 2dc5823 (#191). Adjusts test to account for changes in the fingerprint.