### PR TITLE
storage: fix ceph locking and copy

### DIFF
--- a/providers/libvirt/storage/ceph.go
+++ b/providers/libvirt/storage/ceph.go
@@ -243,8 +243,8 @@ func (c *ceph) copyVol(name string, opts storage.Options) (*storage.Volume, erro
 	}
 
 	// Create the new cloned volume.
-	err = fn.(func(ctx context.Context, connInfo *CephConnect, pool, srcVol, dstVol string) error)(
-		c.pool.ctx, connOpts, info.Source.Name, opts.Source.Volume, name)
+	err = fn.(func(ctx context.Context, logger hclog.Logger, connInfo *CephConnect, pool, srcVol, dstVol string) error)(
+		c.pool.ctx, c.logger, connOpts, info.Source.Name, opts.Source.Volume, name)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/libvirt/storage/plugin/ceph/ceph.go
+++ b/providers/libvirt/storage/plugin/ceph/ceph.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/ceph/go-ceph/rados"
 	"github.com/ceph/go-ceph/rbd"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/storage"
 	"github.com/hashicorp/nomad/helper/uuid"
 )
@@ -29,23 +31,15 @@ const (
 	radosOsdOpTimeout = "30"
 )
 
-const (
-	// Value used for shared lock on source image when copying.
-	imageCopyLockTag = "nomad-vol-copy"
-)
+var errNoSnapshot = errors.New("no current snapshot found")
 
 // VolumeCopy creates a new volume in the pool by creating a full copy of an existing volume.
