### PR TITLE
storage: always call resizer when adding a volume

### DIFF
--- a/providers/libvirt/libvirt_test.go
+++ b/providers/libvirt/libvirt_test.go
@@ -124,7 +124,9 @@ func TestStorage(t *testing.T) {
 			must.NoError(t, err)
 
 			// Add an empty volume
-			v, err := pool.AddVolume("test-vol", storage.Options{Size: 1024, Target: storage.Target{Format: "raw"}})
+			// NOTE: Mark volume as sparse to prevent a resize action which will fail
+			// using the test driver as it is an unsupported action.
+			v, err := pool.AddVolume("test-vol", storage.Options{Size: 1024, Target: storage.Target{Format: "raw"}, Sparse: true})
 			must.NoError(t, err)
 			must.Eq(t, &storage.Volume{Name: "test-vol", Pool: poolName, Format: "raw", Kind: "file", Size: 1024}, v)
 

--- a/providers/libvirt/storage/pool.go
+++ b/providers/libvirt/storage/pool.go
@@ -333,7 +333,7 @@ func (p *pool) defaultResizer(vol shims.StorageVol, sizeBytes uint64, sparse boo
 			return nil
 		}
 
-		// If the volume is fully allocated to the define capacity, no resizing
+		// If the volume is fully allocated to the defined capacity, no resizing
 		// is required.
 		if info.Capacity == info.Allocation {
 			return nil

--- a/providers/libvirt/storage/pool.go
+++ b/providers/libvirt/storage/pool.go
@@ -155,7 +155,6 @@ func (p *pool) AddVolume(name string, opts storage.Options) (*storage.Volume, er
 
 	p.logger.Debug("new volume definition defined", "definition", volData)
 
-	var resize bool
 	var vol shims.StorageVol
 	defer func() {
 		if vol != nil {
@@ -171,7 +170,6 @@ func (p *pool) AddVolume(name string, opts storage.Options) (*storage.Volume, er
 		if err != nil {
 			return nil, err
 		}
-		resize = true
 	} else {
 		vol, err = pool.StorageVolCreateXML(volData, libvirtNoFlags)
 		if err != nil {
@@ -188,20 +186,18 @@ func (p *pool) AddVolume(name string, opts storage.Options) (*storage.Volume, er
 			if err := overwriterFn(vol, opts.Source.Path); err != nil {
 				return nil, err
 			}
-			resize = true
 		}
 	}
 
-	// If flagged, resize the volume to the correct size
-	if resize {
-		resizeFn := p.defaultResizer
-		if p.resizer != nil {
-			resizeFn = p.resizer
-		}
+	// Always run a resize after volume creation even if size has
+	// not changed to ensure expected allocation.
+	resizeFn := p.defaultResizer
+	if p.resizer != nil {
+		resizeFn = p.resizer
+	}
 
-		if err := resizeFn(vol, opts.Size, opts.Sparse); err != nil {
-			return nil, err
-		}
+	if err := resizeFn(vol, opts.Size, opts.Sparse); err != nil {
+		return nil, err
 	}
 
 	// Grab the new volume information to fill in the result.
@@ -321,7 +317,8 @@ func (p *pool) defaultResizer(vol shims.StorageVol, sizeBytes uint64, sparse boo
 		return err
 	}
 
-	// If the size hasn't changed, check if the resize is needed.
+	// If the size hasn't changed, check if the resize is needed. The only time it
+	// will be needed is if the volume should be fully allocated to the capacity.
 	if info.Capacity == sizeBytes {
 		// If the volume is sparse there is no need to resize. Resizing when
 		// the size has not changed is only needed to force allocation of the
@@ -333,6 +330,12 @@ func (p *pool) defaultResizer(vol shims.StorageVol, sizeBytes uint64, sparse boo
 		// If the current size of the volume is 0 and the desired size is 0
 		// resizing the volume does nothing even if the volume is not sparse.
 		if sizeBytes == 0 {
+			return nil
+		}
+
+		// If the volume is fully allocated to the define capacity, no resizing
+		// is required.
+		if info.Capacity == info.Allocation {
 			return nil
 		}
 

--- a/providers/libvirt/storage/pool_test.go
+++ b/providers/libvirt/storage/pool_test.go
@@ -137,6 +137,19 @@ func TestPool_AddVolume(t *testing.T) {
 				mock_libvirt_storage.GetXMLDesc{
 					Result: expectedData,
 				},
+				mock_libvirt_storage.GetXMLDesc{
+					Result: expectedData,
+				},
+				mock_libvirt_storage.GetInfo{
+					Result: &libvirt.StorageVolInfo{
+						Capacity:   200,
+						Allocation: 0,
+					},
+				},
+				mock_libvirt_storage.Resize{
+					Size:  200,
+					Flags: libvirt.STORAGE_VOL_RESIZE_ALLOCATE,
+				},
 				mock_libvirt_storage.Free{},
 			)
 			defer lvVol.AssertExpectations()
@@ -192,6 +205,11 @@ func TestPool_AddVolume(t *testing.T) {
 			lvVol := mock_libvirt_storage.NewMockStorageVol(t).Expect(
 				mock_libvirt_storage.GetXMLDesc{
 					Result: expectedData,
+				},
+				mock_libvirt_storage.GetInfo{
+					Result: &libvirt.StorageVolInfo{
+						Capacity: 200,
+					},
 				},
 				mock_libvirt_storage.Free{},
 			)
@@ -505,6 +523,12 @@ func TestPool_AddVolume(t *testing.T) {
 				mock_libvirt_storage.GetXMLDesc{
 					Result: expectedData,
 				},
+				mock_libvirt_storage.GetInfo{
+					Result: &libvirt.StorageVolInfo{
+						Capacity:   200,
+						Allocation: 200,
+					},
+				},
 				mock_libvirt_storage.Free{},
 			)
 			defer lvVol.AssertExpectations()
@@ -595,6 +619,11 @@ func TestPool_AddVolume(t *testing.T) {
 			lvVol := mock_libvirt_storage.NewMockStorageVol(t).Expect(
 				mock_libvirt_storage.GetXMLDesc{
 					Result: expectedData,
+				},
+				mock_libvirt_storage.GetInfo{
+					Result: &libvirt.StorageVolInfo{
+						Capacity: 200,
+					},
 				},
 				mock_libvirt_storage.Free{},
 			)


### PR DESCRIPTION
When adding a volume, always call the resizer function and let it determine if the resize should be performed. When creating a new volume with no content, libvirt will not always allocate the volume even when requested. Resizing will force the full allocation which is the expected behavior when the volume is not sparse.