### PR TITLE
storage: default sparse in storage pool

### DIFF
--- a/providers/libvirt/storage/directory.go
+++ b/providers/libvirt/storage/directory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	"github.com/hashicorp/nomad-driver-virt/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/disks"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -65,6 +66,12 @@ func newDirectoryPool(ctx context.Context, logger hclog.Logger, l libvirtStorage
 // implements disks.DiskValidator
 func (d *directory) ValidateDisk(disk *disks.Disk) error {
 	var mErr *multierror.Error
+
+	// If the format of the disk is qcow2 and the sparse attribute has not
+	// been set to any value, set it as true.
+	if disk.Sparse == nil && disk.Format == disks.DiskFormatQcow2 {
+		disk.Sparse = pointer.Of(true)
+	}
 
 	// Directory pool currently supports qcow2 and raw volumes
 	if disk.Format != disks.DiskFormatQcow2 && disk.Format != disks.DiskFormatRaw {

--- a/providers/libvirt/storage/directory_test.go
+++ b/providers/libvirt/storage/directory_test.go
@@ -16,6 +16,7 @@ import (
 	mock_libvirt_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt/storage"
 	mock_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/storage"
 	"github.com/hashicorp/nomad-driver-virt/virt/disks"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/shoenig/test/must"
 	"libvirt.org/go/libvirt"
 	"libvirt.org/go/libvirtxml"
@@ -63,6 +64,43 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 			err := pool.ValidateDisk(disk)
 			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format must be qcow2")
+		})
+	})
+
+	t.Run("sparse modification", func(t *testing.T) {
+		t.Run("value is unset", func(t *testing.T) {
+			t.Run("enabled if format is qcow2", func(t *testing.T) {
+				disk := &disks.Disk{Format: disks.DiskFormatQcow2}
+				err := pool.ValidateDisk(disk)
+				must.NoError(t, err)
+				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))
+				must.True(t, *disk.Sparse, must.Sprint("expected sparse to be enabled"))
+			})
+
+			t.Run("unset if format is not qcow2", func(t *testing.T) {
+				disk := &disks.Disk{Format: disks.DiskFormatRaw}
+				err := pool.ValidateDisk(disk)
+				must.NoError(t, err)
+				must.Nil(t, disk.Sparse, must.Sprint("expected sparse to be unset"))
+			})
+		})
+
+		t.Run("value is set", func(t *testing.T) {
+			t.Run("unchanged when format is qcow2", func(t *testing.T) {
+				disk := &disks.Disk{Format: disks.DiskFormatQcow2, Sparse: pointer.Of(false)}
+				err := pool.ValidateDisk(disk)
+				must.NoError(t, err)
+				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))
+				must.False(t, *disk.Sparse, must.Sprint("expected sparse to be disabled"))
+			})
+
+			t.Run("unchanged when format is not qcow2", func(t *testing.T) {
+				disk := &disks.Disk{Format: disks.DiskFormatRaw, Sparse: pointer.Of(false)}
+				err := pool.ValidateDisk(disk)
+				must.NoError(t, err)
+				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))
+				must.False(t, *disk.Sparse, must.Sprint("expected sparse to be disabled"))
+			})
 		})
 	})
 }


### PR DESCRIPTION
For volumes in a directory storage pool that have a qcow2 format and a sparse value unset, automatically enable it.