### PR TITLE
storage: move constants into storage package

### DIFF
--- a/providers/libvirt/storage/ceph.go
+++ b/providers/libvirt/storage/ceph.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// default format used for ceph based volumes
-	defaultCephImageFormat = disks.DiskFormatRaw
+	defaultCephImageFormat = storage.DiskFormatRaw
 )
 
 // cephPlugin holds the plugin for direct volume uploads.
@@ -165,7 +165,7 @@ func (c *ceph) ValidateDisk(disk *disks.Disk) error {
 	var mErr *multierror.Error
 
 	// Only raw format is supported for ceph volumes
-	if disk.Format != disks.DiskFormatRaw {
+	if disk.Format != storage.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
 			fmt.Errorf("%w: format can only be raw for ceph volumes", errs.ErrInvalidConfiguration))
 	}

--- a/providers/libvirt/storage/ceph_test.go
+++ b/providers/libvirt/storage/ceph_test.go
@@ -38,12 +38,12 @@ func TestCeph_ValidateDisk(t *testing.T) {
 
 	t.Run("format support", func(t *testing.T) {
 		t.Run("raw", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatRaw}
+			disk := &disks.Disk{Format: storage.DiskFormatRaw}
 			must.NoError(t, pool.ValidateDisk(disk))
 		})
 
 		t.Run("qcow2", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatQcow2}
+			disk := &disks.Disk{Format: storage.DiskFormatQcow2}
 			err := pool.ValidateDisk(disk)
 			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format can only be raw")
@@ -52,12 +52,12 @@ func TestCeph_ValidateDisk(t *testing.T) {
 
 	t.Run("sparse support", func(t *testing.T) {
 		t.Run("enabled", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatRaw, Sparse: pointer.Of(true)}
+			disk := &disks.Disk{Format: storage.DiskFormatRaw, Sparse: pointer.Of(true)}
 			must.NoError(t, pool.ValidateDisk(disk))
 		})
 
 		t.Run("disabled", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatRaw, Sparse: pointer.Of(false)}
+			disk := &disks.Disk{Format: storage.DiskFormatRaw, Sparse: pointer.Of(false)}
 			err := pool.ValidateDisk(disk)
 			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "sparse cannot be disabled")

--- a/providers/libvirt/storage/directory.go
+++ b/providers/libvirt/storage/directory.go
@@ -18,7 +18,7 @@ import (
 	"libvirt.org/go/libvirtxml"
 )
 
-const defaultDirectoryImageFormat = disks.DiskFormatQcow2
+const defaultDirectoryImageFormat = storage.DiskFormatQcow2
 
 // directory provides a local directory based implementation
 // of a storage pool.
@@ -69,18 +69,18 @@ func (d *directory) ValidateDisk(disk *disks.Disk) error {
 
 	// If the format of the disk is qcow2 and the sparse attribute has not
 	// been set to any value, set it as true.
-	if disk.Sparse == nil && disk.Format == disks.DiskFormatQcow2 {
+	if disk.Sparse == nil && disk.Format == storage.DiskFormatQcow2 {
 		disk.Sparse = pointer.Of(true)
 	}
 
 	// Directory pool currently supports qcow2 and raw volumes
-	if disk.Format != disks.DiskFormatQcow2 && disk.Format != disks.DiskFormatRaw {
+	if disk.Format != storage.DiskFormatQcow2 && disk.Format != storage.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
 			fmt.Errorf("%w: format only supports raw or qcow2 for directory volumes", errs.ErrInvalidConfiguration))
 	}
 
 	// Disk chaining is only supported with qcow2 images.
-	if disk.Format != disks.DiskFormatQcow2 && disk.Chained {
+	if disk.Format != storage.DiskFormatQcow2 && disk.Chained {
 		mErr = multierror.Append(mErr,
 			fmt.Errorf("%w: format must be qcow2 for chained directory volumes", errs.ErrInvalidConfiguration))
 	}

--- a/providers/libvirt/storage/directory_test.go
+++ b/providers/libvirt/storage/directory_test.go
@@ -36,12 +36,12 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 
 	t.Run("format support", func(t *testing.T) {
 		t.Run("qcow2", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatQcow2}
+			disk := &disks.Disk{Format: storage.DiskFormatQcow2}
 			must.NoError(t, pool.ValidateDisk(disk))
 		})
 
 		t.Run("raw", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatRaw}
+			disk := &disks.Disk{Format: storage.DiskFormatRaw}
 			must.NoError(t, pool.ValidateDisk(disk))
 		})
 
@@ -55,12 +55,12 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 
 	t.Run("chained support", func(t *testing.T) {
 		t.Run("qcow2 format", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatQcow2, Chained: true}
+			disk := &disks.Disk{Format: storage.DiskFormatQcow2, Chained: true}
 			must.NoError(t, pool.ValidateDisk(disk))
 		})
 
 		t.Run("raw format", func(t *testing.T) {
-			disk := &disks.Disk{Format: disks.DiskFormatRaw, Chained: true}
+			disk := &disks.Disk{Format: storage.DiskFormatRaw, Chained: true}
 			err := pool.ValidateDisk(disk)
 			must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
 			must.ErrorContains(t, err, "format must be qcow2")
@@ -70,7 +70,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 	t.Run("sparse modification", func(t *testing.T) {
 		t.Run("value is unset", func(t *testing.T) {
 			t.Run("enabled if format is qcow2", func(t *testing.T) {
-				disk := &disks.Disk{Format: disks.DiskFormatQcow2}
+				disk := &disks.Disk{Format: storage.DiskFormatQcow2}
 				err := pool.ValidateDisk(disk)
 				must.NoError(t, err)
 				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))
@@ -78,7 +78,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 			})
 
 			t.Run("unset if format is not qcow2", func(t *testing.T) {
-				disk := &disks.Disk{Format: disks.DiskFormatRaw}
+				disk := &disks.Disk{Format: storage.DiskFormatRaw}
 				err := pool.ValidateDisk(disk)
 				must.NoError(t, err)
 				must.Nil(t, disk.Sparse, must.Sprint("expected sparse to be unset"))
@@ -87,7 +87,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 
 		t.Run("value is set", func(t *testing.T) {
 			t.Run("unchanged when format is qcow2", func(t *testing.T) {
-				disk := &disks.Disk{Format: disks.DiskFormatQcow2, Sparse: pointer.Of(false)}
+				disk := &disks.Disk{Format: storage.DiskFormatQcow2, Sparse: pointer.Of(false)}
 				err := pool.ValidateDisk(disk)
 				must.NoError(t, err)
 				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))
@@ -95,7 +95,7 @@ func TestDirectory_ValidateDisk(t *testing.T) {
 			})
 
 			t.Run("unchanged when format is not qcow2", func(t *testing.T) {
-				disk := &disks.Disk{Format: disks.DiskFormatRaw, Sparse: pointer.Of(false)}
+				disk := &disks.Disk{Format: storage.DiskFormatRaw, Sparse: pointer.Of(false)}
 				err := pool.ValidateDisk(disk)
 				must.NoError(t, err)
 				must.NotNil(t, disk.Sparse, must.Sprint("expected sparse to be set"))

--- a/providers/libvirt/storage/storage.go
+++ b/providers/libvirt/storage/storage.go
@@ -229,8 +229,8 @@ func (s *Storage) VolumeToDisk(vol storage.Volume) (*libvirtxml.DomainDisk, erro
 	// Sometimes after uploading an image into a volume, libvirt will overwrite
 	// the volume type from raw to iso. Check for that when setting the format.
 	diskFmt := vol.Format
-	if diskFmt == "iso" {
-		diskFmt = "raw"
+	if diskFmt == storage.DiskFormatIso {
+		diskFmt = storage.DiskFormatRaw
 	}
 
 	disk := &libvirtxml.DomainDisk{

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -11,6 +11,19 @@ import (
 const (
 	PoolTypeDirectory = "directory"
 	PoolTypeCeph      = "ceph"
+
+	BusTypeVirtio = "virtio"
+	BusTypeIde    = "ide"
+	BusTypeScsi   = "scsi"
+	BusTypeSata   = "sata"
+
+	DiskFormatIso   = "iso"
+	DiskFormatQcow2 = "qcow2"
+	DiskFormatRaw   = "raw"
+
+	DiskKindDisk  = "disk"
+	DiskKindLun   = "lun"
+	DiskKindCdrom = "cdrom"
 )
 
 // Storage defines the required interface for support storage

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -50,20 +50,8 @@ var (
 )
 
 const (
-	BusTypeVirtio = "virtio"
-	BusTypeIde    = "ide"
-	BusTypeScsi   = "scsi"
-	BusTypeSata   = "sata"
-
-	DiskFormatRaw   = "raw"
-	DiskFormatQcow2 = "qcow2"
-
-	DiskKindDisk  = "disk"
-	DiskKindLun   = "lun"
-	DiskKindCdrom = "cdrom"
-
-	BusTypeDefault  = "virtio"
-	DiskKindDefault = "disk"
+	BusTypeDefault  = storage.BusTypeVirtio
+	DiskKindDefault = storage.DiskKindDisk
 
 	identifierPrefix = "nmdsrc"
 )
@@ -160,7 +148,7 @@ func (d *Disk) ValidateNomadVolume() error {
 
 	var mErr *multierror.Error
 
-	if d.Format != "" && d.Format != DiskFormatRaw {
+	if d.Format != "" && d.Format != storage.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
 			fmt.Errorf("%w - format cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
@@ -223,8 +211,8 @@ func (d Disks) ApplyCloudInit(isoPath string) Disks {
 	}
 
 	newDisk := &Disk{
-		BusType: BusTypeIde,
-		Kind:    DiskKindCdrom,
+		BusType: storage.BusTypeIde,
+		Kind:    storage.DiskKindCdrom,
 		Format:  "raw",
 		Source: &Source{
 			Format: "raw",
@@ -243,7 +231,7 @@ func (d Disks) CompatAddImage(image string, size int64, thinCopy bool) Disks {
 	}
 
 	newDisk := &Disk{
-		BusType: BusTypeVirtio,
+		BusType: storage.BusTypeVirtio,
 		Primary: true,
 		Source: &Source{
 			Image: image,
@@ -255,7 +243,7 @@ func (d Disks) CompatAddImage(image string, size int64, thinCopy bool) Disks {
 	// For proper compatibility, set the format to qcow2
 	// if making a thin copy.
 	if thinCopy {
-		newDisk.Format = DiskFormatQcow2
+		newDisk.Format = storage.DiskFormatQcow2
 	}
 
 	return append(d, newDisk)
@@ -323,7 +311,7 @@ func (d Disks) ApplyMounts(mounts []*drivers.MountConfig) error {
 
 		disk.blockDevicePath = m.HostPath
 		disk.ReadOnly = m.Readonly
-		disk.Format = DiskFormatRaw // block device will always be raw
+		disk.Format = storage.DiskFormatRaw // block device will always be raw
 
 		// If a device name is set directly on the disk, then it is the value
 		// used. Otherwise extract the device name from the task path.
@@ -359,8 +347,8 @@ func (d Disks) Prepare(s storage.Storage) error {
 		// If the kind of disk is a cdrom, set the bus to IDE, otherwise.
 		// just default to virtio.
 		if disk.BusType == "" {
-			if disk.Kind == DiskKindCdrom {
-				disk.BusType = BusTypeIde
+			if disk.Kind == storage.DiskKindCdrom {
+				disk.BusType = storage.BusTypeIde
 			} else {
 				disk.BusType = BusTypeDefault
 			}
@@ -384,7 +372,7 @@ func (d Disks) Prepare(s storage.Storage) error {
 			primaryFound = true
 		}
 
-		if disk.Kind != DiskKindCdrom {
+		if disk.Kind != storage.DiskKindCdrom {
 			validPrimaryDisks = append(validPrimaryDisks, disk)
 		}
 

--- a/virt/disks/config_test.go
+++ b/virt/disks/config_test.go
@@ -245,13 +245,13 @@ func TestDisk(t *testing.T) {
 		})
 
 		t.Run("defaults cdrom", func(t *testing.T) {
-			d := Disks{{Kind: DiskKindCdrom}}
+			d := Disks{{Kind: storage.DiskKindCdrom}}
 			must.NoError(t, d.Prepare(mockStorage))
 			disk := d[0]
 
-			must.Eq(t, DiskKindCdrom, disk.Kind)
+			must.Eq(t, storage.DiskKindCdrom, disk.Kind)
 			must.Eq(t, testDriver, disk.Driver)
-			must.Eq(t, BusTypeIde, disk.BusType)
+			must.Eq(t, storage.BusTypeIde, disk.BusType)
 			must.Eq(t, testDevname, disk.Devname)
 			must.Eq(t, "testing-image-format", disk.Format)
 			must.False(t, disk.Primary) // Single disk cdrom are not automatically set to primary
@@ -437,8 +437,8 @@ func TestDisk(t *testing.T) {
 
 	t.Run("Generate", func(t *testing.T) {
 		t.Run("creates volume", func(t *testing.T) {
-			d := Disks{{Kind: DiskKindDisk, Driver: "test-driver", Format: DiskFormatRaw,
-				Devname: "test-device", BusType: BusTypeSata, Size: "20MB", Source: &Source{Image: "image-path"}}}
+			d := Disks{{Kind: storage.DiskKindDisk, Driver: "test-driver", Format: storage.DiskFormatRaw,
+				Devname: "test-device", BusType: storage.BusTypeSata, Size: "20MB", Source: &Source{Image: "image-path"}}}
 
 			pool := mock_storage.NewMockPool(t)
 			pool.ExpectAddVolume(mock_storage.AddVolume{
@@ -447,7 +447,7 @@ func TestDisk(t *testing.T) {
 					Chained: false,
 					Size:    20000000,
 					Target: storage.Target{
-						Format: DiskFormatRaw,
+						Format: storage.DiskFormatRaw,
 					},
 					Source: storage.Source{
 						Path: "image-path",
@@ -465,11 +465,11 @@ func TestDisk(t *testing.T) {
 			expectedVolume := &storage.Volume{
 				Pool:       "test-pool",
 				Name:       "test-volume",
-				Kind:       DiskKindDisk,
+				Kind:       storage.DiskKindDisk,
 				Driver:     "test-driver",
-				Format:     DiskFormatRaw,
+				Format:     storage.DiskFormatRaw,
 				DeviceName: "test-device",
-				BusType:    BusTypeSata,
+				BusType:    storage.BusTypeSata,
 				Primary:    false,
 			}
 
@@ -486,8 +486,8 @@ func TestDisk(t *testing.T) {
 			srcPath := src.Name()
 
 			t.Run("does not create block volumes", func(t *testing.T) {
-				d := Disks{{Kind: DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: DiskFormatRaw,
-					Devname: "test-device", BusType: BusTypeSata, blockDevicePath: "/dev/null"}}
+				d := Disks{{Kind: storage.DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: storage.DiskFormatRaw,
+					Devname: "test-device", BusType: storage.BusTypeSata, blockDevicePath: "/dev/null"}}
 
 				pool := mock_storage.NewStaticPool()
 				store := &mock_storage.StaticStorage{
@@ -500,11 +500,11 @@ func TestDisk(t *testing.T) {
 				expectedVolume := &storage.Volume{
 					Block:      "/dev/null",
 					Name:       "task_test-device.img",
-					Kind:       DiskKindDisk,
+					Kind:       storage.DiskKindDisk,
 					Driver:     "test-driver",
-					Format:     DiskFormatRaw,
+					Format:     storage.DiskFormatRaw,
 					DeviceName: "test-device",
-					BusType:    BusTypeSata,
+					BusType:    storage.BusTypeSata,
 					Primary:    false,
 				}
 
@@ -513,8 +513,8 @@ func TestDisk(t *testing.T) {
 			})
 
 			t.Run("errors if no block device path is set", func(t *testing.T) {
-				d := Disks{{Kind: DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: DiskFormatRaw,
-					Devname: "test-device", BusType: BusTypeSata}}
+				d := Disks{{Kind: storage.DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: storage.DiskFormatRaw,
+					Devname: "test-device", BusType: storage.BusTypeSata}}
 
 				pool := mock_storage.NewStaticPool()
 				store := &mock_storage.StaticStorage{
@@ -530,9 +530,9 @@ func TestDisk(t *testing.T) {
 				must.NoError(t, err)
 				device.Close()
 
-				d := Disks{{Kind: DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: DiskFormatRaw,
-					Devname: "test-device", BusType: BusTypeSata, blockDevicePath: device.Name(), Source: &Source{Image: srcPath,
-						Format: DiskFormatRaw}}}
+				d := Disks{{Kind: storage.DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: storage.DiskFormatRaw,
+					Devname: "test-device", BusType: storage.BusTypeSata, blockDevicePath: device.Name(), Source: &Source{Image: srcPath,
+						Format: storage.DiskFormatRaw}}}
 				pool := mock_storage.NewStaticPool()
 				store := &mock_storage.StaticStorage{
 					DefaultPoolResult: pool,
@@ -558,8 +558,8 @@ func TestDisk(t *testing.T) {
 				_, err = src.WriteString(srcContent)
 				must.NoError(t, err)
 
-				d := Disks{{Kind: DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: DiskFormatRaw,
-					Devname: "test-device", BusType: BusTypeSata, blockDevicePath: device.Name(), Source: &Source{Image: srcPath}}}
+				d := Disks{{Kind: storage.DiskKindDisk, Driver: "test-driver", VolumeName: "nomad-volume", Format: storage.DiskFormatRaw,
+					Devname: "test-device", BusType: storage.BusTypeSata, blockDevicePath: device.Name(), Source: &Source{Image: srcPath}}}
 				pool := mock_storage.NewStaticPool()
 				imageHandler := mock_image_tools.NewStaticImageHandler()
 				store := &mock_storage.StaticStorage{


### PR DESCRIPTION
Relocate storage related constants from the disks configuration package into the storage package and update the references.