### PR TITLE
storage: handle libvirt async jobs error

### DIFF
--- a/providers/libvirt/storage/common.go
+++ b/providers/libvirt/storage/common.go
@@ -4,9 +4,10 @@
 package storage
 
 import (
+	"context"
 	"errors"
-	"io"
-	"os"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/storage"
@@ -84,74 +85,6 @@ func getVolumeFormat(vol shims.StorageVol) (string, error) {
 	return "", nil // return empty value, allow auto detection if available
 }
 
-// uploadToVolume uploads a file to a volume.
-// TODO: add specialization to support sparse files on upload
-func uploadToVolume(l libvirtStorage, src string, vol shims.StorageVol, opts *storage.Options) error {
-	// Open the source file for uploading
-	file, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	// Get the info for the source file to get the size
-	info, err := file.Stat()
-	if err != nil {
-		return err
-	}
-
-	// If the source file is empty, there is nothing to upload. This
-	// really only happens in tests where uploads are not supported.
-	if info.Size() == 0 {
-		return nil
-	}
-
-	// Create a new stream for uploading the data
-	stream, err := l.NewStream()
-	if err != nil {
-		return err
-	}
-
-	// Abort the stream if an error was encountered
-	// and ensure the stream is freed.
-	defer func() {
-		if err != nil {
-			stream.Abort()
-		}
-		stream.Free()
-	}()
-
-	// Connect the stream to the volume for upload
-	if err = vol.Upload(stream, 0, uint64(info.Size()), libvirtNoFlags); err != nil {
-		return err
-	}
-
-	// Copy the file contents onto the stream
-	if _, err = io.Copy(stream, file); err != nil {
-		return err
-	}
-
-	// Finish the stream so the other side knows the upload is complete
-	if err = stream.Finish(); err != nil {
-		return err
-	}
-
-	// After the upload the capacity will clamp to the size of the image,
-	// so if options were passed and a size is set, resize the volume.
-	if opts != nil && opts.Size > 0 && opts.Size > uint64(info.Size()) {
-		var flag libvirt.StorageVolResizeFlags
-		if !opts.Sparse {
-			flag = libvirt.STORAGE_VOL_RESIZE_ALLOCATE // ensure size is fully allocated if not sparse
-		}
-
-		if err := vol.Resize(opts.Size, flag); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // getPoolInfo returns the pool description information.
 func getPoolInfo(pool shims.StoragePool) (*libvirtxml.StoragePool, error) {
 	poolXml, err := pool.GetXMLDesc(libvirtNoFlags)
@@ -166,6 +99,7 @@ func getPoolInfo(pool shims.StoragePool) (*libvirtxml.StoragePool, error) {
 	return poolInfo, nil
 }
 
+// getVolumeInfo returns the volume description information.
 func getVolumeInfo(vol shims.StorageVol) (*libvirtxml.StorageVolume, error) {
 	volXml, err := vol.GetXMLDesc(libvirtNoFlags)
 	if err != nil {
@@ -177,4 +111,47 @@ func getVolumeInfo(vol shims.StorageVol) (*libvirtxml.StorageVolume, error) {
 	}
 
 	return volInfo, nil
+}
+
+// refreshPool is a helper for refreshing the pool that handles errors
+// caused by running async jobs by polling for a successful result.
+// NOTE: libvirt issue related to this: https://gitlab.com/libvirt/libvirt/-/work_items/454
+func refreshPool(ctx context.Context, pool shims.StoragePool, retryInterval, retryTimeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, retryTimeout)
+	defer cancel()
+	retryAfter := time.Duration(0)
+
+	for {
+		select {
+		case <-time.After(retryAfter):
+			err := pool.Refresh(libvirtNoFlags)
+			if err == nil {
+				return nil
+			}
+			if !isAsyncJobErr(err) {
+				return err
+			}
+			retryAfter = retryInterval
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// asyncJobErrMsg is content found within an async job error from libvirt.
+const asyncJobErrMsg = "asynchronous jobs running"
+
+var (
+	// asyncJobErrRetryDefaultInterval is the polling interval used for retries.
+	asyncJobErrRetryDefaultInterval = time.Second
+
+	// asyncJobErrRetryDefaultTimeout is the maximum amount of time to attempt retries.
+	asyncJobErrRetryDefaultTimeout = 30 * time.Second
+)
+
+// isAsyncJobErr is a helper function to determine if an error is an async job
+// error from libvirt.
+func isAsyncJobErr(err error) bool {
+	return errors.Is(err, libvirt.ERR_INTERNAL_ERROR) &&
+		strings.Contains(err.Error(), asyncJobErrMsg)
 }

--- a/providers/libvirt/storage/common_test.go
+++ b/providers/libvirt/storage/common_test.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	mock_libvirt_storage "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt/storage"
+	"github.com/shoenig/test/must"
+	"libvirt.org/go/libvirt"
+)
+
+func Test_refreshPool(t *testing.T) {
+	testErr := &libvirt.Error{
+		Code:    libvirt.ErrorNumber(libvirt.ERR_INTERNAL_ERROR),
+		Message: "internal error: pool 'test' has asynchronous jobs running.",
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		pool := mock_libvirt_storage.NewMockStoragePool(t).Expect(
+			mock_libvirt_storage.Refresh{},
+		)
+		defer pool.AssertExpectations()
+
+		must.NoError(t, refreshPool(t.Context(), pool, time.Millisecond, time.Millisecond))
+	})
+
+	t.Run("retries", func(t *testing.T) {
+		pool := mock_libvirt_storage.NewMockStoragePool(t).Expect(
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{},
+		)
+		defer pool.AssertExpectations()
+
+		must.NoError(t, refreshPool(t.Context(), pool, 1*time.Millisecond, 5*time.Millisecond))
+	})
+
+	t.Run("retries timeout", func(t *testing.T) {
+		pool := mock_libvirt_storage.NewMockStoragePool(t).Expect(
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+		)
+		// NOTE: Do not assert pool expectations since we don't care
+		// if all the refreshes are called.
+
+		must.ErrorIs(t, refreshPool(t.Context(), pool, 1*time.Millisecond, 2*time.Millisecond), context.DeadlineExceeded)
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		customErr := errors.New("custom test error")
+
+		pool := mock_libvirt_storage.NewMockStoragePool(t).Expect(
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: customErr},
+		)
+		defer pool.AssertExpectations()
+
+		must.ErrorIs(t, refreshPool(t.Context(), pool, 1*time.Millisecond, 5*time.Millisecond), customErr)
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		pool := mock_libvirt_storage.NewMockStoragePool(t).Expect(
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+			mock_libvirt_storage.Refresh{Err: testErr},
+		)
+		// NOTE: Do not assert pool expectations since we don't care
+		// if all the refreshes are called.
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		timer := time.AfterFunc(2*time.Millisecond, func() { cancel() })
+		defer timer.Stop()
+
+		must.ErrorIs(t, refreshPool(ctx, pool, 1*time.Millisecond, 5*time.Millisecond), context.Canceled)
+	})
+}

--- a/providers/libvirt/storage/directory_test.go
+++ b/providers/libvirt/storage/directory_test.go
@@ -453,6 +453,7 @@ func TestDirectory_DeleteVolume(t *testing.T) {
 	mkDirPool := func() *directory {
 		return &directory{
 			pool: &pool{
+				ctx:    t.Context(),
 				name:   testPoolName,
 				logger: hclog.NewNullLogger(),
 				l:      mock_libvirt.NewStaticLibvirt(),

--- a/providers/libvirt/storage/pool.go
+++ b/providers/libvirt/storage/pool.go
@@ -72,7 +72,7 @@ func (p *pool) AddVolume(name string, opts storage.Options) (*storage.Volume, er
 	defer pool.Free()
 
 	// Always start with refreshing the pool.
-	if err := pool.Refresh(libvirtNoFlags); err != nil {
+	if err := refreshPool(p.ctx, pool, asyncJobErrRetryDefaultInterval, asyncJobErrRetryDefaultTimeout); err != nil {
 		return nil, err
 	}
 
@@ -239,7 +239,7 @@ func (p *pool) DeleteVolume(name string) error {
 	defer pool.Free()
 
 	// Refresh the pool to ensure volume list is up-to-date
-	if err := pool.Refresh(libvirtNoFlags); err != nil {
+	if err := refreshPool(p.ctx, pool, asyncJobErrRetryDefaultInterval, asyncJobErrRetryDefaultTimeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Refreshing a pool when async jobs are running results in an internal error. This typically happens during storage volume creation resulting in errors when multiple attempts at volume creation/deletions are happening simultaneously. Detect these errors and poll for a successful refresh instead.

Recent discussion around this behavior with libvirt (along with a patch that was not used) can be found [here](https://lists.libvirt.org/archives/list/devel@lists.libvirt.org/thread/ONCMFNXZ7URUWSKX4XDKBMRLP6G6QXZI/?sort=date). An open issue around this behavior can be found [here](https://gitlab.com/libvirt/libvirt/-/work_items/454).

Also included in this changeset is the removal of a no longer used helper function.