### PR TITLE
config: clean validation, verify disk size

### DIFF
--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -17,7 +17,7 @@ var (
 	ErrNotSupported         = errors.New("not supported")
 	ErrInvalidConfiguration = errors.New("invalid configuration")
 
-	ErrMissingAttribute = fmt.Errorf("%w - missing required attribute", ErrInvalidConfiguration)
+	ErrMissingAttribute = fmt.Errorf("%w: missing required attribute", ErrInvalidConfiguration)
 )
 
 // options are optional arguments used by helper functions.
@@ -66,8 +66,8 @@ func MissingAttribute(attrName string, value any, opts ...optionFn) error {
 	tmpl := []string{"%w:"}
 	args := []any{ErrMissingAttribute}
 	if o.prefix != "" {
-		tmpl = append(tmpl, "%s")
-		args = append(args, o.prefix)
+		tmpl = append([]string{"%s"}, tmpl...)
+		args = append([]any{o.prefix}, args...)
 	}
 	tmpl = append(tmpl, "%s")
 	args = append(args, attrName)

--- a/internal/errs/errors_test.go
+++ b/internal/errs/errors_test.go
@@ -75,28 +75,28 @@ func TestMissingAttribute(t *testing.T) {
 			desc:       "missing - message",
 			value:      "",
 			attrName:   "test.value",
-			errContent: "invalid configuration - missing required attribute: test.value",
+			errContent: "invalid configuration: missing required attribute: test.value",
 		},
 		{
 			desc:       "missing - prefix",
 			value:      "",
 			attrName:   "test.value",
 			options:    []optionFn{WithPrefix("test-prefix -")},
-			errContent: "invalid configuration - missing required attribute: test-prefix - test.value",
+			errContent: "test-prefix - invalid configuration: missing required attribute: test.value",
 		},
 		{
 			desc:       "missing - suffix",
 			value:      "",
 			attrName:   "test.value",
 			options:    []optionFn{WithSuffix("- test-suffix")},
-			errContent: "invalid configuration - missing required attribute: test.value - test-suffix",
+			errContent: "invalid configuration: missing required attribute: test.value - test-suffix",
 		},
 		{
 			desc:       "missing - prefix and suffix",
 			value:      "",
 			attrName:   "test.value",
 			options:    []optionFn{WithPrefix("test-prefix -"), WithSuffix("- test-suffix")},
-			errContent: "invalid configuration - missing required attribute: test-prefix - test.value - test-suffix",
+			errContent: "test-prefix - invalid configuration: missing required attribute: test.value - test-suffix",
 		},
 	}
 

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -23,10 +23,10 @@ import (
 )
 
 var (
-	ErrDisallowedPath  = fmt.Errorf("%w - access to path is not allowed", errs.ErrInvalidConfiguration)
-	ErrPathNotFound    = fmt.Errorf("%w - path not found", errs.ErrInvalidConfiguration)
-	ErrNoPrimary       = fmt.Errorf("%w - no primary disk defined", errs.ErrInvalidConfiguration)
-	ErrMultiplePrimary = fmt.Errorf("%w - multiple primary disks defined", errs.ErrInvalidConfiguration)
+	ErrDisallowedPath  = fmt.Errorf("%w: access to path is not allowed", errs.ErrInvalidConfiguration)
+	ErrPathNotFound    = fmt.Errorf("%w: path not found", errs.ErrInvalidConfiguration)
+	ErrNoPrimary       = fmt.Errorf("%w: no primary disk defined", errs.ErrInvalidConfiguration)
+	ErrMultiplePrimary = fmt.Errorf("%w: multiple primary disks defined", errs.ErrInvalidConfiguration)
 
 	configSpec = hclspec.NewBlockSet("disk", hclspec.NewObject(map[string]*hclspec.Spec{
 		"pool":      hclspec.NewAttr("pool", "string", false),
@@ -150,34 +150,34 @@ func (d *Disk) ValidateNomadVolume() error {
 
 	if d.Format != "" && d.Format != storage.DiskFormatRaw {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - format cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: format cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Size != "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - size cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: size cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Sparse != nil {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - sparse cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: sparse cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Pool != "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - pool cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: pool cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Chained {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - chained cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: chained cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 	}
 	if d.Source != nil {
 		if d.Source.Volume != "" {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%w - source.volume cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
+				fmt.Errorf("%w: source.volume cannot be set when using Nomad volume", errs.ErrInvalidConfiguration))
 		}
 	}
 
 	if d.blockDevicePath == "" {
 		mErr = multierror.Append(mErr,
-			fmt.Errorf("%w - missing Nomad volume mount configuration", errs.ErrInvalidConfiguration))
+			fmt.Errorf("%w: missing Nomad volume mount configuration", errs.ErrInvalidConfiguration))
 	}
 
 	return mErr.ErrorOrNil()
@@ -535,7 +535,7 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 			}
 			if disk.Source.Volume != "" {
 				mErr = multierror.Append(mErr,
-					fmt.Errorf("%s %w: storage.volume and storage.image are mutually exclusive", errPrefix, errs.ErrInvalidConfiguration))
+					fmt.Errorf("%s %w: source.volume and source.image are mutually exclusive", errPrefix, errs.ErrInvalidConfiguration))
 			}
 
 			mErr = multierror.Append(mErr,
@@ -560,16 +560,17 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 		// If a size for the disk is set, check that the value is a size.
 		if disk.Size != "" && !convert.ValidBytesString(disk.Size) {
 			mErr = multierror.Append(mErr,
-				fmt.Errorf("%s size value is not valid - %q", errPrefix, disk.Size))
+				fmt.Errorf("%s %w: size value is not valid - %q", errPrefix, errs.ErrInvalidConfiguration, disk.Size))
 		}
 
+		// If the disk is chained, validate that a source is provided.
 		if disk.Chained && (disk.Source == nil || (disk.Source.Volume == "" && disk.Source.Image == "")) {
 			mErr = multierror.Append(mErr,
 				fmt.Errorf("%s %w: chained cannot be enabled without a source", errPrefix, errs.ErrInvalidConfiguration))
 		}
 
-		// Load the storage pool for this disk and apply any custom validation if
-		// the pool provides it.
+		// Load the storage pool for this disk. It will be used if the disk source is
+		// a volume as well as applying any custom validation if the pool provides it.
 		var pool storage.Pool
 		var err error
 		if disk.Pool != "" {
@@ -583,6 +584,41 @@ func (d Disks) Validate(s storage.Storage, opts ValidationOptions) error {
 			continue
 		}
 
+		// If a source is defined, check that a source value is provided.
+		if disk.Source != nil {
+			if disk.Source.Volume == "" && disk.Source.Image == "" {
+				mErr = multierror.Append(mErr,
+					fmt.Errorf("%s %w: disk source must define an image or volume", errPrefix, errs.ErrInvalidConfiguration))
+			} else {
+				// Check that the size of the disk is sufficient for the source.
+				var size uint64
+				if disk.Source.Image != "" {
+					info, err := os.Stat(disk.Source.Image)
+					if err != nil {
+						mErr = multierror.Append(mErr,
+							fmt.Errorf("%s %w: unable to read source image to determine size: %w", errPrefix, errs.ErrInvalidConfiguration, err))
+					} else {
+						size = uint64(info.Size())
+					}
+				} else {
+					vol, err := pool.GetVolume(disk.Source.Volume)
+					if err != nil {
+						mErr = multierror.Append(mErr,
+							fmt.Errorf("%s %w: unable to load source volume to determine size: %w", errPrefix, errs.ErrInvalidConfiguration, err))
+					} else {
+						size = vol.Size
+					}
+				}
+
+				// Check the size if it's non-zero
+				if size > 0 && size > convert.MustToBytes(disk.Size) {
+					mErr = multierror.Append(mErr,
+						fmt.Errorf("%s %w: size of disk must be equal to or greater than source", errPrefix, errs.ErrInvalidConfiguration))
+				}
+			}
+		}
+
+		// Apply custom validation if provided by the pool.
 		validator, ok := pool.(DiskValidator)
 		if !ok {
 			continue
@@ -749,9 +785,10 @@ func generateIdentifier(path, format string) (string, error) {
 // fileExists checks if a file exists at the path
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
+
 	return !info.IsDir()
 }
 

--- a/virt/disks/config_test.go
+++ b/virt/disks/config_test.go
@@ -605,6 +605,164 @@ func TestDisk(t *testing.T) {
 			must.Eq(t, expectedVolumes, d.Volumes())
 		})
 	})
+
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("ok - empty disk", func(t *testing.T) {
+			d := Disks{{Format: "raw", Size: "200", Devname: "sda", Kind: storage.DiskKindDisk,
+				BusType: storage.BusTypeVirtio, Primary: true}}
+			err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+			must.NoError(t, err)
+		})
+
+		t.Run("ok - no capacity", func(t *testing.T) {
+			d := Disks{{Format: "raw", Size: "0", Devname: "sda", Kind: storage.DiskKindDisk,
+				BusType: storage.BusTypeVirtio, Primary: true}}
+			err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+			must.NoError(t, err)
+		})
+
+		t.Run("source", func(t *testing.T) {
+			opts := ValidationOptions{AllowedPaths: []string{t.TempDir()}}
+			imagePath := filepath.Join(opts.AllowedPaths[0], "image")
+			imageContent := "test content"
+			img, err := os.Create(imagePath)
+			must.NoError(t, err)
+			_, err = img.WriteString(imageContent)
+			must.NoError(t, err)
+			must.NoError(t, img.Close())
+
+			volumeName := "test-volume"
+
+			t.Run("image", func(t *testing.T) {
+				t.Run("ok", func(t *testing.T) {
+					d := Disks{{Format: "raw", Size: "100", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Image: imagePath, Format: "raw"}}}
+					must.NoError(t, d.Validate(mock_storage.NewStaticStorage(), opts))
+				})
+
+				t.Run("missing format", func(t *testing.T) {
+					d := Disks{{Format: "raw", Size: "100", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Image: imagePath}}}
+					err := d.Validate(mock_storage.NewStaticStorage(), opts)
+					must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+					must.ErrorContains(t, err, "format")
+				})
+
+				t.Run("path does not exist", func(t *testing.T) {
+					d := Disks{{Format: "raw", Size: "100", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Image: filepath.Join(t.TempDir(), "image"), Format: "raw"}}}
+					err := d.Validate(mock_storage.NewStaticStorage(), opts)
+					must.ErrorIs(t, err, ErrPathNotFound)
+				})
+
+				t.Run("path is not allowed", func(t *testing.T) {
+					d := Disks{{Format: "raw", Size: "100", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Image: filepath.Join(t.TempDir(), "image"), Format: "raw"}}}
+					err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+					must.ErrorIs(t, err, ErrDisallowedPath)
+				})
+
+				t.Run("disk is too small", func(t *testing.T) {
+					d := Disks{{Format: "raw", Size: "1", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Image: imagePath, Format: "raw"}}}
+					err := d.Validate(mock_storage.NewStaticStorage(), opts)
+					must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+					must.ErrorContains(t, err, "size of disk must")
+				})
+			})
+
+			t.Run("volume", func(t *testing.T) {
+				t.Run("ok", func(t *testing.T) {
+					pool := mock_storage.NewMockPool(t).Expect(
+						mock_storage.GetVolume{
+							Name: volumeName,
+							Result: &storage.Volume{
+								Size: 100,
+							},
+						},
+					)
+					defer pool.AssertExpectations()
+					d := Disks{{Format: "raw", Size: "200", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Volume: volumeName, Format: "raw"}}}
+					err := d.Validate(&mock_storage.StaticStorage{DefaultPoolResult: pool}, opts)
+					must.NoError(t, err)
+				})
+
+				t.Run("disk is too small", func(t *testing.T) {
+					pool := mock_storage.NewMockPool(t).Expect(
+						mock_storage.GetVolume{
+							Name: volumeName,
+							Result: &storage.Volume{
+								Size: 500,
+							},
+						},
+					)
+					defer pool.AssertExpectations()
+					d := Disks{{Format: "raw", Size: "200", Devname: "sda", Kind: storage.DiskKindDisk,
+						BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Volume: volumeName, Format: "raw"}}}
+					err := d.Validate(&mock_storage.StaticStorage{DefaultPoolResult: pool}, opts)
+					must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+					must.ErrorContains(t, err, "size of disk must")
+				})
+			})
+
+			t.Run("image and volume defined", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "200", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true, Source: &Source{Volume: volumeName, Image: imagePath, Format: "raw"}}}
+				err := d.Validate(mock_storage.NewStaticStorage(), opts)
+				must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+				must.ErrorContains(t, err, "source.volume and source.image")
+			})
+		})
+
+		t.Run("size", func(t *testing.T) {
+			t.Run("ok bytes", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "200", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true}}
+				must.NoError(t, d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{}))
+			})
+
+			t.Run("ok gigabytes", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "200GB", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true}}
+				must.NoError(t, d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{}))
+			})
+
+			t.Run("ok gibibytes", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "200GiB", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true}}
+				must.NoError(t, d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{}))
+			})
+
+			t.Run("unknown suffix", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "200G", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true}}
+				err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+				must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+				must.ErrorContains(t, err, "size value")
+			})
+
+			t.Run("not a size", func(t *testing.T) {
+				d := Disks{{Format: "raw", Size: "hello world", Devname: "sda", Kind: storage.DiskKindDisk,
+					BusType: storage.BusTypeVirtio, Primary: true}}
+				err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+				must.ErrorIs(t, err, errs.ErrInvalidConfiguration)
+				must.ErrorContains(t, err, "size value")
+			})
+		})
+
+		t.Run("missing required", func(t *testing.T) {
+			d := Disks{{}}
+			err := d.Validate(mock_storage.NewStaticStorage(), ValidationOptions{})
+			must.ErrorIs(t, err, errs.ErrMissingAttribute)
+			must.ErrorContains(t, err, "bus_type")
+			must.ErrorContains(t, err, "kind")
+			must.ErrorContains(t, err, "devname")
+			must.ErrorContains(t, err, "format")
+			must.ErrorContains(t, err, "size")
+			must.ErrorContains(t, err, "primary")
+		})
+	})
 }
 
 func TestConfig(t *testing.T) {


### PR DESCRIPTION
Adds a check on the disk size value when a source image or volume is defined to verify the disk will be large enough for the source. Validation tests added. Validation messages were updated where required to provide consistent error message formatting.