### PR TITLE
Implement macvtap interface configuration

### DIFF
--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -658,7 +658,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 	// invisible to Nomad's port mapping machinery. Only bridge interfaces
 	// participate in host-side port allocation, so we filter the config down
 	// to those before handing it to the networking layer.
-	bridgeOnlyConfig := driverConfig.NetworkInterfacesConfig.BridgeOnly()
+	bridgeOnlyConfig := driverConfig.NetworkInterfacesConfig.ConfigurableOnly()
 
 	// Build our network request to send now that the VM has been started. The
 	// response will contain our teardown spec, which gets stored in the task

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -654,13 +654,19 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 		hwaddrs[i] = iface.MAC
 	}
 
+	// Macvtap interfaces own their own IP on the physical network and are
+	// invisible to Nomad's port mapping machinery. Only bridge interfaces
+	// participate in host-side port allocation, so we filter the config down
+	// to those before handing it to the networking layer.
+	bridgeOnlyConfig := driverConfig.NetworkInterfacesConfig.BridgeOnly()
+
 	// Build our network request to send now that the VM has been started. The
 	// response will contain our teardown spec, which gets stored in the task
 	// handle, so we can easily perform deletions.
 	netBuildReq := net.VMStartedBuildRequest{
 		VMName:    taskName,
 		Hostname:  hostname,
-		NetConfig: driverConfig.NetworkInterfacesConfig,
+		NetConfig: bridgeOnlyConfig,
 		Resources: cfg.Resources,
 		Hwaddrs:   hwaddrs,
 	}

--- a/providers/libvirt/domain_config.go
+++ b/providers/libvirt/domain_config.go
@@ -96,6 +96,18 @@ func (p *provider) parseConfiguration(config *vm.Config) (string, error) {
 						Type: defaultInterfaceModel,
 					},
 				})
+			} else if networkInterface.Macvtap != nil {
+				interfaces = append(interfaces, libvirtxml.DomainInterface{
+					Source: &libvirtxml.DomainInterfaceSource{
+						Direct: &libvirtxml.DomainInterfaceSourceDirect{
+							Dev:  networkInterface.Macvtap.Device,
+							Mode: string(networkInterface.Macvtap.Mode),
+						},
+					},
+					Model: &libvirtxml.DomainInterfaceModel{
+						Type: defaultInterfaceModel,
+					},
+				})
 			}
 		}
 	}

--- a/virt/net/config.go
+++ b/virt/net/config.go
@@ -12,6 +12,38 @@ import (
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
 
+// MacvtapMode represents the operating mode of a macvtap interface.
+type MacvtapMode string
+
+const (
+	// MacvtapModeBridge allows the VM to communicate with other VMs on the
+	// same host and with the external network, but not with the host itself.
+	MacvtapModeBridge MacvtapMode = "bridge"
+
+	// MacvtapModePrivate isolates the VM so it can only communicate with the
+	// external network. Communication with the host and other VMs on the same
+	// lower device is blocked.
+	MacvtapModePrivate MacvtapMode = "private"
+
+	// MacvtapModeVEPA (Virtual Ethernet Port Aggregator) forwards all traffic
+	// to an external switch that is responsible for hairpin routing between
+	// VMs on the same host.
+	MacvtapModeVEPA MacvtapMode = "vepa"
+
+	// MacvtapModePassthrough passes a single lower device exclusively to the
+	// VM, giving it direct access to the physical interface. The lower device
+	// is set into promiscuous mode.
+	MacvtapModePassthrough MacvtapMode = "passthrough"
+)
+
+// validMacvtapModes is the set of accepted MacvtapMode values.
+var validMacvtapModes = []MacvtapMode{
+	MacvtapModeBridge,
+	MacvtapModePrivate,
+	MacvtapModeVEPA,
+	MacvtapModePassthrough,
+}
+
 // NetworkInterfacesConfig is the list of network interfaces that should be
 // added to a VM. Currently, the driver only supports a single entry which is
 // validated within the Validate function.
@@ -38,7 +70,8 @@ func (n NetworkInterfacesConfig) Equal(rhs NetworkInterfacesConfig) bool {
 // NetworkInterfaceConfig contains all the possible network interface options
 // that a VM currently supports via the Nomad driver.
 type NetworkInterfaceConfig struct {
-	Bridge *NetworkInterfaceBridgeConfig `codec:"bridge"`
+	Bridge  *NetworkInterfaceBridgeConfig  `codec:"bridge"`
+	Macvtap *NetworkInterfaceMacvtapConfig `codec:"macvtap"`
 }
 
 // Equal returns if the given NetworkInterfaceConfig is equal.
@@ -48,6 +81,10 @@ func (n *NetworkInterfaceConfig) Equal(rhs *NetworkInterfaceConfig) bool {
 	}
 
 	if !n.Bridge.Equal(rhs.Bridge) {
+		return false
+	}
+
+	if !n.Macvtap.Equal(rhs.Macvtap) {
 		return false
 	}
 
@@ -89,6 +126,42 @@ func (n *NetworkInterfaceBridgeConfig) Equal(rhs *NetworkInterfaceBridgeConfig) 
 	return true
 }
 
+// NetworkInterfaceMacvtapConfig is the network object when a VM is attached to
+// a macvtap interface.
+type NetworkInterfaceMacvtapConfig struct {
+
+	// Device is the name of the lower (physical or virtual) network device
+	// that the macvtap interface will be created on top of. This should match
+	// an interface visible in "ip addr show" output (e.g. "eth0", "ens3").
+	Device string `codec:"device"`
+
+	// Mode controls the traffic isolation policy of the macvtap interface.
+	// Accepted values are: "bridge", "private", "vepa", and "passthrough".
+	// Defaults to "bridge" when not specified.
+	Mode MacvtapMode `codec:"mode"`
+}
+
+// Equal returns if the given NetworkInterfaceMacvtapConfig is equal.
+func (n *NetworkInterfaceMacvtapConfig) Equal(rhs *NetworkInterfaceMacvtapConfig) bool {
+	if n == nil && rhs == nil {
+		return true
+	}
+
+	if n == nil || rhs == nil {
+		return false
+	}
+
+	if n.Device != rhs.Device {
+		return false
+	}
+
+	if n.Mode != rhs.Mode {
+		return false
+	}
+
+	return true
+}
+
 // Validate ensures the NetworkInterfaces is a valid object supported by the
 // driver. Any error returned here should be considered terminal for a task
 // and stop the process execution.
@@ -111,9 +184,33 @@ func (n *NetworkInterfacesConfig) Validate() error {
 	// Iterate the network interfaces and validate each object to be correct
 	// according to their type.
 	for i, netInterface := range *n {
+		if netInterface.Bridge != nil && netInterface.Macvtap != nil {
+			mErr.Errors = append(mErr.Errors,
+				fmt.Errorf("network interface '%v' cannot configure both bridge and macvtap", i))
+			continue
+		}
+
 		if netInterface.Bridge != nil && netInterface.Bridge.Name == "" {
 			mErr.Errors = append(mErr.Errors,
 				fmt.Errorf("network interface bridge '%v' requires name parameter", i))
+		}
+
+		if netInterface.Macvtap != nil {
+			if netInterface.Macvtap.Device == "" {
+				mErr.Errors = append(mErr.Errors,
+					fmt.Errorf("network interface macvtap '%v' requires device parameter", i))
+			}
+
+			// Default the mode to bridge when unset, matching common macvtap
+			// usage and libvirt's own default behaviour.
+			if netInterface.Macvtap.Mode == "" {
+				netInterface.Macvtap.Mode = MacvtapModeBridge
+			}
+
+			if !slices.Contains(validMacvtapModes, netInterface.Macvtap.Mode) {
+				mErr.Errors = append(mErr.Errors,
+					fmt.Errorf("network interface macvtap '%v' has invalid mode %q; must be one of: bridge, private, vepa, passthrough", i, netInterface.Macvtap.Mode))
+			}
 		}
 	}
 
@@ -128,5 +225,23 @@ func NetworkInterfaceHCLSpec() *hclspec.Spec {
 			"name":  hclspec.NewAttr("name", "string", true),
 			"ports": hclspec.NewAttr("ports", "list(string)", false),
 		})),