-func VolumeCopy(ctx context.Context, con *storage.CephConnect, pool, srcVol, dstVol string) error {
+func VolumeCopy(ctx context.Context, logger hclog.Logger, con *storage.CephConnect, pool, srcVol, dstVol string) error {
 	conn, err := cephConnect(con)
 	if err != nil {
 		return fmt.Errorf("ceph copy connection failure: %w", err)
 	}
 	defer conn.Shutdown()
-
-	// Generate a cookie for locking the source image.
-	lockCookie := uuid.Short()
-	// Define a name for the ephemeral snapshot.
-	snapName := fmt.Sprintf("nomad-tmp-clone-%s", lockCookie)
 
 	// Create an IO context which is used for interacting
 	// with the pool.
@@ -55,31 +49,60 @@ func VolumeCopy(ctx context.Context, con *storage.CephConnect, pool, srcVol, dst
 	}
 	defer ioctx.Destroy()
 
-	// Open the source image and lock it before starting.
-	src, err := rbd.OpenImage(ioctx, srcVol, rbd.NoSnapshot)
+	// Find an existing up-to-date snapshot to use for the clone.
+	snapName, err := getImageSnapshot(ioctx, srcVol)
 	if err != nil {
-		return fmt.Errorf("source open failure: %w", err)
-	}
-	defer src.Close()
+		if !errors.Is(err, errNoSnapshot) {
+			return err
+		}
 
-	if err := src.LockShared(lockCookie, imageCopyLockTag); err != nil {
-		return fmt.Errorf("source lock failure: %w", err)
+		// No viable snapshot is available so generate a new one.
+		snapName, err = generateSnapshot(ioctx, srcVol)
+		if err != nil {
+			return err
+		}
 	}
-	defer src.Unlock(lockCookie)
 
-	// Create a new snapshot of the source volume. This snapshot
-	// will only exist for this copy, so delete it when complete.
-	snap, err := src.CreateSnapshot(snapName)
+	// Open the base image.
+	img, err := rbd.OpenImageReadOnly(ioctx, srcVol, rbd.NoSnapshot)
 	if err != nil {
-		return fmt.Errorf("snapshot create failure: %w", err)
+		return fmt.Errorf("volume read-only open failure: %w", err)
 	}
-	defer snap.Remove()
+	defer img.Close()
 
-	// Protect the snapshot to prevent deletion.
-	if err := snap.Protect(); err != nil {
-		return fmt.Errorf("snapshot protect failure: %w", err)
+	// Check that the image has the layering feature enabled. It is required
+	// for cloning the image. The layering feature is enabled by default, so
+	// this should (hopefully) be something that is rarely seen.
+	if ok, err := imageHasFeature(img, rbd.FeatureLayering); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("source volume missing required 'layering' feature")
 	}
-	defer snap.Unprotect()
+
+	// Load the snapshot.
+	snap := img.GetSnapshot(snapName)
+
+	// Snapshots must be protected for cloning. If the snapshot is unprotected
+	// then protect it during the clone and flatten process and return it to its
+	// unprotected state once done.
+	if ok, err := snap.IsProtected(); err != nil {
+		return fmt.Errorf("snapshot protection detection failure: %w", err)
+	} else if !ok {
+		unprotector, err := protectSnapshot(ioctx, srcVol, snapName)
+		if err != nil {
+			return err
+		}
+
+		// Unprotect the snapshot on the way out. If a failure is encountered,
+		// just log it as a warning since the failure might be expected (if
+		// a new clone was created).
+		defer func() {
+			if err := unprotector(); err != nil {
+				logger.Warn("non-fatal failure to unprotect snapshot", "image", srcVol,
+					"snapshot", snapName, "error", err)
+			}
+		}()
+	}
 
 	// New image options for the clone just sets the clone format
 	// to the new (latest) version.
@@ -167,12 +190,12 @@ func VolumeUpload(ctx context.Context, con *storage.CephConnect, pool, volume, p
 		return fmt.Errorf("path info failure: %w", err)
 	}
 
-	// Grab an exclusive lock on the image to prevent anything
-	// being done to it while it is being used.
-	if err := img.LockAcquire(rbd.LockModeExclusive); err != nil {
-		return fmt.Errorf("volume lock failure: %w", err)
+	// Lock the image for modification.
+	unlocker, err := writeLock(img)
+	if err != nil {
+		return err
 	}
-	defer img.LockRelease()
+	defer unlocker()
 
 	// Copy the source image into the volume. The reader and writer
 	// are wrapped with a context to allow the copy to be interrupted
@@ -223,4 +246,194 @@ func cephConnect(con *storage.CephConnect) (*rados.Conn, error) {
 
 	// Looks like it's working \o/
 	return conn, nil
+}
+
+// writeLock locks the image for modification and returns a function for
+// unlocking the image.
+func writeLock(img *rbd.Image) (func() error, error) {
+	// Check the image for the `exclusive-lock` feature. If it is enabled acquire a managed
+	// lock for modifying the image. The feature is enabled by default so this should
+	// generally be the locking method used.
+	if ok, err := imageHasFeature(img, rbd.FeatureExclusiveLock); err != nil {
+		return nil, err
+	} else if ok {
+		if err := img.LockAcquire(rbd.LockModeExclusive); err != nil {
+			return nil, err
+		}
+
+		return img.LockRelease, nil
+	}
+
+	// Without the `exclusive-lock` feature, use an unmanaged lock.
+	cookie := uuid.Short()
+	if err := img.LockExclusive(cookie); err != nil {
+		return nil, err
+	}
+
+	return func() error { return img.Unlock(cookie) }, nil
+}
+
+// hasFeature checks if the image has the requested feature enabled.
+func imageHasFeature(img *rbd.Image, feature uint64) (bool, error) {
+	currentFeatures, err := img.GetFeatures()
+	if err != nil {
+		return false, fmt.Errorf("volume features failure: %w", err)
+	}
+
+	return (currentFeatures & feature) == feature, nil
+}
+
+// protectSnapshot will protect the snapshot of the image. Snapshots must be
+// protected to be cloned. Returns an optional function to unprotect the snapshot.
+func protectSnapshot(ioctx *rados.IOContext, imgName, snapName string) (func() error, error) {
+	img, err := rbd.OpenImage(ioctx, imgName, rbd.NoSnapshot)
+	if err != nil {
+		return nil, fmt.Errorf("volume open failure: %w", err)
+	}
+	defer img.Close()
+
+	unlocker, err := writeLock(img)
+	if err != nil {
+		return nil, fmt.Errorf("volume write lock failure: %w", err)
+	}
+	defer unlocker()
+
+	if err := img.GetSnapshot(snapName).Protect(); err != nil {
+		return nil, fmt.Errorf("volume snapshot protection failure: %w", err)
+	}
+
+	return func() error { return unprotectSnapshot(ioctx, imgName, snapName) }, nil
+}
+
+// unprotectSnapshot will unprotect the snapshot of the image. Snapshots must
+// not have any clones to be unprotected.
+func unprotectSnapshot(ioctx *rados.IOContext, imgName, snapName string) error {
+	img, err := rbd.OpenImage(ioctx, imgName, rbd.NoSnapshot)
+	if err != nil {
+		return fmt.Errorf("volume open failure: %w", err)
+	}
+	defer img.Close()
+
+	unlocker, err := writeLock(img)
+	if err != nil {
+		return fmt.Errorf("volume write lock failure: %w", err)
+	}
+	defer unlocker()
+
+	if err := img.GetSnapshot(snapName).Unprotect(); err != nil {
+		return fmt.Errorf("volume snapshot protection failure: %w", err)
+	}
+
+	return nil
+}
+
+// getImageSnapshot returns the name of an existing up-to-date snapshot of the
+// image. If an up-to-date snapshot of the image does not exist, errNoSnapshot
+// will be returned.
+func getImageSnapshot(ioctx *rados.IOContext, imgName string) (string, error) {
+	img, err := rbd.OpenImageReadOnly(ioctx, imgName, rbd.NoSnapshot)
+	if err != nil {
+		return "", fmt.Errorf("volume open failure: %w", err)
+	}
+	defer img.Close()
+
+	// Start with getting the size of the image.
+	imgSize, err := img.GetSize()
+	if err != nil {
+		return "", fmt.Errorf("volume size unavailable: %w", err)
+	}
+
+	// Get the list of existing snapshots.
+	snaps, err := img.GetSnapshotNames()
+	if err != nil {
+		return "", fmt.Errorf("volume snapshot list failure: %w", err)
+	}
+
+	// If there are no snapshots, there is no latest.
+	if len(snaps) == 0 {
+		return "", errNoSnapshot
+	}
+
+	// Attempt to find an up-to-date snapshot of the image. To do this we run a
+	// diff between the image and the snapshot. If no difference is detected then
+	// it is an up-to-date snapshot that can be used for cloning.
+	for _, snapInfo := range snaps {
+		// This value is used to surface the result of the check.
+		isDiff := false
+		// Build the configuration for the diff operation. The callback is invoked
+		// with all the diff chunks between the image and the snapshot. To prevent
+		// processing all the chunks, an error will be forced immediately.
+		config := rbd.DiffIterateConfig{
+			SnapName:      snapInfo.Name,
+			Offset:        0,
+			Length:        imgSize,
+			IncludeParent: rbd.IncludeParent,
+			WholeObject:   rbd.EnableWholeObject,
+			Callback: func(uint64, uint64, int, interface{}) int {
+				// Mark that the snapshot is different than the image.
+				isDiff = true
+
+				// return an error to force stop processing diffs since
+				// we only care about the first one.
+				return -1
+			},
+		}
+
+		err := img.DiffIterate(config)
+		// An error is expected when a difference is detected (because the callback
+		// was executed) so if there is no difference detected but an error was returned
+		// then it was an unexpected error.
+		if err != nil && !isDiff {
+			return "", fmt.Errorf("failed to iterate snapshot diffs on %q: %w", snapInfo.Name, err)
+		}
+
+		// If there was no difference detected then this
+		// snapshot can be used for cloning.
+		if !isDiff {
+			return snapInfo.Name, nil
+		}
+	}
+
+	// If we are still here then there are no existing snapshots of the
+	// image in its current state.
+	return "", errNoSnapshot
+}
+
+// generateSnapshot generates a new protected snapshot of the image and returns the snapshot name.
+func generateSnapshot(ioctx *rados.IOContext, imgName string) (string, error) {
+	// Open the source image and lock it before starting.
+	img, err := rbd.OpenImage(ioctx, imgName, rbd.NoSnapshot)
+	if err != nil {
+		return "", fmt.Errorf("volume open failure: %w", err)
+	}
+	defer img.Close()
+
+	// Only generate a snapshot if the image supports layering since
+	// the generated snapshots are used for cloning.
+	if ok, err := imageHasFeature(img, rbd.FeatureLayering); err != nil {
+		return "", err
+	} else if !ok {
+		return "", fmt.Errorf("volume missing required 'layering' feature for snapshot")
+	}
+
+	// Lock the image for modification.
+	unlocker, err := writeLock(img)
+	if err != nil {
+		return "", fmt.Errorf("volume lock failure: %w", err)
+	}
+	defer unlocker()
+
+	// Create a new snapshot of the source volume.
+	snapshotName := fmt.Sprintf("nomad-snap-%s", uuid.Short())
+	snap, err := img.CreateSnapshot(snapshotName)
+	if err != nil {
+		return "", fmt.Errorf("volume snapshot create failure: %w", err)
+	}
+
+	// Protect the snapshot to prevent deletion.
+	if err := snap.Protect(); err != nil {
+		return "", fmt.Errorf("volume snapshot protection failure: %w", err)
+	}
+
+	return snapshotName, nil
 }


### PR DESCRIPTION
Updates locking behavior to use managed locks (`exclusive-lock` feature) when available and fall back to unmanaged locks when not. The volume copy behavior has been updated to:

* Verify `layering` feature is enabled.
* Detect existing snapshot for use to clone.
* Create and retain snapshot if needed.