### PR TITLE
testing: add helper to check for qemu-img

### DIFF
--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/nomad-driver-virt/providers"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/storage"
+	"github.com/hashicorp/nomad-driver-virt/testutil"
 	mock_cloudinit "github.com/hashicorp/nomad-driver-virt/testutil/mock/cloudinit"
 	mock_providers "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers"
 	mock_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/storage"
@@ -867,6 +868,7 @@ func TestVirtDriver(t *testing.T) {
 
 func TestVirtDriver_Libvirt(t *testing.T) {
 	ci.Parallel(t)
+	testutil.RequireQemuImg(t)
 
 	dir := t.TempDir()
 	virtcfg := testVirtTaskConfig(t, filepath.Join(dir, "images"))

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -13,7 +13,8 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 )
 
-// RequireRoot will skip the test if not running as root.
+// RequireRoot will skip the test if not running as root. If the
+// test is detected as running within CI it will error.
 func RequireRoot(t *testing.T) {
 	if syscall.Geteuid() != 0 {
 		if isCI() {
@@ -26,7 +27,8 @@ func RequireRoot(t *testing.T) {
 }
 
 // RequireIPTables will skip the test if not running as
-// root or if iptables is not available.
+// root or if iptables is not available. If the test is
+// detected as running within CI it will error.
 func RequireIPTables(t *testing.T) {
 	RequireRoot(t)
 
@@ -38,6 +40,15 @@ func RequireIPTables(t *testing.T) {
 		}
 
 		t.Skip("Test requires iptables")
+	}
+}
+
+// RequireQemuImg will check if the qemu-img executable is
+// available and error if it is not found.
+func RequireQemuImg(t *testing.T) {
+	_, err := exec.LookPath("qemu-img")
+	if err != nil {
+		t.Fatalf("Test requires qemu-img executable (%s)", err)
 	}
 }
 


### PR DESCRIPTION
Add and use helper to verify the `qemu-img` executable is available when running tests.