### PR TITLE
storage: use image virtual size for volume size

### DIFF
--- a/providers/libvirt/storage/pool.go
+++ b/providers/libvirt/storage/pool.go
@@ -331,6 +331,7 @@ func (p *pool) defaultResizer(vol shims.StorageVol, sizeBytes uint64, sparse boo
 		flags = libvirtNoFlags
 	}
 
+	p.logger.Debug("resizing volume", "current-size", info.Capacity, "desired-size", sizeBytes)
 	if err := vol.Resize(sizeBytes, flags); err != nil {
 		return err
 	}

--- a/storage/image_tools/image_tools.go
+++ b/storage/image_tools/image_tools.go
@@ -4,15 +4,7 @@
 package image_tools
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -21,149 +13,20 @@ var (
 
 // ImageHandler is the interface handling image files directly.
 type ImageHandler interface {
-	// GetImageFormat gets the format of a given image
-	GetImageFormat(path string) (string, error)
 	// ConvertImage makes a copy of the image in a new format
 	ConvertImage(src, srcFmt, dst, dstFmt string) error
+
 	// CreateCopy creates a full copy from the src image
 	CreateCopy(src, dst string, sizeM int64) error
+
 	// CreateChainedCopy creates a copy chained copy from src image
 	CreateChainedCopy(src, dst string, sizeM int64) error
-}
 
-type QemuTools struct {
-	logger hclog.Logger
-}
+	// GetImageFormat returns the format of a given image
+	GetImageFormat(path string) (string, error)
 
-func NewQemuHandler(logger hclog.Logger) *QemuTools {
-	return &QemuTools{
-		logger: logger,
-	}
-}
-
-// ConvertImage makes a copy of the image in a new format
-func (q *QemuTools) ConvertImage(src, srcFmt, dst, dstFmt string) error {
-	var err error
-	if srcFmt == "" {
-		srcFmt, err = q.GetImageFormat(src)
-		if err != nil {
-			return err
-		}
-	}
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-
-	cmd := exec.Command("qemu-img", "convert", "-f", srcFmt, "-O", dstFmt, src, dst)
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	if err := cmd.Run(); err != nil {
-		q.logger.Error("qemu-img convert image", "stderr", stderrBuf.String())
-		q.logger.Debug("qemu-img convert image", "stdout", stdoutBuf.String())
-		return err
-	}
-
-	return nil
-}
-
-// GetImageFormat gets the format of a given image
-func (q *QemuTools) GetImageFormat(basePath string) (string, error) {
-	q.logger.Debug("reading the disk format", "base", basePath)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-
-	cmd := exec.Command("qemu-img", "info", "--output=json", basePath)
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	err := cmd.Run()
-	if err != nil {
-		q.logger.Error("qemu-img read image", "stderr", stderrBuf.String())
-		q.logger.Debug("qemu-img read image", "stdout", stdoutBuf.String())
-		return "", err
-	}
-
-	q.logger.Debug("qemu-img read image", "stdout", stdoutBuf.String())
-
-	// The qemu command returns more information, but for now, only the format
-	// is necessary.
-	var output = struct {
-		Format string `json:"format"`
-	}{}
-
-	err = json.Unmarshal(stdoutBuf.Bytes(), &output)
-	if err != nil {
-		return "", fmt.Errorf("qemu-img: unable read info response %s: %w", basePath, err)
-	}
-
-	return output.Format, nil
-}
-
-// CreateCopy creates a full copy from the src image
-func (q *QemuTools) CreateCopy(src, dst string, sizeM int64) error {
-	q.logger.Debug("creating copy", "base", src, "dest", dst)
-	if err := os.MkdirAll(filepath.Base(dst), 0755); err != nil {
-		return err
-	}
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-
-	if sizeM <= 0 {
-		return fmt.Errorf("qemu-img: %w", ErrNoMemory)
-	}
-
-	// First create the new image file of approripate size
-	cmd := exec.Command("qemu-img", "create", "-F", "qcow2", dst, fmt.Sprintf("%dM", sizeM))
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	err := cmd.Run()
-	if err != nil {
-		q.logger.Error("qemu-img create output", "stderr", stderrBuf.String())
-		q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
-		return err
-	}
-
-	// Now copy the source image into the new file
-	stderrBuf.Reset()
-	stdoutBuf.Reset()
-	cmd = exec.Command("qemu-img", "dd", fmt.Sprintf("if=%s", src), fmt.Sprintf("of=%s", dst))
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	err = cmd.Run()
-	if err != nil {
-		q.logger.Error("qemu-img dd output", "stderr", stderrBuf.String())
-		q.logger.Debug("qemu-img dd output", "stdout", stdoutBuf.String())
-		return err
-	}
-
-	return nil
-}
-
-// CreateChainedCopy creates a copy chained copy from src image
-func (q *QemuTools) CreateChainedCopy(src string, destination string, sizeM int64) error {
-	q.logger.Debug("creating chained copy", "base", src, "dest", destination)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-
-	if sizeM <= 0 {
-		return fmt.Errorf("qemu-img: %w", ErrNoMemory)
-	}
-
-	cmd := exec.Command("qemu-img", "create", "-b", src, "-f", "qcow2", "-F", "qcow2",
-		destination, fmt.Sprintf("%dM", sizeM),
-	)
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-
-	err := cmd.Run()
-	if err != nil {
-		q.logger.Error("qemu-img create output", "stderr", stderrBuf.String())
-		q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
-		return err
-	}
-
-	q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
-	return nil
+	// GetImageSize returns the real size of the image. For some formats
+	// the size of the image will be larger than the size of the image
+	// file itself.
+	GetImageSize(path string) (uint64, error)
 }

--- a/storage/image_tools/qemu.go
+++ b/storage/image_tools/qemu.go
@@ -1,0 +1,175 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package image_tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+type QemuTools struct {
+	logger hclog.Logger
+}
+
+func NewQemuHandler(logger hclog.Logger) *QemuTools {
+	return &QemuTools{
+		logger: logger,
+	}
+}
+
+// ConvertImage makes a copy of the image in a new format
+func (q *QemuTools) ConvertImage(src, srcFmt, dst, dstFmt string) error {
+	var err error
+	if srcFmt == "" {
+		srcFmt, err = q.GetImageFormat(src)
+		if err != nil {
+			return err
+		}
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	cmd := exec.Command("qemu-img", "convert", "-f", srcFmt, "-O", dstFmt, src, dst)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		q.logger.Error("qemu-img convert image", "stderr", stderrBuf.String())
+		q.logger.Debug("qemu-img convert image", "stdout", stdoutBuf.String())
+		return err
+	}
+
+	return nil
+}
+
+// GetImageFormat gets the format of a given image
+func (q *QemuTools) GetImageFormat(path string) (string, error) {
+	var output = struct {
+		Format string `json:"format"`
+	}{}
+
+	if err := q.getImageInfo(path, &output); err != nil {
+		return "", err
+	}
+
+	return output.Format, nil
+}
+
+// CreateCopy creates a full copy from the src image
+func (q *QemuTools) CreateCopy(src, dst string, sizeM int64) error {
+	q.logger.Debug("creating copy", "base", src, "dest", dst)
+	if err := os.MkdirAll(filepath.Base(dst), 0755); err != nil {
+		return err
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	if sizeM <= 0 {
+		return fmt.Errorf("qemu-img: %w", ErrNoMemory)
+	}
+
+	// First create the new image file of approripate size
+	cmd := exec.Command("qemu-img", "create", "-F", "qcow2", dst, fmt.Sprintf("%dM", sizeM))
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		q.logger.Error("qemu-img create output", "stderr", stderrBuf.String())
+		q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
+		return err
+	}
+
+	// Now copy the source image into the new file
+	stderrBuf.Reset()
+	stdoutBuf.Reset()
+	cmd = exec.Command("qemu-img", "dd", fmt.Sprintf("if=%s", src), fmt.Sprintf("of=%s", dst))
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+	if err != nil {
+		q.logger.Error("qemu-img dd output", "stderr", stderrBuf.String())
+		q.logger.Debug("qemu-img dd output", "stdout", stdoutBuf.String())
+		return err
+	}
+
+	return nil
+}
+
+// CreateChainedCopy creates a copy chained copy from src image
+func (q *QemuTools) CreateChainedCopy(src string, destination string, sizeM int64) error {
+	q.logger.Debug("creating chained copy", "base", src, "dest", destination)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	if sizeM <= 0 {
+		return fmt.Errorf("qemu-img: %w", ErrNoMemory)
+	}
+
+	cmd := exec.Command("qemu-img", "create", "-b", src, "-f", "qcow2", "-F", "qcow2",
+		destination, fmt.Sprintf("%dM", sizeM),
+	)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		q.logger.Error("qemu-img create output", "stderr", stderrBuf.String())
+		q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
+		return err
+	}
+
+	q.logger.Debug("qemu-img create output", "stdout", stdoutBuf.String())
+	return nil
+}
+
+// GetImageSize returns the real size of the image. For some formats
+// the size of the image will be larger than the size of the image
+// file itself.
+func (q *QemuTools) GetImageSize(path string) (uint64, error) {
+	var output = struct {
+		Size uint64 `json:"virtual-size"`
+	}{}
+
+	if err := q.getImageInfo(path, &output); err != nil {
+		return 0, err
+	}
+
+	return output.Size, nil
+}
+
+// getImageInfo reads information about the image file and unmarshals the result
+// into the provided value.
+func (q *QemuTools) getImageInfo(path string, result any) error {
+	q.logger.Debug("reading image info", "image", path)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	cmd := exec.Command("qemu-img", "info", "--output=json", path)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		q.logger.Error("qemu-img read image", "stderr", stderrBuf.String())
+		q.logger.Debug("qemu-img read image", "stdout", stdoutBuf.String())
+		return err
+	}
+
+	q.logger.Debug("qemu-img read image", "stdout", stdoutBuf.String())
+
+	err = json.Unmarshal(stdoutBuf.Bytes(), &result)
+	if err != nil {
+		return fmt.Errorf("qemu-img: unable read info response %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/testutil/mock/storage/image_tools/image_tools.go
+++ b/testutil/mock/storage/image_tools/image_tools.go
@@ -21,6 +21,7 @@ func NewStaticImageHandler() *StaticImageHandler {
 
 type StaticImageHandler struct {
 	GetImageFormatResult string
+	GetImageSizeResult   uint64
 
 	counts map[string]int
 	m      sync.Mutex
@@ -76,6 +77,14 @@ func (s *StaticImageHandler) GetImageFormat(string) (string, error) {
 	return "test-format", nil
 }
 
+func (s *StaticImageHandler) GetImageSize(string) (uint64, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.incrCount()
+
+	return s.GetImageSizeResult, nil
+}
+
 func (s *StaticImageHandler) CreateCopy(string, string, int64) error {
 	s.m.Lock()
 	defer s.m.Unlock()
@@ -120,6 +129,12 @@ type CreateChainedCopy struct {
 	Err   error
 }
 
+type GetImageSize struct {
+	Path   string
+	Result uint64
+	Err    error
+}
+
 type MockImageHandler struct {
 	t must.T
 
@@ -127,6 +142,7 @@ type MockImageHandler struct {
 	convertImage      []ConvertImage
 	createCopy        []CreateCopy
 	createChainedCopy []CreateChainedCopy
+	getImageSize      []GetImageSize
 	m                 sync.Mutex
 }
 
@@ -135,6 +151,8 @@ func (m *MockImageHandler) Expect(calls ...any) *MockImageHandler {
 		switch c := call.(type) {
 		case GetImageFormat:
 			m.ExpectGetImageFormat(c)
+		case GetImageSize:
+			m.ExpectGetImageSize(c)
 		case CreateCopy:
 			m.ExpectCreateCopy(c)
 		case CreateChainedCopy:
@@ -162,6 +180,14 @@ func (m *MockImageHandler) ExpectGetImageFormat(c GetImageFormat) *MockImageHand
 	defer m.m.Unlock()
 
 	m.getImageFormat = append(m.getImageFormat, c)
+	return m
+}
+
+func (m *MockImageHandler) ExpectGetImageSize(c GetImageSize) *MockImageHandler {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.getImageSize = append(m.getImageSize, c)
 	return m
 }
 
@@ -213,6 +239,26 @@ func (m *MockImageHandler) GetImageFormat(path string) (string, error) {
 		struct{ Path string }{call.Path},
 		struct{ Path string }{path},
 		must.Sprint("GetImageFormat received incorrect arguments"),
+	)
+
+	return call.Result, call.Err
+}
+
+func (m *MockImageHandler) GetImageSize(path string) (uint64, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.getImageSize,
+		must.Sprint("Unexpected call to GetImageSize"))
+	call := m.getImageSize[0]
+	m.getImageSize = m.getImageSize[1:]
+
+	must.Eq(m.t,
+		struct{ Path string }{call.Path},
+		struct{ Path string }{path},
+		must.Sprint("GetImageSize received incorrect arguments"),
 	)
 
 	return call.Result, call.Err
@@ -278,6 +324,8 @@ func (m *MockImageHandler) AssertExpectations() {
 
 	must.SliceEmpty(m.t, m.getImageFormat,
 		must.Sprintf("GetImageFormat expecting %d more invocations", len(m.getImageFormat)))
+	must.SliceEmpty(m.t, m.getImageSize,
+		must.Sprintf("GetImageSize expecting %d more invocations", len(m.getImageSize)))
 	must.SliceEmpty(m.t, m.createCopy,
 		must.Sprintf("CreateCopy expecting %d more invocations", len(m.createCopy)))
 	must.SliceEmpty(m.t, m.createChainedCopy,

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -446,7 +446,7 @@ func (d Disks) Prepare(s storage.Storage) error {
 						defer os.Remove(disk.Source.Image)
 					}
 
-					info, err := os.Stat(disk.Source.Image)
+					size, err := s.ImageHandler().GetImageSize(disk.Source.Image)
 					if err != nil {
 						return err
 					}
@@ -459,7 +459,7 @@ func (d Disks) Prepare(s storage.Storage) error {
 						Source: storage.Source{
 							Path: disk.Source.Image,
 						},
-						Size: uint64(info.Size()),
+						Size: size,
 					}
 
 					// Create the parent volume.
@@ -496,9 +496,9 @@ func (d Disks) Prepare(s storage.Storage) error {
 			// If an image is defined, use the size of the image. This may not be large enough
 			// if a format conversion happens, but this is just best effort.
 			if disk.Source.Image != "" {
-				info, err := os.Stat(disk.Source.Image)
+				size, err := s.ImageHandler().GetImageSize(disk.Source.Image)
 				if err == nil {
-					disk.Size = fmt.Sprintf("%d", info.Size())
+					disk.Size = fmt.Sprintf("%d", size)
 				}
 			}
 

--- a/virt/disks/config_test.go
+++ b/virt/disks/config_test.go
@@ -226,6 +226,9 @@ func TestDisk(t *testing.T) {
 		mockStorage := &mock_storage.StaticStorage{
 			DefaultDiskDriverResult:  testDriver,
 			GenerateDeviceNameResult: testDevname,
+			ImageHandlerResult: &mock_image_tools.StaticImageHandler{
+				GetImageSizeResult: 22,
+			},
 		}
 
 		t.Run("defaults", func(t *testing.T) {
@@ -376,6 +379,9 @@ func TestDisk(t *testing.T) {
 					)
 					s := &mock_storage.StaticStorage{
 						DefaultPoolResult: p,
+						ImageHandlerResult: &mock_image_tools.StaticImageHandler{
+							GetImageSizeResult: 22,
+						},
 					}
 					must.NoError(t, d.Prepare(s))
 					disk := d[0]


### PR DESCRIPTION
When automatically setting the volume size from a configured source image, use the virtual size of the image instead of the size of the image file itself. This adds a new method on the `ImageHandler` interface for providing the correct size of an image file.