### PR TITLE
test: force requirements in ci

### DIFF
--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -5,6 +5,7 @@ package testutil
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -15,6 +16,11 @@ import (
 // RequireRoot will skip the test if not running as root.
 func RequireRoot(t *testing.T) {
 	if syscall.Geteuid() != 0 {
+		if isCI() {
+			t.Fatal("Test requires root in CI")
+			return
+		}
+
 		t.Skip("Test requires root")
 	}
 }
@@ -26,6 +32,17 @@ func RequireIPTables(t *testing.T) {
 
 	_, err := iptables.New()
 	if errors.Is(err, exec.ErrNotFound) {
+		if isCI() {
+			t.Fatal("Test requires iptables in CI")
+			return
+		}
+
 		t.Skip("Test requires iptables")
 	}
+}
+
+// isCI checks if the process is currently running in
+// CI by checking for a `CI` environment variable.
+func isCI() bool {
+	return os.Getenv("CI") != ""
 }


### PR DESCRIPTION
Check if running within CI and force errors if test requirements are not met in CI while skipping them if not in CI.

Based on https://github.com/hashicorp/nomad-driver-virt/pull/195#discussion_r3133022181