### PR TITLE
ci: declare permissions on build, jira-sync, test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ on: [workflow_dispatch, push]
 env:
   PKG_NAME: "nomad-driver-virt"
 
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     name: "get Go toolchain version"

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -15,6 +15,12 @@ env:
   JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
   JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
+# Jira mirror only reads issue/comment metadata; writes go to Jira via
+# JIRA_API_TOKEN.
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ on:
       README.md
       GNUMakefile
 
+permissions:
+  contents: read
+
 jobs:
   mod:
     name: "run go mod tidy"


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to the minimum scope for the three workflows still inheriting org defaults:

- `build.yaml` — `contents: read`. Go build pipeline, no API writes.
- `jira-sync.yml` — `contents: read` + `issues: read`. The atlassian/gajira-* and tomhjp/gh-action-jira-* steps write to the Jira API via `JIRA_API_TOKEN`; GitHub side only reads issue/comment context.
- `test.yaml` — `contents: read`. Plain go test + mod tidy verification.

YAML validated locally.