+		"macvtap": hclspec.NewBlock("macvtap", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"device": hclspec.NewAttr("device", "string", true),
+			"mode":   hclspec.NewAttr("mode", "string", false),
+		})),
 	}))
+}
+
+// BridgeOnly returns a new NetworkInterfacesConfig containing only bridge
+// interfaces. This is used to filter out interface types — such as macvtap —
+// that manage their own network identity and have no interaction with Nomad's
+// host-side port mapping machinery.
+func (n NetworkInterfacesConfig) BridgeOnly() NetworkInterfacesConfig {
+	var out NetworkInterfacesConfig
+	for _, iface := range n {
+		if iface.Bridge != nil {
+			out = append(out, iface)
+		}
+	}
+	return out
 }

--- a/virt/net/config.go
+++ b/virt/net/config.go
@@ -227,16 +227,19 @@ func NetworkInterfaceHCLSpec() *hclspec.Spec {
 		})),
 		"macvtap": hclspec.NewBlock("macvtap", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"device": hclspec.NewAttr("device", "string", true),
-			"mode":   hclspec.NewAttr("mode", "string", false),
+			"mode": hclspec.NewDefault(
+				hclspec.NewAttr("mode", "string", false),
+				hclspec.NewLiteral(fmt.Sprintf("%q", MacvtapModeBridge)),
+			),
 		})),
 	}))
 }
 
-// BridgeOnly returns a new NetworkInterfacesConfig containing only bridge
-// interfaces. This is used to filter out interface types — such as macvtap —
-// that manage their own network identity and have no interaction with Nomad's
-// host-side port mapping machinery.
-func (n NetworkInterfacesConfig) BridgeOnly() NetworkInterfacesConfig {
+// ConfigurableOnly returns a new NetworkInterfacesConfig containing only configurable
+// interfaces. This is used to filter out interface types such as macvtap that manage
+// their own network identity and have no interaction with Nomad's host-side port
+// mapping machinery.
+func (n NetworkInterfacesConfig) ConfigurableOnly() NetworkInterfacesConfig {
 	var out NetworkInterfacesConfig
 	for _, iface := range n {
 		if iface.Bridge != nil {


### PR DESCRIPTION
This pull request implements the macvtap interface configuration. As a macvtap interface typically has it's own IP, it is not really compatible with nomad ports definitions, as such they're omitted for this mode. CNI with a dummy interface could be used instead.

I'm leaving this as a draft to gather feedback until I've tested it a bit.