### PR TITLE
net: isolate iptables into reusable package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coreos/go-iptables v0.8.0
 	github.com/diskfs/go-diskfs v1.9.3
 	github.com/docker/distribution v2.8.3+incompatible
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/go-cmp v0.7.0
 	github.com/gopacket/gopacket v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3
@@ -49,7 +50,6 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gojuno/minimock/v3 v3.4.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/net/filter/filter.go
+++ b/net/filter/filter.go
@@ -1,0 +1,16 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package filter
+
+import (
+	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+// Filter is the interface to add and remove packet filtering
+// configuration for virt tasks.
+type Filter interface {
+	Configure(*drivers.Resources, *virtnet.NetworkInterfaceBridgeConfig, string) (*virtnet.FilterRemoval, error)
+	Teardown(*virtnet.FilterRemoval) error
+}

--- a/net/filter/filter.go
+++ b/net/filter/filter.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package filter

--- a/net/filter/filter.go
+++ b/net/filter/filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"github.com/hashicorp/go-hclog"
 	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
@@ -11,6 +12,7 @@ import (
 // Filter is the interface to add and remove packet filtering
 // configuration for virt tasks.
 type Filter interface {
+	SetLogger(hclog.Logger)
 	Configure(*drivers.Resources, *virtnet.NetworkInterfaceBridgeConfig, string) (*virtnet.FilterRemoval, error)
 	Teardown(*virtnet.FilterRemoval) error
 }

--- a/net/filter/iptables/iptables.go
+++ b/net/filter/iptables/iptables.go
@@ -34,11 +34,15 @@ const (
 // implementations for testing.
 type IPTables interface {
 	Append(table, chain string, rulespec ...string) error
+	AppendUnique(table, chain string, rulespec ...string) error
+	ChainExists(table, chain string) (bool, error)
+	ClearAndDeleteChain(table, chain string) error
 	ClearChain(table, chain string) error
 	Delete(table, chain string, rulespec ...string) error
 	DeleteChain(table, chain string) error
 	DeleteIfExists(table, chain string, rulespec ...string) error
 	Insert(table, chain string, pos int, rulespec ...string) error
+	InsertUnique(table, chain string, pos int, rulespec ...string) error
 	ListChains(table string) ([]string, error)
 	List(table, chain string) ([]string, error)
 	NewChain(table, chain string) error
@@ -47,7 +51,7 @@ type IPTables interface {
 // New returns the filter.Filter interface instance. If the singleton instance does not yet
 // exist it will create the instance and run setup. Otherwise it will return the
 // existing instance.
-func New(logger hclog.Logger) (*virtTables, error) {
+func New() (*virtTables, error) {
 	loadLock.Lock()
 	defer loadLock.Unlock()
 
@@ -65,7 +69,7 @@ func New(logger hclog.Logger) (*virtTables, error) {
 		interfaceByIPGetter:        getInterfaceByIP,
 		names:                      NewNames(),
 		routingInterfaceByIPGetter: getRoutingInterfaceByIP,
-		logger:                     logger.Named("iptables"),
+		logger:                     hclog.Default().Named("iptables"),
 	}
 
 	if err := nt.setup(); err != nil {
@@ -74,4 +78,15 @@ func New(logger hclog.Logger) (*virtTables, error) {
 
 	singleton = nt
 	return singleton, nil
+}
+
+// isNotExistErr is a helper to check if the error was caused
+// by a rule or chain not existing.
+func isNotExistErr(err error) bool {
+	iptErr, ok := err.(*iptables.Error)
+	if !ok {
+		return false
+	}
+
+	return iptErr.IsNotExist()
 }

--- a/net/filter/iptables/iptables.go
+++ b/net/filter/iptables/iptables.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -33,15 +33,11 @@ const (
 // that are currently used. This allows for easily swapping out
 // implementations for testing.
 type IPTables interface {
-	Append(table, chain string, rulespec ...string) error
 	AppendUnique(table, chain string, rulespec ...string) error
 	ChainExists(table, chain string) (bool, error)
 	ClearAndDeleteChain(table, chain string) error
-	ClearChain(table, chain string) error
-	Delete(table, chain string, rulespec ...string) error
 	DeleteChain(table, chain string) error
 	DeleteIfExists(table, chain string, rulespec ...string) error
-	Insert(table, chain string, pos int, rulespec ...string) error
 	InsertUnique(table, chain string, pos int, rulespec ...string) error
 	ListChains(table string) ([]string, error)
 	List(table, chain string) ([]string, error)

--- a/net/filter/iptables/iptables.go
+++ b/net/filter/iptables/iptables.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"sync"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/hashicorp/go-hclog"
+)
+
+var (
+	// loadLock is used to synchronize creation and setup of the singleton.
+	loadLock sync.Mutex
+
+	// singleton is the single instance of the filter.Filter interface.
+	singleton *virtTables
+)
+
+const (
+	// routeLocalnetPathTemplate is the template for generating the path to check for device specific routing support.
+	routeLocalnetPathTemplate = "/proc/sys/net/ipv4/conf/%s/route_localnet"
+
+	// routeLocalnetGlobalName is the name of the global kernel configuration for localnet routing.
+	routeLocalnetGlobalName = "all"
+
+	// removalName is the name set in the FilterRemoval
+	removalName = "iptables"
+)
+
+// Interface for iptables which defines the subset of functions
+// that are currently used. This allows for easily swapping out
+// implementations for testing.
+type IPTables interface {
+	Append(table, chain string, rulespec ...string) error
+	ClearChain(table, chain string) error
+	Delete(table, chain string, rulespec ...string) error
+	DeleteChain(table, chain string) error
+	DeleteIfExists(table, chain string, rulespec ...string) error
+	Insert(table, chain string, pos int, rulespec ...string) error
+	ListChains(table string) ([]string, error)
+	List(table, chain string) ([]string, error)
+	NewChain(table, chain string) error
+}
+
+// New returns the filter.Filter interface instance. If the singleton instance does not yet
+// exist it will create the instance and run setup. Otherwise it will return the
+// existing instance.
+func New(logger hclog.Logger) (*virtTables, error) {
+	loadLock.Lock()
+	defer loadLock.Unlock()
+
+	if singleton != nil {
+		return singleton, nil
+	}
+
+	ipt, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+
+	nt := &virtTables{
+		ipt:                        ipt,
+		interfaceByIPGetter:        getInterfaceByIP,
+		names:                      NewNames(),
+		routingInterfaceByIPGetter: getRoutingInterfaceByIP,
+		logger:                     logger.Named("iptables"),
+	}
+
+	if err := nt.setup(); err != nil {
+		return nil, err
+	}
+
+	singleton = nt
+	return singleton, nil
+}

--- a/net/filter/iptables/names.go
+++ b/net/filter/iptables/names.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables

--- a/net/filter/iptables/names.go
+++ b/net/filter/iptables/names.go
@@ -1,0 +1,96 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+const (
+	// defaultChainNameNomadPostrouting is the IPTables chain name used by the
+	// driver for postrouting rules. This is currently used for entries within
+	// the nat table specifically for handling the special case of loopback
+	// addresses.
+	defaultChainNameNomadPostrouting = "NOMAD_VT_PST"
+
+	// defaultChainNameNomadPrerouting is the IPTables chain name used by the
+	// driver for prerouting rules. This is currently used for entries within
+	// the nat table.
+	defaultChainNameNomadPrerouting = "NOMAD_VT_PRT"
+
+	// defaultChainNameNomadForward is the IPTables chain name used by the driver
+	// for forwarding rules. This is currently used for entries within the
+	// filter table.
+	defaultChainNameNomadForward = "NOMAD_VT_FW"
+
+	// defaultChainNameNomadOutput is the IPTables chain name used by the driver
+	// for output rules. This is currently used for entries within the nat
+	// table specifically for handling the special case of loopback addresses.
+	defaultChainNameNomadOutput = "NOMAD_VT_OUT"
+
+	// defaultChainNameOutput is the name of the output chain within iptables.
+	defaultChainNameOutput = "OUTPUT"
+
+	// defaultChainNamePostrouting is the name of the postrouting chain within iptables.
+	defaultChainNamePostrouting = "POSTROUTING"
+
+	// defaultChainNamePrerouting is the name of the prerouting chain within iptables.
+	defaultChainNamePrerouting = "PREROUTING"
+
+	// defaultChainNameForward is the name of the forward chain within iptables.
+	defaultChainNameForward = "FORWARD"
+
+	// defaultTableNameNAT is the name of the nat table within iptables.
+	defaultTableNameNAT = "nat"
+
+	// defaultTableNameFilter is the name of the filter table within iptables.
+	defaultTableNameFilter = "filter"
+)
+
+// names holds the names for tables and chains used in iptables.
+type names struct {
+	chains *ChainNames
+	tables *TableNames
+}
+
+// TableNames holds the names of tables used in iptables.
+type TableNames struct {
+	Filter string
+	NAT    string
+}
+
+// ChainNames holds the name of chains used in iptables.
+type ChainNames struct {
+	Forward     string
+	Nomad       *NomadChainNames
+	Output      string
+	Postrouting string
+	Prerouting  string
+}
+
+// NomadChainNames holds the names of nomad specific chains used in iptables.
+type NomadChainNames struct {
+	Forward     string
+	Postrouting string
+	Prerouting  string
+	Output      string
+}
+
+// NewNames creates a new instance with all values set to defaults.
+func NewNames() *names {
+	return &names{
+		chains: &ChainNames{
+			Forward:     defaultChainNameForward,
+			Output:      defaultChainNameNomadOutput,
+			Postrouting: defaultChainNamePostrouting,
+			Prerouting:  defaultChainNamePrerouting,
+			Nomad: &NomadChainNames{
+				Forward:     defaultChainNameNomadForward,
+				Postrouting: defaultChainNameNomadPostrouting,
+				Prerouting:  defaultChainNameNomadPrerouting,
+				Output:      defaultChainNameNomadOutput,
+			},
+		},
+		tables: &TableNames{
+			Filter: defaultTableNameFilter,
+			NAT:    defaultTableNameNAT,
+		},
+	}
+}

--- a/net/filter/iptables/request.go
+++ b/net/filter/iptables/request.go
@@ -4,8 +4,6 @@
 package iptables
 
 import (
-	"cmp"
-	"slices"
 	"sync"
 
 	"github.com/hashicorp/go-set/v3"
@@ -33,99 +31,25 @@ type request struct {
 	m          sync.Mutex                   // mutex to sync stamping
 }
 
-// tableList returns the list of table name referenced in the
-// request.
-func (r *request) tableList() []string {
-	s := set.New[string](0)
-	tables := make([]string, 0)
-
-	for _, c := range r.sortedChains() {
-		if s.Insert(c.table) {
-			tables = append(tables, c.table)
-		}
-	}
-
-	for _, ru := range r.sortedRules() {
-		if s.Insert(ru.table) {
-			tables = append(tables, ru.table)
-		}
-	}
-
-	return tables
-}
-
-// chainTables returns the collection of table names defined
-// in the request's chain collection.
-func (r *request) chainTables() []string {
-	s := set.New[string](0)
-	tables := make([]string, 0)
-
-	for _, c := range r.sortedChains() {
-		if s.Insert(c.table) {
-			tables = append(tables, c.table)
-		}
-	}
-
-	return tables
-}
-
-// chainList returns the list of chains referenced in the request.
-func (r *request) chainList() []*chain {
-	s := set.NewHashSet[*chain](0)
-	chains := make([]*chain, 0)
-	for _, ru := range r.sortedRules() {
-		c := ru.mkchain()
-		if s.Insert(c) {
-			chains = append(chains, c)
-		}
-	}
-
-	return chains
-}
-
-// ruleChains returns the collection chains defined in the
-// request's rule collection.
-func (r *request) ruleChains() []*chain {
-	s := set.NewHashSet[*chain](0)
-	chains := make([]*chain, 0)
-	for _, rule := range r.sortedRules() {
-		c := &chain{table: rule.table, chain: rule.chain}
-		if s.Insert(c) {
-			chains = append(chains, c)
-		}
-	}
-
-	return chains
-}
-
 // sortedRules returns the rules as a sorted slice based on
 // stamp value.
 // NOTE: accessing rules directly is unsorted due to map backing.
-func (r *request) sortedRules() []*rule {
-	rules := r.rules.Slice()
-	slices.SortFunc(rules, func(a, b *rule) int { return cmp.Compare(a.stamp, b.stamp) })
-
-	return rules
+func (r *request) sortedRules() rules {
+	return rules(r.rules.Slice()).sort()
 }
 
 // sortedChains returns the chain as a sorted slice based on
 // stamp value.
 // NOTE: accessing chains directly is unsorted due to map backing.
-func (r *request) sortedChains() []*chain {
-	chains := r.chains.Slice()
-	slices.SortFunc(chains, func(a, b *chain) int { return cmp.Compare(a.stamp, b.stamp) })
-
-	return chains
+func (r *request) sortedChains() chains {
+	return chains(r.chains.Slice()).sort()
 }
 
-// teardown returns the raw collection of rules from the
+// removalInstructions returns the raw collection of rules from the
 // request that have been flagged as teardown.
-func (r *request) teardown() Rules {
+func (r *request) removalInstructions() Rules {
 	result := make([][]string, 0)
-	for _, r := range r.sortedRules() {
-		if !r.teardown {
-			continue
-		}
+	for _, r := range r.sortedRules().removables() {
 		result = append(result, r.slice())
 	}
 
@@ -137,26 +61,16 @@ type stampable interface {
 	setStamp(uint)
 }
 
-// addChain adds a single chain to the request.
+// addChain adds chains to the request.
 func (r *request) addChain(chains ...*chain) {
-	r.addChains(chains)
-}
-
-// addChains adds a chain slice to the request.
-func (r *request) addChains(chains []*chain) {
 	for _, c := range chains {
 		r.stamp(c)
 		r.chains.Insert(c)
 	}
 }
 
-// addRule adds a single rule to the request.
+// addRule adds rules to the request.
 func (r *request) addRule(rules ...*rule) {
-	r.addRules(rules)
-}
-
-// addRules adds a rule slice to the request.
-func (r *request) addRules(rules []*rule) {
 	for _, rule := range rules {
 		r.stamp(rule)
 		r.rules.Insert(rule)

--- a/net/filter/iptables/request.go
+++ b/net/filter/iptables/request.go
@@ -1,0 +1,175 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+
+	"github.com/hashicorp/go-set/v3"
+)
+
+// newRequest returns a new request instance.
+func newRequest() *request {
+	return &request{
+		chains: set.NewHashSet[*chain](0),
+		rules:  set.NewHashSet[*rule](0),
+	}
+}
+
+// request is used to provide chains and rules that need to
+// be created or removed.
+// NOTE: Chains and rules should be added to the request using
+// the custom functions instead of adding them directly to the
+// underlying sets. This is because the custom functions will
+// stamp the values to ensure they can be provided in the
+// correct order.
+type request struct {
+	chains     *set.HashSet[*chain, string] // collection of chains
+	rules      *set.HashSet[*rule, string]  // collection of rules
+	stampValue uint                         // value to stamp on rules/chains for sorting
+	m          sync.Mutex                   // mutex to sync stamping
+}
+
+// tableList returns the list of table name referenced in the
+// request.
+func (r *request) tableList() []string {
+	s := set.New[string](0)
+	tables := make([]string, 0)
+
+	for _, c := range r.sortedChains() {
+		if s.Insert(c.table) {
+			tables = append(tables, c.table)
+		}
+	}
+
+	for _, ru := range r.sortedRules() {
+		if s.Insert(ru.table) {
+			tables = append(tables, ru.table)
+		}
+	}
+
+	return tables
+}
+
+// chainTables returns the collection of table names defined
+// in the request's chain collection.
+func (r *request) chainTables() []string {
+	s := set.New[string](0)
+	tables := make([]string, 0)
+
+	for _, c := range r.sortedChains() {
+		if s.Insert(c.table) {
+			tables = append(tables, c.table)
+		}
+	}
+
+	return tables
+}
+
+// chainList returns the list of chains referenced in the request.
+func (r *request) chainList() []*chain {
+	s := set.NewHashSet[*chain](0)
+	chains := make([]*chain, 0)
+	for _, ru := range r.sortedRules() {
+		c := ru.mkchain()
+		if s.Insert(c) {
+			chains = append(chains, c)
+		}
+	}
+
+	return chains
+}
+
+// ruleChains returns the collection chains defined in the
+// request's rule collection.
+func (r *request) ruleChains() []*chain {
+	s := set.NewHashSet[*chain](0)
+	chains := make([]*chain, 0)
+	for _, rule := range r.sortedRules() {
+		c := &chain{table: rule.table, chain: rule.chain}
+		if s.Insert(c) {
+			chains = append(chains, c)
+		}
+	}
+
+	return chains
+}
+
+// sortedRules returns the rules as a sorted slice based on
+// stamp value.
+// NOTE: accessing rules directly is unsorted due to map backing.
+func (r *request) sortedRules() []*rule {
+	rules := r.rules.Slice()
+	slices.SortFunc(rules, func(a, b *rule) int { return cmp.Compare(a.stamp, b.stamp) })
+
+	return rules
+}
+
+// sortedChains returns the chain as a sorted slice based on
+// stamp value.
+// NOTE: accessing chains directly is unsorted due to map backing.
+func (r *request) sortedChains() []*chain {
+	chains := r.chains.Slice()
+	slices.SortFunc(chains, func(a, b *chain) int { return cmp.Compare(a.stamp, b.stamp) })
+
+	return chains
+}
+
+// teardown returns the raw collection of rules from the
+// request that have been flagged as teardown.
+func (r *request) teardown() Rules {
+	result := make([][]string, 0)
+	for _, r := range r.sortedRules() {
+		if !r.teardown {
+			continue
+		}
+		result = append(result, r.slice())
+	}
+
+	return result
+}
+
+// stampable describes a type that can be stamped.
+type stampable interface {
+	setStamp(uint)
+}
+
+// addChain adds a single chain to the request.
+func (r *request) addChain(chains ...*chain) {
+	r.addChains(chains)
+}
+
+// addChains adds a chain slice to the request.
+func (r *request) addChains(chains []*chain) {
+	for _, c := range chains {
+		r.stamp(c)
+		r.chains.Insert(c)
+	}
+}
+
+// addRule adds a single rule to the request.
+func (r *request) addRule(rules ...*rule) {
+	r.addRules(rules)
+}
+
+// addRules adds a rule slice to the request.
+func (r *request) addRules(rules []*rule) {
+	for _, rule := range rules {
+		r.stamp(rule)
+		r.rules.Insert(rule)
+	}
+}
+
+// stamp sets the stamp value on the item(s).
+func (r *request) stamp(items ...stampable) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	for _, item := range items {
+		item.setStamp(r.stampValue)
+		r.stampValue++
+	}
+}

--- a/net/filter/iptables/request.go
+++ b/net/filter/iptables/request.go
@@ -1,89 +1,46 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
 
 import (
 	"sync"
-
-	"github.com/hashicorp/go-set/v3"
 )
 
 // newRequest returns a new request instance.
 func newRequest() *request {
-	return &request{
-		chains: set.NewHashSet[*chain](0),
-		rules:  set.NewHashSet[*rule](0),
-	}
+	r := &request{}
+	r.chains = newChains(r.stamp)
+	r.rules = newRules(r.stamp)
+
+	return r
 }
 
 // request is used to provide chains and rules that need to
 // be created or removed.
-// NOTE: Chains and rules should be added to the request using
-// the custom functions instead of adding them directly to the
-// underlying sets. This is because the custom functions will
-// stamp the values to ensure they can be provided in the
-// correct order.
 type request struct {
-	chains     *set.HashSet[*chain, string] // collection of chains
-	rules      *set.HashSet[*rule, string]  // collection of rules
-	stampValue uint                         // value to stamp on rules/chains for sorting
-	m          sync.Mutex                   // mutex to sync stamping
-}
-
-// sortedRules returns the rules as a sorted slice based on
-// stamp value.
-// NOTE: accessing rules directly is unsorted due to map backing.
-func (r *request) sortedRules() rules {
-	return rules(r.rules.Slice()).sort()
-}
-
-// sortedChains returns the chain as a sorted slice based on
-// stamp value.
-// NOTE: accessing chains directly is unsorted due to map backing.
-func (r *request) sortedChains() chains {
-	return chains(r.chains.Slice()).sort()
+	chains     *chains    // collection of chains
+	rules      *rules     // collection of rules
+	stampValue uint       // value to stamp on rules/chains for sorting
+	m          sync.Mutex // mutex to sync stamping
 }
 
 // removalInstructions returns the raw collection of rules from the
 // request that have been flagged as teardown.
 func (r *request) removalInstructions() Rules {
-	result := make([][]string, 0)
-	for _, r := range r.sortedRules().removables() {
+	result := make(Rules, 0)
+	for _, r := range r.rules.removables().Slice() {
 		result = append(result, r.slice())
 	}
 
 	return result
 }
 
-// stampable describes a type that can be stamped.
-type stampable interface {
-	setStamp(uint)
-}
-
-// addChain adds chains to the request.
-func (r *request) addChain(chains ...*chain) {
-	for _, c := range chains {
-		r.stamp(c)
-		r.chains.Insert(c)
-	}
-}
-
-// addRule adds rules to the request.
-func (r *request) addRule(rules ...*rule) {
-	for _, rule := range rules {
-		r.stamp(rule)
-		r.rules.Insert(rule)
-	}
-}
-
 // stamp sets the stamp value on the item(s).
-func (r *request) stamp(items ...stampable) {
+func (r *request) stamp(item stampable) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	for _, item := range items {
-		item.setStamp(r.stampValue)
-		r.stampValue++
-	}
+	item.setStamp(r.stampValue)
+	r.stampValue++
 }

--- a/net/filter/iptables/request.go
+++ b/net/filter/iptables/request.go
@@ -26,7 +26,7 @@ type request struct {
 }
 
 // removalInstructions returns the raw collection of rules from the
-// request that have been flagged as teardown.
+// request that have been flagged as removeable.
 func (r *request) removalInstructions() Rules {
 	result := make(Rules, 0)
 	for _, r := range r.rules.removables().Slice() {

--- a/net/filter/iptables/request_test.go
+++ b/net/filter/iptables/request_test.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func Test_request_tablesList(t *testing.T) {
+	req := newRequest()
+
+	// Start with an empty request.
+	must.SliceEmpty(t, req.tableList())
+
+	// Add a chain.
+	req.addChain(&chain{table: "test-table", chain: "test-chain"})
+	must.Size(t, 1, req.chains, must.Sprint("expected 1 chain entry"))
+	must.SliceContainsAll(t, req.tableList(), []string{"test-table"})
+
+	// Add another chain on different table.
+	req.addChain(&chain{table: "mock-table", chain: "mock-chain"})
+	must.Size(t, 2, req.chains, must.Sprint("expected 2 chain entries"))
+	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table"})
+
+	// Add chain on existing table.
+	req.addChain(&chain{table: "test-table", chain: "mock-chain"})
+	must.Size(t, 3, req.chains, must.Sprint("expected 3 chain entries"))
+	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table"})
+
+	// Add a rule.
+	req.addRule(&rule{table: "faux-table", chain: "test-chain"})
+	must.Size(t, 1, req.rules, must.Sprint("expected 1 chain entry"))
+	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table", "faux-table"})
+}
+
+func Test_request_chainList(t *testing.T) {
+	req := newRequest()
+
+	// Start with an empty request.
+	must.SliceEmpty(t, req.chainList())
+
+	// Add a rule.
+	req.addRule(&rule{table: "test-table", chain: "test-chain"})
+	must.Size(t, 1, req.rules, must.Sprint("expected 1 rule entry"))
+	expectedChains := []*chain{{table: "test-table", chain: "test-chain"}}
+	must.SliceContainsAll(t, req.chainList(), expectedChains)
+
+	// Add a rule on a different chain but same table.
+	req.addRule(&rule{table: "test-table", chain: "mock-chain"})
+	must.Size(t, 2, req.rules, must.Sprint("expected 2 rule entries"))
+	expectedChains = append(expectedChains, &chain{table: "test-table", chain: "mock-chain"})
+	must.SliceContainsAll(t, req.chainList(), expectedChains)
+
+	// Add a rule on a different table and but same chain name.
+	req.addRule(&rule{table: "mock-table", chain: "mock-chain"})
+	must.Size(t, 3, req.rules, must.Sprint("expected 3 rule entries"))
+	expectedChains = append(expectedChains, &chain{table: "mock-table", chain: "mock-chain"})
+	must.SliceContainsAll(t, req.chainList(), expectedChains)
+
+	// Add a rule on an existing table and chain.
+	req.addRule(&rule{table: "test-table", chain: "test-chain", position: 1})
+	must.Size(t, 3, req.rules, must.Sprint("expected 3 rule entry"))
+	must.SliceContainsAll(t, req.chainList(), expectedChains)
+}
+
+func Test_request_teardown(t *testing.T) {
+	req := newRequest()
+	expectedTeardown := make(Rules, 0)
+
+	// Start with an empty request.
+	must.Empty(t, req.teardown())
+
+	// Add a chain entry.
+	req.chains.Insert(&chain{table: "test-table", chain: "test-chain"})
+	must.Size(t, 1, req.chains)
+
+	// No teardown entries should be provided from chains.
+	must.Empty(t, req.teardown())
+
+	// Add a rule entry.
+	req.addRule(&rule{table: "test-table", chain: "test-chain"})
+	must.Size(t, 1, req.rules)
+
+	// Rule is not marked as teardown so no entries should be returned.
+	must.Empty(t, req.teardown())
+
+	// Add a rule entry marked as teardown.
+	req.addRule(&rule{table: "mock-table", chain: "test-chain", teardown: true})
+	must.Size(t, 2, req.rules)
+	expectedTeardown = append(expectedTeardown, []string{"mock-table", "test-chain"})
+	must.SliceContainsAll(t, expectedTeardown, req.teardown())
+
+	// Add another rule entry marked as teardown.
+	req.addRule(&rule{table: "mock-table", chain: "mock-chain", teardown: true})
+	must.Size(t, 3, req.rules)
+	expectedTeardown = append(expectedTeardown, []string{"mock-table", "mock-chain"})
+	must.SliceContainsAll(t, expectedTeardown, req.teardown())
+}

--- a/net/filter/iptables/request_test.go
+++ b/net/filter/iptables/request_test.go
@@ -4,98 +4,71 @@
 package iptables
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/shoenig/test/must"
 )
 
-func Test_request_tablesList(t *testing.T) {
-	req := newRequest()
-
-	// Start with an empty request.
-	must.SliceEmpty(t, req.tableList())
-
-	// Add a chain.
-	req.addChain(&chain{table: "test-table", chain: "test-chain"})
-	must.Size(t, 1, req.chains, must.Sprint("expected 1 chain entry"))
-	must.SliceContainsAll(t, req.tableList(), []string{"test-table"})
-
-	// Add another chain on different table.
-	req.addChain(&chain{table: "mock-table", chain: "mock-chain"})
-	must.Size(t, 2, req.chains, must.Sprint("expected 2 chain entries"))
-	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table"})
-
-	// Add chain on existing table.
-	req.addChain(&chain{table: "test-table", chain: "mock-chain"})
-	must.Size(t, 3, req.chains, must.Sprint("expected 3 chain entries"))
-	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table"})
-
-	// Add a rule.
-	req.addRule(&rule{table: "faux-table", chain: "test-chain"})
-	must.Size(t, 1, req.rules, must.Sprint("expected 1 chain entry"))
-	must.SliceContainsAll(t, req.tableList(), []string{"test-table", "mock-table", "faux-table"})
-}
-
-func Test_request_chainList(t *testing.T) {
-	req := newRequest()
-
-	// Start with an empty request.
-	must.SliceEmpty(t, req.chainList())
-
-	// Add a rule.
-	req.addRule(&rule{table: "test-table", chain: "test-chain"})
-	must.Size(t, 1, req.rules, must.Sprint("expected 1 rule entry"))
-	expectedChains := []*chain{{table: "test-table", chain: "test-chain"}}
-	must.SliceContainsAll(t, req.chainList(), expectedChains)
-
-	// Add a rule on a different chain but same table.
-	req.addRule(&rule{table: "test-table", chain: "mock-chain"})
-	must.Size(t, 2, req.rules, must.Sprint("expected 2 rule entries"))
-	expectedChains = append(expectedChains, &chain{table: "test-table", chain: "mock-chain"})
-	must.SliceContainsAll(t, req.chainList(), expectedChains)
-
-	// Add a rule on a different table and but same chain name.
-	req.addRule(&rule{table: "mock-table", chain: "mock-chain"})
-	must.Size(t, 3, req.rules, must.Sprint("expected 3 rule entries"))
-	expectedChains = append(expectedChains, &chain{table: "mock-table", chain: "mock-chain"})
-	must.SliceContainsAll(t, req.chainList(), expectedChains)
-
-	// Add a rule on an existing table and chain.
-	req.addRule(&rule{table: "test-table", chain: "test-chain", position: 1})
-	must.Size(t, 3, req.rules, must.Sprint("expected 3 rule entry"))
-	must.SliceContainsAll(t, req.chainList(), expectedChains)
-}
-
-func Test_request_teardown(t *testing.T) {
+func Test_request_removalInstructions(t *testing.T) {
 	req := newRequest()
 	expectedTeardown := make(Rules, 0)
 
 	// Start with an empty request.
-	must.Empty(t, req.teardown())
+	must.Empty(t, req.removalInstructions())
 
 	// Add a chain entry.
 	req.chains.Insert(&chain{table: "test-table", chain: "test-chain"})
 	must.Size(t, 1, req.chains)
 
 	// No teardown entries should be provided from chains.
-	must.Empty(t, req.teardown())
+	must.Empty(t, req.removalInstructions())
 
 	// Add a rule entry.
 	req.addRule(&rule{table: "test-table", chain: "test-chain"})
 	must.Size(t, 1, req.rules)
 
 	// Rule is not marked as teardown so no entries should be returned.
-	must.Empty(t, req.teardown())
+	must.Empty(t, req.removalInstructions())
 
-	// Add a rule entry marked as teardown.
-	req.addRule(&rule{table: "mock-table", chain: "test-chain", teardown: true})
+	// Add a rule entry marked as removable.
+	req.addRule(&rule{table: "mock-table", chain: "test-chain", removable: true})
 	must.Size(t, 2, req.rules)
 	expectedTeardown = append(expectedTeardown, []string{"mock-table", "test-chain"})
-	must.SliceContainsAll(t, expectedTeardown, req.teardown())
+	must.SliceContainsAll(t, expectedTeardown, req.removalInstructions())
 
-	// Add another rule entry marked as teardown.
-	req.addRule(&rule{table: "mock-table", chain: "mock-chain", teardown: true})
+	// Add another rule entry marked as removable.
+	req.addRule(&rule{table: "mock-table", chain: "mock-chain", removable: true})
 	must.Size(t, 3, req.rules)
 	expectedTeardown = append(expectedTeardown, []string{"mock-table", "mock-chain"})
-	must.SliceContainsAll(t, expectedTeardown, req.teardown())
+	must.SliceContainsAll(t, expectedTeardown, req.removalInstructions())
+}
+
+func Test_request_sortedRules(t *testing.T) {
+	list := make([]*rule, 50)
+	for i := range len(list) {
+		list[i] = &rule{
+			table: "test-table",
+			chain: "test-chain",
+			spec:  []string{fmt.Sprintf("rule-%d", i)},
+		}
+	}
+	req := newRequest()
+	req.addRule(list...)
+
+	must.Eq(t, list, req.sortedRules())
+}
+
+func Test_request_sortedChains(t *testing.T) {
+	list := make([]*chain, 50)
+	for i := range len(list) {
+		list[i] = &chain{
+			table: "test-table",
+			chain: fmt.Sprintf("test-chain-%d", i),
+		}
+	}
+	req := newRequest()
+	req.addChain(list...)
+
+	must.Eq(t, list, req.sortedChains())
 }

--- a/net/filter/iptables/request_test.go
+++ b/net/filter/iptables/request_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -25,20 +25,20 @@ func Test_request_removalInstructions(t *testing.T) {
 	must.Empty(t, req.removalInstructions())
 
 	// Add a rule entry.
-	req.addRule(&rule{table: "test-table", chain: "test-chain"})
+	req.rules.Insert(&rule{table: "test-table", chain: "test-chain"})
 	must.Size(t, 1, req.rules)
 
 	// Rule is not marked as teardown so no entries should be returned.
 	must.Empty(t, req.removalInstructions())
 
 	// Add a rule entry marked as removable.
-	req.addRule(&rule{table: "mock-table", chain: "test-chain", removable: true})
+	req.rules.Insert(&rule{table: "mock-table", chain: "test-chain", removable: true})
 	must.Size(t, 2, req.rules)
 	expectedTeardown = append(expectedTeardown, []string{"mock-table", "test-chain"})
 	must.SliceContainsAll(t, expectedTeardown, req.removalInstructions())
 
 	// Add another rule entry marked as removable.
-	req.addRule(&rule{table: "mock-table", chain: "mock-chain", removable: true})
+	req.rules.Insert(&rule{table: "mock-table", chain: "mock-chain", removable: true})
 	must.Size(t, 3, req.rules)
 	expectedTeardown = append(expectedTeardown, []string{"mock-table", "mock-chain"})
 	must.SliceContainsAll(t, expectedTeardown, req.removalInstructions())
@@ -54,9 +54,9 @@ func Test_request_sortedRules(t *testing.T) {
 		}
 	}
 	req := newRequest()
-	req.addRule(list...)
+	req.rules.InsertSlice(list)
 
-	must.Eq(t, list, req.sortedRules())
+	must.Eq(t, list, req.rules.Slice())
 }
 
 func Test_request_sortedChains(t *testing.T) {
@@ -68,7 +68,7 @@ func Test_request_sortedChains(t *testing.T) {
 		}
 	}
 	req := newRequest()
-	req.addChain(list...)
+	req.chains.InsertSlice(list)
 
-	must.Eq(t, list, req.sortedChains())
+	must.Eq(t, list, req.chains.Slice())
 }

--- a/net/filter/iptables/rules.go
+++ b/net/filter/iptables/rules.go
@@ -1,0 +1,111 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-set/v3"
+)
+
+type Rules [][]string
+
+// Empty returns if collection is empty.
+func (r Rules) Empty() bool {
+	return len(r) == 0
+}
+
+// rules converts the raw slice into a collection of rules.
+func (r Rules) rules() set.Collection[*rule] {
+	result := set.NewHashSet[*rule](0)
+	for _, entry := range r {
+		if len(entry) < 3 {
+			// invalid rule so skip.
+			continue
+		}
+		result.Insert(&rule{
+			table: entry[0],
+			chain: entry[1],
+			spec:  entry[2:],
+		})
+	}
+
+	return result
+}
+
+// chain represents an iptables chain.
+type chain struct {
+	table string // table name
+	chain string // chain name
+	stamp uint   // sorting value for collections
+}
+
+// setStamp sets the stamp value on the chain.
+func (c *chain) setStamp(stamp uint) {
+	c.stamp = stamp
+}
+
+// Equal returns if the chains are equal.
+func (c *chain) Equal(rhs *chain) bool {
+	if c == nil || rhs == nil {
+		return c == rhs
+	}
+
+	return c.table == rhs.table &&
+		c.chain == rhs.chain
+}
+
+// Hash returns a unique string for the chain.
+func (c *chain) Hash() string {
+	return c.table + c.chain
+}
+
+// rule represents an iptables rule.
+type rule struct {
+	table    string   // table name
+	chain    string   // chain name
+	position int      // position of the rule if it should be inserted
+	spec     []string // rule specification
+	teardown bool     // rule should be included in teardown list
+	stamp    uint     // sorting value for collections
+}
+
+// setStamp sets the stamp value on the rule.
+func (r *rule) setStamp(stamp uint) {
+	r.stamp = stamp
+}
+
+// Equal returns if the rules are equal.
+func (r *rule) Equal(rhs *rule) bool {
+	if r == nil || rhs == nil {
+		return r == rhs
+	}
+
+	return r.table == rhs.table &&
+		r.chain == rhs.chain &&
+		r.position == rhs.position &&
+		slices.Equal(r.spec, rhs.spec)
+}
+
+// Hash returns a unique string for the rule.
+func (r *rule) Hash() string {
+	return fmt.Sprintf("%s%s%s", r.table, r.chain, strings.Join(r.spec, ""))
+}
+
+// String returns a string representation of the rule.
+func (r *rule) String() string {
+	return fmt.Sprintf("-A %s %s", r.chain, strings.Join(r.spec, " "))
+}
+
+// slice converts the rule into a string slice.
+func (r *rule) slice() []string {
+	return append([]string{r.table, r.chain}, r.spec...)
+}
+
+// mkchain builds a chain from the rule.
+func (r *rule) mkchain() *chain {
+	return &chain{table: r.table, chain: r.chain}
+}

--- a/net/filter/iptables/rules.go
+++ b/net/filter/iptables/rules.go
@@ -4,6 +4,7 @@
 package iptables
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -36,6 +37,15 @@ func (r Rules) rules() set.Collection[*rule] {
 	return result
 }
 
+// chains is a slice of chain pointers.
+type chains []*chain
+
+// sort sorts the chain slice by the stamp value.
+func (c chains) sort() chains {
+	slices.SortFunc(c, func(a, b *chain) int { return cmp.Compare(a.stamp, b.stamp) })
+	return c
+}
+
 // chain represents an iptables chain.
 type chain struct {
 	table string // table name
@@ -63,14 +73,34 @@ func (c *chain) Hash() string {
 	return c.table + c.chain
 }
 
+// rules is a slice of rule pointers.
+type rules []*rule
+
+// sort sorts the rule slice by the stamp value.
+func (r rules) sort() rules {
+	slices.SortFunc(r, func(a, b *rule) int { return cmp.Compare(a.stamp, b.stamp) })
+	return r
+}
+
+// removables returns all rules marked as removable.
+func (r rules) removables() rules {
+	return slices.Collect(func(yield func(*rule) bool) {
+		for _, rule := range r {
+			if rule.removable && !yield(rule) {
+				return
+			}
+		}
+	})
+}
+
 // rule represents an iptables rule.
 type rule struct {
-	table    string   // table name
-	chain    string   // chain name
-	position int      // position of the rule if it should be inserted
-	spec     []string // rule specification
-	teardown bool     // rule should be included in teardown list
-	stamp    uint     // sorting value for collections
+	table     string   // table name.
+	chain     string   // chain name.
+	position  int      // position of the rule if it should be inserted.
+	spec      []string // rule specification.
+	removable bool     // rule should be removed during teardown.
+	stamp     uint     // sorting value for collections.
 }
 
 // setStamp sets the stamp value on the rule.

--- a/net/filter/iptables/rules.go
+++ b/net/filter/iptables/rules.go
@@ -23,15 +23,18 @@ func (r Rules) Empty() bool {
 func (r Rules) rules() set.Collection[*rule] {
 	result := set.NewHashSet[*rule](0)
 	for _, entry := range r {
-		if len(entry) < 3 {
-			// invalid rule so skip.
-			continue
+		var newRule *rule
+		switch len(entry) {
+		case 0:
+			newRule = new(rule)
+		case 1:
+			newRule = &rule{table: entry[0]}
+		case 2:
+			newRule = &rule{table: entry[0], chain: entry[1]}
+		default:
+			newRule = &rule{table: entry[0], chain: entry[1], spec: entry[2:]}
 		}
-		result.Insert(&rule{
-			table: entry[0],
-			chain: entry[1],
-			spec:  entry[2:],
-		})
+		result.Insert(newRule)
 	}
 
 	return result

--- a/net/filter/iptables/rules.go
+++ b/net/filter/iptables/rules.go
@@ -54,7 +54,7 @@ func newChains(fn stampFn) *chains {
 	}
 }
 
-// chains is a slice of chain pointers.
+// chains is a collection of chain pointers.
 type chains struct {
 	*set.HashSet[*chain, string]
 	stampFn
@@ -134,7 +134,7 @@ func newRules(fn stampFn) *rules {
 	}
 }
 
-// rules is a slice of rule pointers.
+// rules is a collection of rule pointers.
 type rules struct {
 	*set.HashSet[*rule, string]
 	stampFn

--- a/net/filter/iptables/rules.go
+++ b/net/filter/iptables/rules.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -37,13 +37,65 @@ func (r Rules) rules() set.Collection[*rule] {
 	return result
 }
 
-// chains is a slice of chain pointers.
-type chains []*chain
+// stampFn is the signature for a stamping function.
+type stampFn func(stampable)
 
-// sort sorts the chain slice by the stamp value.
-func (c chains) sort() chains {
-	slices.SortFunc(c, func(a, b *chain) int { return cmp.Compare(a.stamp, b.stamp) })
-	return c
+// stampable describes a type that can be stamped.
+type stampable interface {
+	setStamp(uint)
+}
+
+// newChains creates a new chains collection with a stamping
+// function to stamp chains.
+func newChains(fn stampFn) *chains {
+	return &chains{
+		HashSet: set.NewHashSet[*chain](0),
+		stampFn: fn,
+	}
+}
+
+// chains is a slice of chain pointers.
+type chains struct {
+	*set.HashSet[*chain, string]
+	stampFn
+}
+
+// Insert inserts a chain into the collection.
+func (c *chains) Insert(item *chain) bool {
+	if c.stampFn != nil {
+		c.stampFn(item)
+	}
+
+	return c.HashSet.Insert(item)
+}
+
+// InsertSlice inserts a chain slice into the collection.
+func (c *chains) InsertSlice(items []*chain) bool {
+	if c.stampFn != nil {
+		for _, i := range items {
+			c.stampFn(i)
+		}
+	}
+
+	return c.HashSet.InsertSlice(items)
+}
+
+// InsertSet inserts a chain set into the collection.
+func (c *chains) InsertSet(items set.Collection[*chain]) bool {
+	if c.stampFn != nil {
+		for _, i := range items.Slice() {
+			c.stampFn(i)
+		}
+	}
+
+	return c.HashSet.InsertSet(items)
+}
+
+// Slice returns the chain slice of the collection, sorted by stamp.
+func (c *chains) Slice() []*chain {
+	s := c.HashSet.Slice()
+	slices.SortFunc(s, func(a, b *chain) int { return cmp.Compare(a.stamp, b.stamp) })
+	return s
 }
 
 // chain represents an iptables chain.
@@ -73,24 +125,73 @@ func (c *chain) Hash() string {
 	return c.table + c.chain
 }
 
-// rules is a slice of rule pointers.
-type rules []*rule
+// newRules creates a new rules collection with a stamping
+// function to stamp rules.
+func newRules(fn stampFn) *rules {
+	return &rules{
+		HashSet: set.NewHashSet[*rule](0),
+		stampFn: fn,
+	}
+}
 
-// sort sorts the rule slice by the stamp value.
-func (r rules) sort() rules {
-	slices.SortFunc(r, func(a, b *rule) int { return cmp.Compare(a.stamp, b.stamp) })
-	return r
+// rules is a slice of rule pointers.
+type rules struct {
+	*set.HashSet[*rule, string]
+	stampFn
+}
+
+// Insert inserts a rule into the collection.
+func (r *rules) Insert(item *rule) bool {
+	if r.stampFn != nil {
+		r.stampFn(item)
+	}
+
+	return r.HashSet.Insert(item)
+}
+
+// InsertSlice inserts a rule slice into the collection.
+func (r *rules) InsertSlice(items []*rule) bool {
+	if r.stampFn != nil {
+		for _, i := range items {
+			r.stampFn(i)
+		}
+	}
+
+	return r.HashSet.InsertSlice(items)
+}
+
+// InsertSet inserts a rule set into the collection.
+func (r *rules) InsertSet(items set.Collection[*rule]) bool {
+	if r.stampFn != nil {
+		for _, i := range items.Slice() {
+			r.stampFn(i)
+		}
+	}
+
+	return r.HashSet.InsertSet(items)
+}
+
+// Slice returns the rule slice of the collection, sorted by stamp.
+func (r *rules) Slice() []*rule {
+	s := r.HashSet.Slice()
+	slices.SortFunc(s, func(a, b *rule) int { return cmp.Compare(a.stamp, b.stamp) })
+	return s
 }
 
 // removables returns all rules marked as removable.
-func (r rules) removables() rules {
-	return slices.Collect(func(yield func(*rule) bool) {
-		for _, rule := range r {
-			if rule.removable && !yield(rule) {
-				return
-			}
+func (r *rules) removables() *rules {
+	result := []*rule{}
+	for _, item := range r.Slice() {
+		if item.removable {
+			rm := *item
+			result = append(result, &rm)
 		}
-	})
+	}
+
+	return &rules{
+		HashSet: set.HashSetFrom(result),
+		stampFn: r.stampFn,
+	}
 }
 
 // rule represents an iptables rule.

--- a/net/filter/iptables/rules_test.go
+++ b/net/filter/iptables/rules_test.go
@@ -1,0 +1,205 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestRulesEmpty(t *testing.T) {
+	r := make(Rules, 0)
+
+	// Empty rules are empty.
+	must.Empty(t, r)
+
+	// Add an entry.
+	r = append(r, []string{"item"})
+
+	// Non-empty rules are not empty.
+	must.NotEmpty(t, r)
+}
+
+func TestRules_rules(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		Rules  Rules
+		result []*rule
+	}{
+		{
+			desc:  "ok",
+			Rules: Rules{{"table-name", "chain-name", "spec", "values"}},
+			result: []*rule{{
+				table: "table-name", chain: "chain-name",
+				spec: []string{"spec", "values"}}},
+		},
+		{
+			desc: "duplicaes",
+			Rules: Rules{
+				{"table-name", "chain-name", "spec", "values"},
+				{"mock-name", "chain-name", "spec", "values"},
+				{"table-name", "chain-name", "spec", "values"},
+			},
+			result: []*rule{
+				{
+					table: "table-name", chain: "chain-name",
+					spec: []string{"spec", "values"},
+				},
+				{
+					table: "mock-name", chain: "chain-name",
+					spec: []string{"spec", "values"},
+				},
+			},
+		},
+		{
+			desc:   "empty",
+			Rules:  Rules{{}},
+			result: []*rule{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := tc.Rules.rules()
+			must.SliceContainsAll(t, tc.result, res.Slice())
+		})
+	}
+}
+
+func Test_chain_Equal(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		lhs   *chain
+		rhs   *chain
+		equal bool
+	}{
+		{
+			desc:  "nil",
+			equal: true,
+		},
+		{
+			desc:  "empty",
+			lhs:   &chain{},
+			rhs:   &chain{},
+			equal: true,
+		},
+		{
+			desc: "lhs nil",
+			rhs:  &chain{},
+		},
+		{
+			desc: "rhs nil",
+			lhs:  &chain{},
+		},
+		{
+			desc:  "ok",
+			lhs:   &chain{table: "test-table", chain: "test-chain"},
+			rhs:   &chain{table: "test-table", chain: "test-chain"},
+			equal: true,
+		},
+		{
+			desc: "diff table",
+			lhs:  &chain{table: "mock-table", chain: "test-chain"},
+			rhs:  &chain{table: "test-table", chain: "test-chain"},
+		},
+		{
+			desc: "diff chain",
+			lhs:  &chain{table: "test-table", chain: "mock-chain"},
+			rhs:  &chain{table: "test-table", chain: "test-chain"},
+		},
+		{
+			desc: "diff table and chain",
+			lhs:  &chain{table: "test-table", chain: "mock-chain"},
+			rhs:  &chain{table: "mock-table", chain: "test-chain"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.equal {
+				must.Equal(t, tc.lhs, tc.rhs)
+			} else {
+				must.NotEqual(t, tc.lhs, tc.rhs)
+			}
+		})
+	}
+}
+
+func Test_rule_Equal(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		lhs   *rule
+		rhs   *rule
+		equal bool
+	}{
+		{
+			desc:  "nil",
+			equal: true,
+		},
+		{
+			desc:  "empty",
+			lhs:   &rule{},
+			rhs:   &rule{},
+			equal: true,
+		},
+		{
+			desc: "lhs nil",
+			rhs:  &rule{},
+		},
+		{
+			desc: "rhs nil",
+			lhs:  &rule{},
+		},
+		{
+			desc:  "ok table",
+			lhs:   &rule{table: "test-table"},
+			rhs:   &rule{table: "test-table"},
+			equal: true,
+		},
+		{
+			desc:  "ok chain",
+			lhs:   &rule{chain: "test-chain"},
+			rhs:   &rule{chain: "test-chain"},
+			equal: true,
+		},
+		{
+			desc:  "ok table chain",
+			lhs:   &rule{table: "test-table", chain: "test-chain"},
+			rhs:   &rule{table: "test-table", chain: "test-chain"},
+			equal: true,
+		},
+		{
+			desc:  "ok table chain spec",
+			lhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+			rhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+			equal: true,
+		},
+		{
+			desc: "diff table",
+			lhs:  &rule{table: "mock-table", chain: "test-chain", spec: []string{"test", "spec"}},
+			rhs:  &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+		},
+		{
+			desc: "diff chain",
+			lhs:  &rule{table: "test-table", chain: "mock-chain", spec: []string{"test", "spec"}},
+			rhs:  &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+		},
+		{
+			desc: "diff spec",
+			lhs:  &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+			rhs:  &rule{table: "test-table", chain: "test-chain", spec: []string{"mock", "spec"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.equal {
+				must.Equal(t, tc.rhs, tc.lhs)
+			} else {
+				must.NotEqual(t, tc.rhs, tc.lhs)
+			}
+		})
+	}
+}

--- a/net/filter/iptables/rules_test.go
+++ b/net/filter/iptables/rules_test.go
@@ -65,6 +65,12 @@ func TestRules_rules(t *testing.T) {
 			result: []*rule{
 				{
 					table: "table-name", chain: "chain-name",
+				},
+				{
+					table: "mock-name", chain: "chain-name",
+				},
+				{
+					table: "table-name", chain: "chain-name",
 					spec: []string{"spec", "values"},
 				},
 			},
@@ -72,7 +78,7 @@ func TestRules_rules(t *testing.T) {
 		{
 			desc:   "empty",
 			Rules:  Rules{{}},
-			result: []*rule{},
+			result: []*rule{{}},
 		},
 	}
 

--- a/net/filter/iptables/rules_test.go
+++ b/net/filter/iptables/rules_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -56,6 +56,20 @@ func TestRules_rules(t *testing.T) {
 			},
 		},
 		{
+			desc: "no spec",
+			Rules: Rules{
+				{"table-name", "chain-name"},
+				{"mock-name", "chain-name"},
+				{"table-name", "chain-name", "spec", "values"},
+			},
+			result: []*rule{
+				{
+					table: "table-name", chain: "chain-name",
+					spec: []string{"spec", "values"},
+				},
+			},
+		},
+		{
 			desc:   "empty",
 			Rules:  Rules{{}},
 			result: []*rule{},
@@ -82,12 +96,15 @@ func Test_chains_sort(t *testing.T) {
 
 	// Create a shuffled chains to sort.
 	p := rand.Perm(len(orig))
-	list := make(chains, len(orig))
+	mixed := make([]*chain, len(orig))
 	for i, j := range p {
-		list[i] = orig[j]
+		mixed[i] = orig[j]
 	}
 
-	must.Eq(t, orig, list.sort())
+	list := newChains(nil)
+	list.InsertSlice(mixed)
+
+	must.Eq(t, orig, list.Slice())
 }
 
 func Test_chain_Equal(t *testing.T) {
@@ -168,19 +185,21 @@ func Test_rules_sort(t *testing.T) {
 
 	// Create a shuffled rules to sort.
 	p := rand.Perm(len(orig))
-	list := make(rules, len(orig))
+	mixed := make([]*rule, len(orig))
 	for i, j := range p {
-		list[i] = orig[j]
+		mixed[i] = orig[j]
 	}
 
-	must.Eq(t, orig, list.sort())
+	list := newRules(nil)
+	list.InsertSlice(mixed)
+	must.Eq(t, orig, list.Slice())
 }
 
 func Test_rules_removables(t *testing.T) {
-	removables := make(rules, 16)
-	list := make(rules, 50)
-	for i := range len(list) {
-		list[i] = &rule{
+	removables := make([]*rule, 16)
+	src := make([]*rule, 50)
+	for i := range len(src) {
+		src[i] = &rule{
 			table: "test-table",
 			chain: "test-chain",
 			spec:  []string{fmt.Sprintf("rule-%d", i)},
@@ -188,12 +207,15 @@ func Test_rules_removables(t *testing.T) {
 		}
 
 		if i > 0 && i%3 == 0 {
-			list[i].removable = true
-			removables[(i/3)-1] = list[i]
+			src[i].removable = true
+			removables[(i/3)-1] = src[i]
 		}
 	}
 
-	must.Eq(t, removables, list.removables())
+	list := newRules(nil)
+	list.InsertSlice(src)
+
+	must.Eq(t, removables, list.removables().Slice())
 }
 
 func Test_rule_Equal(t *testing.T) {

--- a/net/filter/iptables/rules_test.go
+++ b/net/filter/iptables/rules_test.go
@@ -4,6 +4,8 @@
 package iptables
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/shoenig/test/must"
@@ -36,7 +38,7 @@ func TestRules_rules(t *testing.T) {
 				spec: []string{"spec", "values"}}},
 		},
 		{
-			desc: "duplicaes",
+			desc: "duplicates",
 			Rules: Rules{
 				{"table-name", "chain-name", "spec", "values"},
 				{"mock-name", "chain-name", "spec", "values"},
@@ -66,6 +68,26 @@ func TestRules_rules(t *testing.T) {
 			must.SliceContainsAll(t, tc.result, res.Slice())
 		})
 	}
+}
+
+func Test_chains_sort(t *testing.T) {
+	orig := make([]*chain, 50)
+	for i := range len(orig) {
+		orig[i] = &chain{
+			table: "test-table",
+			chain: fmt.Sprintf("test-chain-%d", i),
+			stamp: uint(i),
+		}
+	}
+
+	// Create a shuffled chains to sort.
+	p := rand.Perm(len(orig))
+	list := make(chains, len(orig))
+	for i, j := range p {
+		list[i] = orig[j]
+	}
+
+	must.Eq(t, orig, list.sort())
 }
 
 func Test_chain_Equal(t *testing.T) {
@@ -100,6 +122,12 @@ func Test_chain_Equal(t *testing.T) {
 			equal: true,
 		},
 		{
+			desc:  "ok stamped",
+			lhs:   &chain{table: "test-table", chain: "mock-chain", stamp: 2},
+			rhs:   &chain{table: "test-table", chain: "mock-chain", stamp: 3},
+			equal: true,
+		},
+		{
 			desc: "diff table",
 			lhs:  &chain{table: "mock-table", chain: "test-chain"},
 			rhs:  &chain{table: "test-table", chain: "test-chain"},
@@ -125,6 +153,47 @@ func Test_chain_Equal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_rules_sort(t *testing.T) {
+	orig := make([]*rule, 50)
+	for i := range len(orig) {
+		orig[i] = &rule{
+			table: "test-table",
+			chain: "test-chain",
+			spec:  []string{fmt.Sprintf("rule-%d", i)},
+			stamp: uint(i),
+		}
+	}
+
+	// Create a shuffled rules to sort.
+	p := rand.Perm(len(orig))
+	list := make(rules, len(orig))
+	for i, j := range p {
+		list[i] = orig[j]
+	}
+
+	must.Eq(t, orig, list.sort())
+}
+
+func Test_rules_removables(t *testing.T) {
+	removables := make(rules, 16)
+	list := make(rules, 50)
+	for i := range len(list) {
+		list[i] = &rule{
+			table: "test-table",
+			chain: "test-chain",
+			spec:  []string{fmt.Sprintf("rule-%d", i)},
+			stamp: uint(i),
+		}
+
+		if i > 0 && i%3 == 0 {
+			list[i].removable = true
+			removables[(i/3)-1] = list[i]
+		}
+	}
+
+	must.Eq(t, removables, list.removables())
 }
 
 func Test_rule_Equal(t *testing.T) {
@@ -174,6 +243,12 @@ func Test_rule_Equal(t *testing.T) {
 			desc:  "ok table chain spec",
 			lhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
 			rhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}},
+			equal: true,
+		},
+		{
+			desc:  "ok stamped",
+			lhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}, stamp: 0},
+			rhs:   &rule{table: "test-table", chain: "test-chain", spec: []string{"test", "spec"}, stamp: 1},
 			equal: true,
 		},
 		{

--- a/net/filter/iptables/tables.go
+++ b/net/filter/iptables/tables.go
@@ -52,9 +52,6 @@ func (n *virtTables) SetLogger(logger hclog.Logger) {
 // Configure configures iptables to enable port forwards based on the passed
 // resources and returns a collection of rules that can be used to remove
 // the configuration with Teardown function.
-// NOTE: When adding iptable rules that include IP addresses, include the
-// subnet mask. This is important for properly matching existing rules since
-// iptables adds the mask.
 func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInterfaceBridgeConfig, ip string) (rules *virtnet.FilterRemoval, err error) {
 	// Check that received values are suitable for configuration.
 	if res == nil {
@@ -266,9 +263,7 @@ func (n *virtTables) setup() error {
 	return nil
 }
 
-// add adds chains and rules to iptables. The request will be inspected
-// and compared to existing chains and rules defined in iptables and only
-// add what does not already exist.
+// add adds chains and rules to iptables.
 func (n *virtTables) add(req *request) error {
 	n.m.Lock()
 	defer n.m.Unlock()
@@ -305,9 +300,7 @@ func (n *virtTables) add(req *request) error {
 	return nil
 }
 
-// remove removes chains and rules from iptables. The request will be
-// inspected and compared to existing chains and rules defined in iptables
-// and only remove what does not already exist.
+// remove removes chains and rules from iptables.
 // NOTE: Removal errors are _not_ immediately fatal allowing as much to
 // be removed as possible. The errors will be collected and returned as
 // a multierror.
@@ -315,8 +308,8 @@ func (n *virtTables) remove(req *request) error {
 	n.m.Lock()
 	defer n.m.Unlock()
 
-	// Prune any rules that are on chains to be deleted since the
-	// rules will be cleared before the chain is deleted.
+	// ClearAndDeleteChain below will delete all the rules on the
+	// chain, so those rules don't need to be deleted individually.
 	req.rules.RemoveFunc(func(r *rule) bool {
 		return req.chains.Contains(r.mkchain())
 	})
@@ -327,7 +320,7 @@ func (n *virtTables) remove(req *request) error {
 	for _, r := range req.rules.Slice() {
 		if err := n.ipt.DeleteIfExists(r.table, r.chain, r.spec...); err != nil {
 			// NOTE: attempting to delete jump rules that don't exist will
-			// cause a does not exist error. Check error and ignore.
+			// cause a "does not exist" error. Check error and ignore.
 			if !isNotExistErr(err) {
 				mErr = multierror.Append(mErr, err)
 			}

--- a/net/filter/iptables/tables.go
+++ b/net/filter/iptables/tables.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -18,6 +18,8 @@ import (
 	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
+
+var errLoopbackNotEnabled = errors.New("loopback port forwarding not enabled")
 
 // virtTables implements the filter.Filter interface.
 type virtTables struct {
@@ -121,11 +123,11 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 			// Check if loopback port forwarding is even available before starting.
 			if !n.loopbackPortForwardsSupported(dstIface) {
 				n.logger.Error(fmt.Sprintf("loopback port forwarding requires kernel runtime configuration - net.ipv4.conf.%s.route_localnet=1", dstIface))
-				return nil, fmt.Errorf("loopback port forwarding not enabled for device - %s", dstIface)
+				return nil, fmt.Errorf("%w for device - %s", errLoopbackNotEnabled, dstIface)
 			}
 
 			// Add chains required for loopback port forwarding.
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: n.names.tables.NAT,
 					chain: n.names.chains.Nomad.Output,
@@ -134,10 +136,10 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 					table: n.names.tables.NAT,
 					chain: n.names.chains.Nomad.Postrouting,
 				},
-			}...)
+			})
 
 			// Add the rules.
-			req.addRule([]*rule{
+			req.rules.InsertSlice([]*rule{
 				// Jump rules for the new chains.
 				{
 					table:    n.names.tables.NAT,
@@ -167,10 +169,10 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 						"--dport", strconv.Itoa(reservedPort.Value), "-j", "DNAT", "--to-destination",
 						fmt.Sprintf("%s:%d", ip, reservedPort.To)},
 				},
-			}...)
+			})
 		} else {
 			// Add prerouting and filtering rule to enable the forward.
-			req.addRule([]*rule{
+			req.rules.InsertSlice([]*rule{
 				{
 					table:     n.names.tables.NAT,
 					chain:     n.names.chains.Nomad.Prerouting,
@@ -186,7 +188,7 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 					spec: []string{"-d", ip, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
 						"--dport", strconv.Itoa(reservedPort.To), "-j", "ACCEPT"},
 				},
-			}...)
+			})
 		}
 	}
 
@@ -215,7 +217,7 @@ func (n *virtTables) Teardown(removal *virtnet.FilterRemoval) error {
 		return fmt.Errorf("invalid teardown data, cannot remove iptables rules")
 	}
 	req := newRequest()
-	req.addRule(rules.rules().Slice()...)
+	req.rules.InsertSet(rules.rules())
 
 	return n.remove(req)
 }
@@ -230,7 +232,7 @@ func (n *virtTables) setup() error {
 	req := newRequest()
 
 	// Add the custom NAT and filter chains.
-	req.addChain([]*chain{
+	req.chains.InsertSlice([]*chain{
 		{
 			table: n.names.tables.NAT,
 			chain: n.names.chains.Nomad.Prerouting,
@@ -239,9 +241,9 @@ func (n *virtTables) setup() error {
 			table: n.names.tables.Filter,
 			chain: n.names.chains.Nomad.Forward,
 		},
-	}...)
+	})
 	// Add the jump rules to the custom chains.
-	req.addRule([]*rule{
+	req.rules.InsertSlice([]*rule{
 		{
 			table:    n.names.tables.NAT,
 			chain:    n.names.chains.Prerouting,
@@ -254,7 +256,7 @@ func (n *virtTables) setup() error {
 			position: 1,
 			spec:     []string{"-j", n.names.chains.Nomad.Forward},
 		},
-	}...)
+	})
 
 	// Apply any updates that are required.
 	if err := n.add(req); err != nil {
@@ -272,7 +274,7 @@ func (n *virtTables) add(req *request) error {
 	defer n.m.Unlock()
 
 	// Start with creating any needed chains.
-	for _, c := range req.sortedChains() {
+	for _, c := range req.chains.Slice() {
 		exists, err := n.ipt.ChainExists(c.table, c.chain)
 		if err != nil {
 			return fmt.Errorf("failed to check chain existence: %w", err)
@@ -287,7 +289,7 @@ func (n *virtTables) add(req *request) error {
 
 	// Now add any rules that remain. If a position is defined, then the rule
 	// is inserted, otherwise it is appended.
-	for _, r := range req.sortedRules() {
+	for _, r := range req.rules.Slice() {
 		var err error
 		if r.position > 0 {
 			err = n.ipt.InsertUnique(r.table, r.chain, r.position, r.spec...)
@@ -322,7 +324,7 @@ func (n *virtTables) remove(req *request) error {
 	var mErr *multierror.Error
 
 	// Remove rules in the request.
-	for _, r := range req.sortedRules() {
+	for _, r := range req.rules.Slice() {
 		if err := n.ipt.DeleteIfExists(r.table, r.chain, r.spec...); err != nil {
 			// NOTE: attempting to delete jump rules that don't exist will
 			// cause a does not exist error. Check error and ignore.
@@ -333,7 +335,7 @@ func (n *virtTables) remove(req *request) error {
 	}
 
 	// Remove chains in the request.
-	for _, c := range req.sortedChains() {
+	for _, c := range req.chains.Slice() {
 		// Clear and delete the chain. This function will check that
 		// the chain exists so we don't need to do that here.
 		if err := n.ipt.ClearAndDeleteChain(c.table, c.chain); err != nil {
@@ -387,8 +389,6 @@ func getInterfaceByIP(ip net.IP) (string, error) {
 					if iip.Equal(ip) {
 						return iface.Name, nil
 					}
-				} else {
-					continue
 				}
 			}
 		}

--- a/net/filter/iptables/tables.go
+++ b/net/filter/iptables/tables.go
@@ -322,6 +322,7 @@ func (n *virtTables) remove(req *request) error {
 			// NOTE: attempting to delete jump rules that don't exist will
 			// cause a "does not exist" error. Check error and ignore.
 			if !isNotExistErr(err) {
+				n.logger.Error("failed to delete iptables rule", "error", err, "rule", *r)
 				mErr = multierror.Append(mErr, err)
 			}
 		}
@@ -332,6 +333,7 @@ func (n *virtTables) remove(req *request) error {
 		// Clear and delete the chain. This function will check that
 		// the chain exists so we don't need to do that here.
 		if err := n.ipt.ClearAndDeleteChain(c.table, c.chain); err != nil {
+			n.logger.Error("failed to delete iptables chain", "error", err, "chain", *c)
 			mErr = multierror.Append(mErr, err)
 		}
 	}

--- a/net/filter/iptables/tables.go
+++ b/net/filter/iptables/tables.go
@@ -9,14 +9,12 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v3"
 	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
@@ -42,6 +40,11 @@ type virtTables struct {
 	// routingIngerfaceByIPGetter is the function that queries the host using
 	// the passed IP address and identifies the interface used to reach it.
 	routingInterfaceByIPGetter
+}
+
+// SetLogger sets the logger used.
+func (n *virtTables) SetLogger(logger hclog.Logger) {
+	n.logger = logger
 }
 
 // Configure configures iptables to enable port forwards based on the passed
@@ -72,12 +75,6 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 	// Create a new request to build up the desired changes.
 	req := newRequest()
 
-	// Parse the address to get the address with the mask included.
-	_, maskedTaskIP, err := parseAddr(ip)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse task IP address: %w", err)
-	}
-
 	// Iterate the ports configured within the network interface and pull these
 	// from the task allocated ports.
 	for _, port := range cfg.Ports {
@@ -101,7 +98,7 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 		}
 
 		// Parse the host IP so we can determine if it is a loopback address.
-		hostIP, maskedHostIP, err := parseAddr(reservedPort.HostIP)
+		hostIP, err := netip.ParseAddr(reservedPort.HostIP)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse host IP address: %w", err)
 		}
@@ -128,7 +125,7 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 			}
 
 			// Add chains required for loopback port forwarding.
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: n.names.tables.NAT,
 					chain: n.names.chains.Nomad.Output,
@@ -137,10 +134,10 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 					table: n.names.tables.NAT,
 					chain: n.names.chains.Nomad.Postrouting,
 				},
-			})
+			}...)
 
 			// Add the rules.
-			req.addRules([]*rule{
+			req.addRule([]*rule{
 				// Jump rules for the new chains.
 				{
 					table:    n.names.tables.NAT,
@@ -163,33 +160,33 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 				},
 				// Enable the actual forward.
 				{
-					table:    n.names.tables.NAT,
-					chain:    n.names.chains.Nomad.Output,
-					teardown: true,
-					spec: []string{"-s", maskedHostIP, "-o", iface, "-p", "tcp", "-m", "tcp",
+					table:     n.names.tables.NAT,
+					chain:     n.names.chains.Nomad.Output,
+					removable: true,
+					spec: []string{"-s", reservedPort.HostIP, "-o", iface, "-p", "tcp", "-m", "tcp",
 						"--dport", strconv.Itoa(reservedPort.Value), "-j", "DNAT", "--to-destination",
 						fmt.Sprintf("%s:%d", ip, reservedPort.To)},
 				},
-			})
+			}...)
 		} else {
 			// Add prerouting and filtering rule to enable the forward.
-			req.addRules([]*rule{
+			req.addRule([]*rule{
 				{
-					table:    n.names.tables.NAT,
-					chain:    n.names.chains.Nomad.Prerouting,
-					teardown: true,
-					spec: []string{"-d", maskedHostIP, "-i", iface, "-p", "tcp", "-m", "tcp",
+					table:     n.names.tables.NAT,
+					chain:     n.names.chains.Nomad.Prerouting,
+					removable: true,
+					spec: []string{"-d", reservedPort.HostIP, "-i", iface, "-p", "tcp", "-m", "tcp",
 						"--dport", strconv.Itoa(reservedPort.Value), "-j", "DNAT", "--to-destination",
 						fmt.Sprintf("%s:%d", ip, reservedPort.To)},
 				},
 				{
-					table:    n.names.tables.Filter,
-					chain:    n.names.chains.Nomad.Forward,
-					teardown: true,
-					spec: []string{"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+					table:     n.names.tables.Filter,
+					chain:     n.names.chains.Nomad.Forward,
+					removable: true,
+					spec: []string{"-d", ip, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
 						"--dport", strconv.Itoa(reservedPort.To), "-j", "ACCEPT"},
 				},
-			})
+			}...)
 		}
 	}
 
@@ -199,7 +196,7 @@ func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInter
 
 	return &virtnet.FilterRemoval{
 		Name: removalName,
-		Data: req.teardown(),
+		Data: req.removalInstructions(),
 	}, nil
 }
 
@@ -218,7 +215,7 @@ func (n *virtTables) Teardown(removal *virtnet.FilterRemoval) error {
 		return fmt.Errorf("invalid teardown data, cannot remove iptables rules")
 	}
 	req := newRequest()
-	req.addRules(rules.rules().Slice())
+	req.addRule(rules.rules().Slice()...)
 
 	return n.remove(req)
 }
@@ -233,7 +230,7 @@ func (n *virtTables) setup() error {
 	req := newRequest()
 
 	// Add the custom NAT and filter chains.
-	req.addChains([]*chain{
+	req.addChain([]*chain{
 		{
 			table: n.names.tables.NAT,
 			chain: n.names.chains.Nomad.Prerouting,
@@ -242,9 +239,9 @@ func (n *virtTables) setup() error {
 			table: n.names.tables.Filter,
 			chain: n.names.chains.Nomad.Forward,
 		},
-	})
+	}...)
 	// Add the jump rules to the custom chains.
-	req.addRules([]*rule{
+	req.addRule([]*rule{
 		{
 			table:    n.names.tables.NAT,
 			chain:    n.names.chains.Prerouting,
@@ -257,7 +254,7 @@ func (n *virtTables) setup() error {
 			position: 1,
 			spec:     []string{"-j", n.names.chains.Nomad.Forward},
 		},
-	})
+	}...)
 
 	// Apply any updates that are required.
 	if err := n.add(req); err != nil {
@@ -274,27 +271,17 @@ func (n *virtTables) add(req *request) error {
 	n.m.Lock()
 	defer n.m.Unlock()
 
-	// First collect the existing lists of chains and rules for
-	// the entries in the request.
-	chainLists, ruleLists, err := n.buildLists(req)
-	if err != nil {
-		return err
-	}
-
-	// Prune any chains that already exist.
-	req.chains.RemoveFunc(func(c *chain) bool {
-		return chainLists.Contains(c)
-	})
-
-	// Prune any rules that already exist.
-	req.rules.RemoveFunc(func(r *rule) bool {
-		return ruleLists.Contains(r)
-	})
-
 	// Start with creating any needed chains.
 	for _, c := range req.sortedChains() {
-		if err := n.ipt.NewChain(c.table, c.chain); err != nil {
-			return fmt.Errorf("failed to create new chain: %w", err)
+		exists, err := n.ipt.ChainExists(c.table, c.chain)
+		if err != nil {
+			return fmt.Errorf("failed to check chain existence: %w", err)
+		}
+
+		if !exists {
+			if err := n.ipt.NewChain(c.table, c.chain); err != nil {
+				return fmt.Errorf("failed to create new chain: %w", err)
+			}
 		}
 	}
 
@@ -303,9 +290,9 @@ func (n *virtTables) add(req *request) error {
 	for _, r := range req.sortedRules() {
 		var err error
 		if r.position > 0 {
-			err = n.ipt.Insert(r.table, r.chain, r.position, r.spec...)
+			err = n.ipt.InsertUnique(r.table, r.chain, r.position, r.spec...)
 		} else {
-			err = n.ipt.Append(r.table, r.chain, r.spec...)
+			err = n.ipt.AppendUnique(r.table, r.chain, r.spec...)
 		}
 
 		if err != nil {
@@ -326,85 +313,35 @@ func (n *virtTables) remove(req *request) error {
 	n.m.Lock()
 	defer n.m.Unlock()
 
-	chainLists, ruleLists, err := n.buildLists(req)
-	if err != nil {
-		return err
-	}
-
-	// Prune any chains that do not exist.
-	req.chains.RemoveFunc(func(c *chain) bool {
-		return !chainLists.Contains(c)
-	})
-
-	// Prune any rules that do not exist.
+	// Prune any rules that are on chains to be deleted since the
+	// rules will be cleared before the chain is deleted.
 	req.rules.RemoveFunc(func(r *rule) bool {
-		return !ruleLists.Contains(r)
+		return req.chains.Contains(r.mkchain())
 	})
 
 	var mErr *multierror.Error
 
-	// Start with removing rules.
+	// Remove rules in the request.
 	for _, r := range req.sortedRules() {
-		if err := n.ipt.Delete(r.table, r.chain, r.spec...); err != nil {
-			mErr = multierror.Append(mErr, err)
+		if err := n.ipt.DeleteIfExists(r.table, r.chain, r.spec...); err != nil {
+			// NOTE: attempting to delete jump rules that don't exist will
+			// cause a does not exist error. Check error and ignore.
+			if !isNotExistErr(err) {
+				mErr = multierror.Append(mErr, err)
+			}
 		}
 	}
 
-	// Now remove any chains.
+	// Remove chains in the request.
 	for _, c := range req.sortedChains() {
-		// First clear the chain.
-		if err := n.ipt.ClearChain(c.table, c.chain); err != nil {
-			mErr = multierror.Append(mErr, err)
-			continue
-		}
-
-		// Now delete the chain.
-		if err := n.ipt.DeleteChain(c.table, c.chain); err != nil {
+		// Clear and delete the chain. This function will check that
+		// the chain exists so we don't need to do that here.
+		if err := n.ipt.ClearAndDeleteChain(c.table, c.chain); err != nil {
 			mErr = multierror.Append(mErr, err)
 		}
 	}
 
 	return mErr.ErrorOrNil()
-}
-
-// buildLists gathers lists of existing chains on tables and existing rules on chains that
-// are relevant to the request.
-func (n *virtTables) buildLists(req *request) (chainLists set.Collection[*chain], ruleLists set.Collection[*rule], err error) {
-	chainLists = set.NewHashSet[*chain](0)
-	for _, table := range req.tableList() {
-		list, err := n.ipt.ListChains(table)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to list chains in table %q: %w", table, err)
-		}
-		for _, item := range list {
-			chainLists.Insert(&chain{table: table, chain: item})
-		}
-	}
-
-	ruleLists = set.NewHashSet[*rule](0)
-	for _, c := range req.ruleChains() {
-		// If the chain doesn't exist, don't attempt to list
-		// it as it will just generate an error.
-		if !chainLists.Contains(c) {
-			continue
-		}
-
-		list, err := n.ipt.List(c.table, c.chain)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to list rules in chain %q on table %q: %w", c.table, c.chain, err)
-		}
-		for _, item := range list {
-			parts := strings.Split(item, " ")
-			r := &rule{
-				table: c.table,
-				chain: c.chain,
-				spec:  parts[slices.Index(parts, c.chain)+1:],
-			}
-			ruleLists.Insert(r)
-		}
-	}
-
-	return chainLists, ruleLists, nil
 }
 
 // loopbackPortForwardsSupported returns if the host has been configured for routing localnet packets.
@@ -442,6 +379,7 @@ func getInterfaceByIP(ip net.IP) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	for _, iface := range interfaces {
 		if addrs, err := iface.Addrs(); err == nil {
 			for _, addr := range addrs {
@@ -453,10 +391,9 @@ func getInterfaceByIP(ip net.IP) (string, error) {
 					continue
 				}
 			}
-		} else {
-			continue
 		}
 	}
+
 	return "", fmt.Errorf("failed to find interface for IP %q", ip.String())
 }
 
@@ -486,22 +423,4 @@ func getRoutingInterfaceByIP(ip string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to find interface for IP %q", ip)
-}
-
-// parseAddr will parse the given IP address and return back result along
-// with a formatted string of the address that includes the subnet mask.
-func parseAddr(ip string) (addr netip.Addr, maskedIP string, err error) {
-	addr, err = netip.ParseAddr(ip)
-	if err != nil {
-		return
-	}
-
-	maskedIP = ip
-	if addr.Is4() {
-		maskedIP += "/32"
-	} else if addr.Is6() {
-		maskedIP += "/128"
-	}
-
-	return
 }

--- a/net/filter/iptables/tables.go
+++ b/net/filter/iptables/tables.go
@@ -1,0 +1,507 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-set/v3"
+	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
+	"github.com/hashicorp/nomad/plugins/drivers"
+)
+
+// virtTables implements the filter.Filter interface.
+type virtTables struct {
+	logger hclog.Logger
+	ipt    IPTables
+	names  *names
+	m      sync.Mutex
+
+	// Everything below is used for testing.
+
+	// routeLocalnetTemplate is a template for creating the path to the kernel
+	// runtime configuration for device localnet routing.
+	routeLocalnetPathTemplate string
+
+	// interfaceByIPGetter is the function that queries the host using the
+	// passed IP address and identifies the interface it is assigned to. It is
+	// a field within the controller to aid testing.
+	interfaceByIPGetter
+
+	// routingIngerfaceByIPGetter is the function that queries the host using
+	// the passed IP address and identifies the interface used to reach it.
+	routingInterfaceByIPGetter
+}
+
+// Configure configures iptables to enable port forwards based on the passed
+// resources and returns a collection of rules that can be used to remove
+// the configuration with Teardown function.
+// NOTE: When adding iptable rules that include IP addresses, include the
+// subnet mask. This is important for properly matching existing rules since
+// iptables adds the mask.
+func (n *virtTables) Configure(res *drivers.Resources, cfg *virtnet.NetworkInterfaceBridgeConfig, ip string) (rules *virtnet.FilterRemoval, err error) {
+	// Check that received values are suitable for configuration.
+	if res == nil {
+		return nil, errors.New("cannot configure iptables, resources not provided")
+	}
+
+	if cfg == nil {
+		return nil, errors.New("cannot configure iptables, bridge config not provided")
+	}
+
+	// If the ports are nil, there's nothing to do.
+	if res.Ports == nil {
+		return &virtnet.FilterRemoval{Name: removalName}, nil
+	}
+
+	// Create lookup mapping for ip:interface-name, so we can cache reads of
+	// this and not have to perform the translation each time.
+	interfaceMapping := make(map[string]string)
+
+	// Create a new request to build up the desired changes.
+	req := newRequest()
+
+	// Parse the address to get the address with the mask included.
+	_, maskedTaskIP, err := parseAddr(ip)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse task IP address: %w", err)
+	}
+
+	// Iterate the ports configured within the network interface and pull these
+	// from the task allocated ports.
+	for _, port := range cfg.Ports {
+		reservedPort, ok := res.Ports.Get(port)
+		if !ok {
+			n.logger.Error("failed to find reserved port", "port", port)
+			continue
+		}
+
+		// Look into the mapping for the interface based on the host IP,
+		// otherwise perform the more expensive actual lookup by querying the
+		// host.
+		iface, ok := interfaceMapping[reservedPort.HostIP]
+		if !ok {
+			iface, err = n.interfaceByIPGetter(net.ParseIP(reservedPort.HostIP))
+			if err != nil {
+				return nil, fmt.Errorf("failed to identify IP interface: %w", err)
+			}
+
+			interfaceMapping[reservedPort.HostIP] = iface
+		}
+
+		// Parse the host IP so we can determine if it is a loopback address.
+		hostIP, maskedHostIP, err := parseAddr(reservedPort.HostIP)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse host IP address: %w", err)
+		}
+
+		// If the host IP provided is a loopback, it needs to be picked up on the
+		// output chain and redirected to the VM. This is a special case and which
+		// requires the host to be properly configured.
+		if hostIP.IsLoopback() {
+			// Find the interface that the destination address is attached.
+			dstIface, ok := interfaceMapping[ip]
+			if !ok {
+				dstIface, err = n.routingInterfaceByIPGetter(ip)
+				if err != nil {
+					return nil, fmt.Errorf("failed to identify IP interface: %w", err)
+				}
+
+				interfaceMapping[ip] = dstIface
+			}
+
+			// Check if loopback port forwarding is even available before starting.
+			if !n.loopbackPortForwardsSupported(dstIface) {
+				n.logger.Error(fmt.Sprintf("loopback port forwarding requires kernel runtime configuration - net.ipv4.conf.%s.route_localnet=1", dstIface))
+				return nil, fmt.Errorf("loopback port forwarding not enabled for device - %s", dstIface)
+			}
+
+			// Add chains required for loopback port forwarding.
+			req.addChains([]*chain{
+				{
+					table: n.names.tables.NAT,
+					chain: n.names.chains.Nomad.Output,
+				},
+				{
+					table: n.names.tables.NAT,
+					chain: n.names.chains.Nomad.Postrouting,
+				},
+			})
+
+			// Add the rules.
+			req.addRules([]*rule{
+				// Jump rules for the new chains.
+				{
+					table:    n.names.tables.NAT,
+					chain:    n.names.chains.Output,
+					position: 1,
+					spec:     []string{"-j", n.names.chains.Nomad.Output},
+				},
+				{
+					table:    n.names.tables.NAT,
+					chain:    n.names.chains.Postrouting,
+					position: 1,
+					spec:     []string{"-j", n.names.chains.Nomad.Postrouting},
+				},
+				// Allow forwarding from the loopback to the destination device.
+				{
+					table: n.names.tables.NAT,
+					chain: n.names.chains.Nomad.Postrouting,
+					spec: []string{"-o", dstIface, "-m", "addrtype", "--src-type", "LOCAL",
+						"--dst-type", "UNICAST", "-j", "MASQUERADE"},
+				},
+				// Enable the actual forward.
+				{
+					table:    n.names.tables.NAT,
+					chain:    n.names.chains.Nomad.Output,
+					teardown: true,
+					spec: []string{"-s", maskedHostIP, "-o", iface, "-p", "tcp", "-m", "tcp",
+						"--dport", strconv.Itoa(reservedPort.Value), "-j", "DNAT", "--to-destination",
+						fmt.Sprintf("%s:%d", ip, reservedPort.To)},
+				},
+			})
+		} else {
+			// Add prerouting and filtering rule to enable the forward.
+			req.addRules([]*rule{
+				{
+					table:    n.names.tables.NAT,
+					chain:    n.names.chains.Nomad.Prerouting,
+					teardown: true,
+					spec: []string{"-d", maskedHostIP, "-i", iface, "-p", "tcp", "-m", "tcp",
+						"--dport", strconv.Itoa(reservedPort.Value), "-j", "DNAT", "--to-destination",
+						fmt.Sprintf("%s:%d", ip, reservedPort.To)},
+				},
+				{
+					table:    n.names.tables.Filter,
+					chain:    n.names.chains.Nomad.Forward,
+					teardown: true,
+					spec: []string{"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+						"--dport", strconv.Itoa(reservedPort.To), "-j", "ACCEPT"},
+				},
+			})
+		}
+	}
+
+	if err := n.add(req); err != nil {
+		return nil, err
+	}
+
+	return &virtnet.FilterRemoval{
+		Name: removalName,
+		Data: req.teardown(),
+	}, nil
+}
+
+// Teardown removes rules from iptables.
+func (n *virtTables) Teardown(removal *virtnet.FilterRemoval) error {
+	// If there is no removal information then there
+	// is nothing to do.
+	if removal == nil || removal.Data == nil {
+		return nil
+	}
+
+	rules, ok := removal.Data.(Rules)
+	if !ok {
+		n.logger.Error("invalid teardown data received", "name", removal.Name,
+			"type", hclog.Fmt("%T", removal.Data))
+		return fmt.Errorf("invalid teardown data, cannot remove iptables rules")
+	}
+	req := newRequest()
+	req.addRules(rules.rules().Slice())
+
+	return n.remove(req)
+}
+
+// setup is responsible for ensuring the local host machine iptables
+// are configured with the chains and rules needed by the driver.
+//
+// On a new machine, this function creates the "NOMAD_VT_PRT" and "NOMAD_VT_FW"
+// chains. The "NOMAD_VT_PRT" chain then has a jump rule added to the "nat"
+// table; the "NOMAD_VT_FW" chain has a jump rule added to the "filter" table.
+func (n *virtTables) setup() error {
+	req := newRequest()
+
+	// Add the custom NAT and filter chains.
+	req.addChains([]*chain{
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Nomad.Prerouting,
+		},
+		{
+			table: n.names.tables.Filter,
+			chain: n.names.chains.Nomad.Forward,
+		},
+	})
+	// Add the jump rules to the custom chains.
+	req.addRules([]*rule{
+		{
+			table:    n.names.tables.NAT,
+			chain:    n.names.chains.Prerouting,
+			position: 1,
+			spec:     []string{"-j", n.names.chains.Nomad.Prerouting},
+		},
+		{
+			table:    n.names.tables.Filter,
+			chain:    n.names.chains.Forward,
+			position: 1,
+			spec:     []string{"-j", n.names.chains.Nomad.Forward},
+		},
+	})
+
+	// Apply any updates that are required.
+	if err := n.add(req); err != nil {
+		return fmt.Errorf("setup failure: %w", err)
+	}
+
+	return nil
+}
+
+// add adds chains and rules to iptables. The request will be inspected
+// and compared to existing chains and rules defined in iptables and only
+// add what does not already exist.
+func (n *virtTables) add(req *request) error {
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	// First collect the existing lists of chains and rules for
+	// the entries in the request.
+	chainLists, ruleLists, err := n.buildLists(req)
+	if err != nil {
+		return err
+	}
+
+	// Prune any chains that already exist.
+	req.chains.RemoveFunc(func(c *chain) bool {
+		return chainLists.Contains(c)
+	})
+
+	// Prune any rules that already exist.
+	req.rules.RemoveFunc(func(r *rule) bool {
+		return ruleLists.Contains(r)
+	})
+
+	// Start with creating any needed chains.
+	for _, c := range req.sortedChains() {
+		if err := n.ipt.NewChain(c.table, c.chain); err != nil {
+			return fmt.Errorf("failed to create new chain: %w", err)
+		}
+	}
+
+	// Now add any rules that remain. If a position is defined, then the rule
+	// is inserted, otherwise it is appended.
+	for _, r := range req.sortedRules() {
+		var err error
+		if r.position > 0 {
+			err = n.ipt.Insert(r.table, r.chain, r.position, r.spec...)
+		} else {
+			err = n.ipt.Append(r.table, r.chain, r.spec...)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to add rule: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// remove removes chains and rules from iptables. The request will be
+// inspected and compared to existing chains and rules defined in iptables
+// and only remove what does not already exist.
+// NOTE: Removal errors are _not_ immediately fatal allowing as much to
+// be removed as possible. The errors will be collected and returned as
+// a multierror.
+func (n *virtTables) remove(req *request) error {
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	chainLists, ruleLists, err := n.buildLists(req)
+	if err != nil {
+		return err
+	}
+
+	// Prune any chains that do not exist.
+	req.chains.RemoveFunc(func(c *chain) bool {
+		return !chainLists.Contains(c)
+	})
+
+	// Prune any rules that do not exist.
+	req.rules.RemoveFunc(func(r *rule) bool {
+		return !ruleLists.Contains(r)
+	})
+
+	var mErr *multierror.Error
+
+	// Start with removing rules.
+	for _, r := range req.sortedRules() {
+		if err := n.ipt.Delete(r.table, r.chain, r.spec...); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	// Now remove any chains.
+	for _, c := range req.sortedChains() {
+		// First clear the chain.
+		if err := n.ipt.ClearChain(c.table, c.chain); err != nil {
+			mErr = multierror.Append(mErr, err)
+			continue
+		}
+
+		// Now delete the chain.
+		if err := n.ipt.DeleteChain(c.table, c.chain); err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+// buildLists gathers lists of existing chains on tables and existing rules on chains that
+// are relevant to the request.
+func (n *virtTables) buildLists(req *request) (chainLists set.Collection[*chain], ruleLists set.Collection[*rule], err error) {
+	chainLists = set.NewHashSet[*chain](0)
+	for _, table := range req.tableList() {
+		list, err := n.ipt.ListChains(table)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list chains in table %q: %w", table, err)
+		}
+		for _, item := range list {
+			chainLists.Insert(&chain{table: table, chain: item})
+		}
+	}
+
+	ruleLists = set.NewHashSet[*rule](0)
+	for _, c := range req.ruleChains() {
+		// If the chain doesn't exist, don't attempt to list
+		// it as it will just generate an error.
+		if !chainLists.Contains(c) {
+			continue
+		}
+
+		list, err := n.ipt.List(c.table, c.chain)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list rules in chain %q on table %q: %w", c.table, c.chain, err)
+		}
+		for _, item := range list {
+			parts := strings.Split(item, " ")
+			r := &rule{
+				table: c.table,
+				chain: c.chain,
+				spec:  parts[slices.Index(parts, c.chain)+1:],
+			}
+			ruleLists.Insert(r)
+		}
+	}
+
+	return chainLists, ruleLists, nil
+}
+
+// loopbackPortForwardsSupported returns if the host has been configured for routing localnet packets.
+// NOTE: The global configuration overrides device specific configuration.
+func (n *virtTables) loopbackPortForwardsSupported(device string) bool {
+	for _, configName := range []string{routeLocalnetGlobalName, device} {
+		tmpl := n.routeLocalnetPathTemplate
+		if tmpl == "" {
+			tmpl = routeLocalnetPathTemplate
+		}
+
+		cfgPath := fmt.Sprintf(tmpl, configName)
+		content, err := os.ReadFile(cfgPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
+			n.logger.Error("read failed for device loopback support check", "path", cfgPath, "error", err)
+			return false
+		}
+
+		if strings.TrimSpace(string(content)) == "1" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getInterfaceByIP is a helper function which identifies which host network
+// interface the passed IP address is linked to.
+func getInterfaceByIP(ip net.IP) (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range interfaces {
+		if addrs, err := iface.Addrs(); err == nil {
+			for _, addr := range addrs {
+				if iip, _, err := net.ParseCIDR(addr.String()); err == nil {
+					if iip.Equal(ip) {
+						return iface.Name, nil
+					}
+				} else {
+					continue
+				}
+			}
+		} else {
+			continue
+		}
+	}
+	return "", fmt.Errorf("failed to find interface for IP %q", ip.String())
+}
+
+// getRoutingInterfaceByIP returns the name of the interface that can be used
+// to reach the provided address.
+func getRoutingInterfaceByIP(ip string) (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	checkAddr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range interfaces {
+		if addrs, err := iface.Addrs(); err == nil {
+			for _, addr := range addrs {
+				if prefix, err := netip.ParsePrefix(addr.String()); err == nil {
+					if prefix.Contains(checkAddr) {
+						return iface.Name, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find interface for IP %q", ip)
+}
+
+// parseAddr will parse the given IP address and return back result along
+// with a formatted string of the address that includes the subnet mask.
+func parseAddr(ip string) (addr netip.Addr, maskedIP string, err error) {
+	addr, err = netip.ParseAddr(ip)
+	if err != nil {
+		return
+	}
+
+	maskedIP = ip
+	if addr.Is4() {
+		maskedIP += "/32"
+	} else if addr.Is6() {
+		maskedIP += "/128"
+	}
+
+	return
+}

--- a/net/filter/iptables/tables_test.go
+++ b/net/filter/iptables/tables_test.go
@@ -1,0 +1,1370 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-set/v3"
+	"github.com/hashicorp/nomad-driver-virt/net/filter"
+	"github.com/hashicorp/nomad-driver-virt/testutil"
+	mock_iptables "github.com/hashicorp/nomad-driver-virt/testutil/mock/iptables"
+	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/shoenig/test/must"
+)
+
+// NOTE: Many of the tests in this file contain two versions: mock and direct.
+// The "mock" tests will utilize a mock iptables implementation to exercise the
+// implementation. The "direct" tests require being run as root and the iptables
+// command being available. The "direct" tests are built to be isolated and cleaned
+// up after being run, but they will make changes to iptables and no guarantees are
+// made about the resulting state. We just do our best. Good luck! \o/
+
+func Test_virtTables_Configure(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "192.168.44.22"
+			taskIP := "10.0.22.33"
+			maskedHostIP := "192.168.44.22/32"
+			maskedTaskIP := "10.0.22.33/32"
+			ifaceName := "test0"
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.ListChains{Table: "filter"},
+				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
+					"-d", maskedHostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222",
+					"-j", "DNAT", "--to-destination", taskIP + ":8000"}},
+				mock_iptables.Append{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
+					"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+					"--dport", "8000", "-j", "ACCEPT"}},
+				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
+					"-d", maskedHostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22223",
+					"-j", "DNAT", "--to-destination", taskIP + ":2222"}},
+				mock_iptables.Append{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
+					"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+					"--dport", "2222", "-j", "ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t,
+				WithIPTables(ipt),
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+			)
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+					{
+						Label:  "ssh",
+						To:     2222,
+						HostIP: hostIP,
+						Value:  22223,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http", "ssh"},
+			}
+
+			expected := [][]string{
+				{
+					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT", "--to-destination",
+					taskIP + ":8000",
+				},
+				{
+					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"state", "--state", "NEW", "-m", "tcp", "--dport", "8000", "-j", "ACCEPT",
+				},
+				{
+					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"tcp", "-m", "tcp", "--dport", "22223", "-j", "DNAT", "--to-destination",
+					taskIP + ":2222",
+				},
+				{
+					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"state", "--state", "NEW", "-m", "tcp", "--dport", "2222", "-j", "ACCEPT",
+				},
+			}
+
+			teardownRules, err := vt.Configure(resources, cfg, taskIP)
+			must.NoError(t, err)
+			must.Eq(t, expected, teardownRules.Data.(Rules))
+		})
+
+		t.Run("loopback", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "127.0.0.1"
+			taskIP := "10.0.22.33"
+			maskedHostIP := "127.0.0.1/32"
+
+			ifaceName := "testlo0"
+			dstIfaceName := "testbr0"
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Output},
+				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Postrouting},
+				mock_iptables.Insert{Table: "nat", Chain: "OUTPUT", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Output}},
+				mock_iptables.Insert{Table: "nat", Chain: "POSTROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Postrouting}},
+				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Postrouting, RuleSpec: []string{
+					"-o", dstIfaceName, "-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST", "-j", "MASQUERADE"}},
+				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Output, RuleSpec: []string{
+					"-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT",
+					"--to-destination", taskIP + ":8000"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t,
+				WithIPTables(ipt),
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+				WithRoutingInterfaceByIPGetter(func(string) (string, error) { return dstIfaceName, nil }),
+				WithRoutingLocalnetPathTemplate(enableLocalnetRouting(t, dstIfaceName)),
+			)
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http"},
+			}
+
+			expected := [][]string{
+				{
+					"nat", n.chains.Nomad.Output, "-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
+					"--dport", "22222", "-j", "DNAT", "--to-destination", taskIP + ":8000",
+				},
+			}
+
+			teardownRules, err := vt.Configure(resources, cfg, taskIP)
+			must.NoError(t, err)
+			must.Eq(t, expected, teardownRules.Data.(Rules))
+		})
+
+		t.Run("loopback not enabled", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "127.0.0.1"
+			taskIP := "10.0.22.33"
+			ifaceName := "testlo0"
+			dstIfaceName := "testbr0"
+
+			ipt := mock_iptables.New(t)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t,
+				WithIPTables(ipt),
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+				WithRoutingInterfaceByIPGetter(func(string) (string, error) { return dstIfaceName, nil }),
+			)
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http"},
+			}
+
+			_, err := vt.Configure(resources, cfg, taskIP)
+			must.ErrorContains(t, err, "loopback port forwarding not enabled")
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "192.168.44.22"
+			taskIP := "10.0.22.33"
+			maskedHostIP := "192.168.44.22/32"
+			maskedTaskIP := "10.0.22.33/32"
+
+			ifaceName := "test0"
+
+			vt, cleanup := TestNew(t,
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+			)
+			t.Cleanup(cleanup)
+
+			// Run setup so required chains exist.
+			must.NoError(t, vt.setup())
+
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+					{
+						Label:  "ssh",
+						To:     2222,
+						HostIP: hostIP,
+						Value:  22223,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http", "ssh"},
+			}
+
+			expected := [][]string{
+				{
+					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT", "--to-destination",
+					taskIP + ":8000",
+				},
+				{
+					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"state", "--state", "NEW", "-m", "tcp", "--dport", "8000", "-j", "ACCEPT",
+				},
+				{
+					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"tcp", "-m", "tcp", "--dport", "22223", "-j", "DNAT", "--to-destination",
+					taskIP + ":2222",
+				},
+				{
+					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"state", "--state", "NEW", "-m", "tcp", "--dport", "2222", "-j", "ACCEPT",
+				},
+			}
+
+			teardownRules, err := vt.Configure(resources, cfg, taskIP)
+			must.NoError(t, err)
+			must.Eq(t, expected, teardownRules.Data.(Rules))
+
+			// Check rules in iptables
+			natRules, err := vt.ipt.List("nat", n.chains.Nomad.Prerouting)
+			must.NoError(t, err)
+			filterRules, err := vt.ipt.List("filter", n.chains.Nomad.Forward)
+			must.NoError(t, err)
+
+			expectedNats := []string{
+				fmt.Sprintf("-A %s -d %s -i %s -p tcp -m tcp --dport 22222 -j DNAT --to-destination %s:8000", n.chains.Nomad.Prerouting, maskedHostIP, ifaceName, taskIP),
+				fmt.Sprintf("-A %s -d %s -i %s -p tcp -m tcp --dport 22223 -j DNAT --to-destination %s:2222", n.chains.Nomad.Prerouting, maskedHostIP, ifaceName, taskIP),
+			}
+
+			expectedFilters := []string{
+				fmt.Sprintf("-A %s -d %s -p tcp -m state --state NEW -m tcp --dport 8000 -j ACCEPT", n.chains.Nomad.Forward, maskedTaskIP),
+				fmt.Sprintf("-A %s -d %s -p tcp -m state --state NEW -m tcp --dport 2222 -j ACCEPT", n.chains.Nomad.Forward, maskedTaskIP),
+			}
+
+			must.SliceContainsSubset(t, natRules, expectedNats)
+			must.SliceContainsSubset(t, filterRules, expectedFilters)
+		})
+
+		t.Run("loopback", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "127.0.0.1"
+			taskIP := "10.0.22.33"
+			maskedHostIP := "127.0.0.1/32"
+
+			ifaceName := "testlo0"
+			dstIfaceName := "testbr0"
+
+			vt, _ := TestNew(t,
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+				WithRoutingInterfaceByIPGetter(func(string) (string, error) { return dstIfaceName, nil }),
+				WithRoutingLocalnetPathTemplate(enableLocalnetRouting(t, dstIfaceName)),
+			)
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http"},
+			}
+
+			expected := [][]string{
+				{
+					"nat", n.chains.Nomad.Output, "-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
+					"--dport", "22222", "-j", "DNAT", "--to-destination", taskIP + ":8000",
+				},
+			}
+
+			teardownRules, err := vt.Configure(resources, cfg, taskIP)
+			must.NoError(t, err)
+			must.Eq(t, expected, teardownRules.Data.(Rules))
+
+			natChains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			postRules, err := vt.ipt.List("nat", n.chains.Nomad.Postrouting)
+			must.NoError(t, err)
+			outRules, err := vt.ipt.List("nat", n.chains.Nomad.Output)
+			must.NoError(t, err)
+
+			expectedPostRules := []string{
+				fmt.Sprintf("-A %s -o %s -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE", n.chains.Nomad.Postrouting, dstIfaceName),
+			}
+			expectedOutRules := []string{
+				fmt.Sprintf("-A %s -s %s -o %s -p tcp -m tcp --dport 22222 -j DNAT --to-destination %s:8000", n.chains.Nomad.Output, maskedHostIP, ifaceName, taskIP),
+			}
+
+			must.SliceContainsSubset(t, natChains, []string{n.chains.Postrouting, n.chains.Output})
+			must.SliceContainsSubset(t, postRules, expectedPostRules)
+			must.SliceContainsSubset(t, outRules, expectedOutRules)
+		})
+
+		t.Run("with teardown", func(t *testing.T) {
+			n := TestNewNames()
+			hostIP := "192.168.44.22"
+			taskIP := "10.0.22.33"
+			maskedHostIP := "192.168.44.22/32"
+			maskedTaskIP := "10.0.22.33/32"
+
+			ifaceName := "test0"
+
+			vt, cleanup := TestNew(t,
+				WithNames(t, n),
+				WithInterfaceByIPGetter(func(net.IP) (string, error) { return ifaceName, nil }),
+			)
+			t.Cleanup(cleanup)
+
+			// Run setup so required chains exist.
+			must.NoError(t, vt.setup())
+
+			resources := &drivers.Resources{
+				Ports: &structs.AllocatedPorts{
+					{
+						Label:  "http",
+						To:     8000,
+						HostIP: hostIP,
+						Value:  22222,
+					},
+					{
+						Label:  "ssh",
+						To:     2222,
+						HostIP: hostIP,
+						Value:  22223,
+					},
+				},
+			}
+			cfg := &virtnet.NetworkInterfaceBridgeConfig{
+				Ports: []string{"http", "ssh"},
+			}
+
+			// Apply the updates.
+			teardownRules, err := vt.Configure(resources, cfg, taskIP)
+			must.NoError(t, err)
+
+			// Now remove the updates.
+			must.NoError(t, vt.Teardown(teardownRules))
+
+			// Check rules in iptables
+			natRules, err := vt.ipt.List("nat", n.chains.Nomad.Prerouting)
+			must.NoError(t, err)
+			filterRules, err := vt.ipt.List("filter", n.chains.Nomad.Forward)
+			must.NoError(t, err)
+
+			removedNats := []string{
+				fmt.Sprintf("-A %s -d %s -i %s -p tcp -m tcp --dport 22222 -j DNAT --to-destination %s:8000", n.chains.Nomad.Prerouting, maskedHostIP, ifaceName, taskIP),
+				fmt.Sprintf("-A %s -d %s -i %s -p tcp -m tcp --dport 22223 -j DNAT --to-destination %s:2222", n.chains.Nomad.Prerouting, maskedHostIP, ifaceName, taskIP),
+			}
+
+			removedFilters := []string{
+				fmt.Sprintf("-A %s -d %s -p tcp -m state --state NEW -m tcp --dport 8000 -j ACCEPT", n.chains.Nomad.Forward, maskedTaskIP),
+				fmt.Sprintf("-A %s -d %s -p tcp -m state --state NEW -m tcp --dport 2222 -j ACCEPT", n.chains.Nomad.Forward, maskedTaskIP),
+			}
+
+			for _, rn := range removedNats {
+				must.SliceNotContains(t, natRules, rn)
+			}
+
+			for _, rf := range removedFilters {
+				must.SliceNotContains(t, filterRules, rf)
+			}
+		})
+	})
+}
+
+func Test_virtTables_Teardown(t *testing.T) {
+	// This is currently a stub for Teardown tests, of which there are none. This
+	// is because the Teardown function currently just calls `remove` so there is
+	// nothing else to test. If/when that changes, this will no longer be a stub.
+}
+
+func Test_virtTables_setup(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		t.Run("not setup", func(t *testing.T) {
+			n := TestNewNames()
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING"}},
+				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD"}},
+				mock_iptables.List{Table: "nat", Chain: "PREROUTING"},
+				mock_iptables.List{Table: "filter", Chain: "FORWARD"},
+				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Prerouting},
+				mock_iptables.NewChain{Table: "filter", Chain: n.chains.Nomad.Forward},
+				mock_iptables.Insert{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
+				mock_iptables.Insert{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithNames(t, n), WithIPTables(ipt))
+			must.NoError(t, vt.setup())
+		})
+
+		t.Run("already setup", func(t *testing.T) {
+			n := TestNewNames()
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING"}},
+				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD"}},
+				mock_iptables.List{Table: "nat", Chain: "PREROUTING"},
+				mock_iptables.List{Table: "filter", Chain: "FORWARD"},
+				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Prerouting},
+				mock_iptables.NewChain{Table: "filter", Chain: n.chains.Nomad.Forward},
+				mock_iptables.Insert{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
+				mock_iptables.Insert{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
+				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING", n.chains.Nomad.Prerouting}},
+				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD", n.chains.Nomad.Forward}},
+				mock_iptables.List{Table: "nat", Chain: "PREROUTING", Result: []string{"-A PREROUTING -j " + n.chains.Nomad.Prerouting}},
+				mock_iptables.List{Table: "filter", Chain: "FORWARD", Result: []string{"-A FORWARD -j " + n.chains.Nomad.Forward}},
+			)
+			defer ipt.AssertExpectations()
+			vt, _ := TestNew(t, WithNames(t, n), WithIPTables(ipt))
+
+			// Run an initial setup to ensure configuration exists.
+			must.NoError(t, vt.setup())
+
+			// Run the setup again.
+			must.NoError(t, vt.setup())
+		})
+
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		testutil.RequireIPTables(t)
+
+		t.Run("not setup", func(t *testing.T) {
+			vt, cleanup := TestNew(t)
+			// Perform an initial cleanup to provide a clean start.
+			t.Cleanup(cleanup)
+
+			// Run the setup.
+			must.NoError(t, vt.setup())
+
+			// Check that chains exist.
+			natChains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			must.SliceContains(t, natChains, vt.names.chains.Nomad.Prerouting)
+
+			filterChains, err := vt.ipt.ListChains("filter")
+			must.NoError(t, err)
+			must.SliceContains(t, filterChains, vt.names.chains.Nomad.Forward)
+
+			// Check that rules exist.
+			natRules, err := vt.ipt.List("nat", "PREROUTING")
+			must.NoError(t, err)
+			must.SliceContains(t, natRules, "-A PREROUTING -j "+vt.names.chains.Nomad.Prerouting)
+
+			filterRules, err := vt.ipt.List("filter", "FORWARD")
+			must.NoError(t, err)
+			must.SliceContains(t, filterRules, "-A FORWARD -j "+vt.names.chains.Nomad.Forward)
+		})
+
+		t.Run("already setup", func(t *testing.T) {
+			vt, cleanup := TestNew(t)
+			t.Cleanup(cleanup)
+
+			// Run an initial setup to ensure configuration exists.
+			must.NoError(t, vt.setup())
+
+			// Run the setup again.
+			must.NoError(t, vt.setup())
+
+			// Duplicate chains will cause an error but duplicate
+			// rules will not, so check for duplicate rules.
+			natSet := set.New[string](0)
+			natRules, err := vt.ipt.List("nat", "PREROUTING")
+			must.NoError(t, err)
+			for _, r := range natRules {
+				must.True(t, natSet.Insert(r), must.Sprintf("duplicate rule found: %q", r))
+			}
+
+			filterSet := set.New[string](0)
+			filterRules, err := vt.ipt.List("filter", "FORWARD")
+			must.NoError(t, err)
+			for _, r := range filterRules {
+				must.True(t, filterSet.Insert(r), must.Sprintf("duplicate rule found: %q", r))
+			}
+		})
+	})
+}
+
+func Test_virtTables_add(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
+				mock_iptables.NewChain{Table: "nat", Chain: nomadTest2},
+				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+		})
+
+		t.Run("ok insert", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
+				mock_iptables.NewChain{Table: "nat", Chain: nomadTest2},
+				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.Insert{Table: "nat", Chain: nomadTest2, Pos: 1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRules([]*rule{
+				{
+					table: "nat",
+					chain: nomadTest1,
+					spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+				},
+				{
+					table:    "nat",
+					chain:    nomadTest2,
+					position: 1,
+					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
+				},
+			})
+
+			must.NoError(t, vt.add(req))
+		})
+
+		t.Run("chain exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
+				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
+				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+		})
+
+		t.Run("rule exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
+				mock_iptables.List{Table: "nat", Chain: nomadTest1, Result: []string{"-A " + nomadTest1 + " -p tcp -j ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+		})
+
+		t.Run("ok insert", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRules([]*rule{
+				{
+					table: "nat",
+					chain: nomadTest1,
+					spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+				},
+				{
+					table:    "nat",
+					chain:    nomadTest2,
+					position: 1,
+					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
+				},
+			})
+
+			must.NoError(t, vt.add(req))
+
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			rules1, err := vt.ipt.List("nat", nomadTest1)
+			must.NoError(t, err)
+			rules2, err := vt.ipt.List("nat", nomadTest2)
+			must.NoError(t, err)
+
+			must.SliceContainsSubset(t, chains, []string{nomadTest1, nomadTest2})
+			must.SliceContains(t, rules1, "-A "+nomadTest1+" -p tcp -j ACCEPT")
+			must.SliceContains(t, rules2, "-A "+nomadTest2+" -p tcp -j ACCEPT")
+
+		})
+
+		t.Run("chain exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			// Create nomadTest2 chain so it already exists.
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			rules, err := vt.ipt.List("nat", nomadTest1)
+			must.NoError(t, err)
+
+			must.SliceContainsSubset(t, chains, []string{nomadTest1, nomadTest2})
+			must.SliceContains(t, rules, "-A "+nomadTest1+" -p tcp -j ACCEPT")
+		})
+
+		t.Run("rule exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			// Create both chains and rule so no changes are needed.
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.add(req))
+
+			// Validate that everything is still there.
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			rules, err := vt.ipt.List("nat", nomadTest1)
+			must.NoError(t, err)
+
+			must.SliceContainsSubset(t, chains, []string{nomadTest1, nomadTest2})
+			must.SliceContains(t, rules, "-A "+nomadTest1+" -p tcp -j ACCEPT")
+		})
+	})
+}
+
+func Test_virtTables_remove(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
+				mock_iptables.List{Table: "nat", Chain: nomadTest1, Result: []string{"-A " + nomadTest1 + " -p tcp -j ACCEPT"}},
+				mock_iptables.Delete{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.ClearChain{Table: "nat", Chain: nomadTest2},
+				mock_iptables.DeleteChain{Table: "nat", Chain: nomadTest2},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+		})
+
+		t.Run("no rules", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
+				mock_iptables.List{Table: "nat", Chain: nomadTest1},
+				mock_iptables.ClearChain{Table: "nat", Chain: nomadTest2},
+				mock_iptables.DeleteChain{Table: "nat", Chain: nomadTest2},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+		})
+
+		t.Run("no chains", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
+			t.Cleanup(func() {
+				vt.ipt.ClearChain("nat", nomadTest1)
+				vt.ipt.DeleteChain("nat", nomadTest2)
+				vt.ipt.DeleteChain("nat", nomadTest1)
+			})
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			rules, err := vt.ipt.List("nat", nomadTest1)
+			must.NoError(t, err)
+			must.SliceContains(t, chains, nomadTest1)
+			must.SliceNotContains(t, chains, nomadTest2)
+			must.Eq(t, rules, []string{"-N " + nomadTest1})
+		})
+
+		t.Run("no rules", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			rules, err := vt.ipt.List("nat", nomadTest1)
+			must.NoError(t, err)
+			must.SliceContains(t, chains, nomadTest1)
+			must.SliceNotContains(t, chains, nomadTest2)
+			must.Eq(t, rules, []string{"-N " + nomadTest1})
+		})
+
+		t.Run("no chains", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
+			})
+
+			must.NoError(t, vt.remove(req))
+
+			chains, err := vt.ipt.ListChains("nat")
+			must.NoError(t, err)
+			must.SliceNotContains(t, chains, nomadTest1)
+			must.SliceNotContains(t, chains, nomadTest2)
+		})
+	})
+}
+
+func Test_virtTables_buildLists(t *testing.T) {
+	t.Run("mock", func(t *testing.T) {
+		t.Run("empty sets", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat"},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest2,
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+			must.Empty(t, chains)
+			must.Empty(t, rules)
+		})
+
+		t.Run("chain exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
+				// NOTE: empty chain will contain an empty rule
+				mock_iptables.List{Table: "nat", Chain: nomadTest2, Result: []string{"-N " + nomadTest2}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest2,
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+
+			must.SliceEqual(t, chains.Slice(), []*chain{{table: "nat", chain: nomadTest2}})
+			must.SliceEqual(t, rules.Slice(), []*rule{{table: "nat", chain: nomadTest2}})
+		})
+
+		t.Run("rules exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
+				mock_iptables.List{Table: "nat", Chain: nomadTest2, Result: []string{"-A " + nomadTest2 + " -p tcp -j ACCEPT"}},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRules([]*rule{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+
+			must.SliceEqual(t, chains.Slice(), []*chain{{table: "nat", chain: nomadTest2}})
+			expectedRule := &rule{table: "nat", chain: nomadTest2, spec: []string{"-p", "tcp", "-j", "ACCEPT"}}
+			must.True(t, rules.Contains(expectedRule),
+				must.Sprintf("missing expected rule: %s", expectedRule))
+		})
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		t.Run("empty sets", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest2,
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+			// NOTE: There's probably other chains, so just confirm that
+			// the test chains aren't included.
+			must.SliceNotContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest1})
+			must.SliceNotContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
+			must.Empty(t, rules)
+		})
+
+		t.Run("chain exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+			t.Cleanup(func() { vt.ipt.DeleteChain("nat", nomadTest2) })
+
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest2,
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+
+			must.SliceContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
+			must.SliceEqual(t, rules.Slice(), []*rule{{table: "nat", chain: nomadTest2}})
+		})
+
+		t.Run("rules exists", func(t *testing.T) {
+			nomadTest1 := genChainName()
+			nomadTest2 := genChainName()
+
+			vt, _ := TestNew(t)
+			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
+
+			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
+			must.NoError(t, vt.ipt.Append("nat", nomadTest2, "-p", "tcp", "-j", "ACCEPT"))
+			t.Cleanup(func() {
+				vt.ipt.ClearChain("nat", nomadTest2)
+				vt.ipt.DeleteChain("nat", nomadTest2)
+			})
+			req := newRequest()
+			req.addChains([]*chain{
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+			})
+			req.addRules([]*rule{
+				{
+					table: "nat",
+					chain: nomadTest2,
+				},
+				{
+					table: "nat",
+					chain: nomadTest1,
+				},
+			})
+
+			chains, rules, err := vt.buildLists(req)
+			must.NoError(t, err)
+
+			must.SliceContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
+			expectedRule := &rule{table: "nat", chain: nomadTest2, spec: []string{"-p", "tcp", "-j", "ACCEPT"}}
+			must.True(t, rules.Contains(expectedRule),
+				must.Sprintf("missing expected rule: %s", expectedRule))
+		})
+	})
+}
+
+func Test_virtTables_loopbackPortForwardsSupported(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		deviceContent string // empty string will result in no file
+		globalContent string // empty string will result in no file
+		result        bool
+	}{
+		{
+			desc:          "global only enabled",
+			globalContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global only disabled",
+			globalContent: "0",
+			result:        false,
+		},
+		{
+			desc:          "device only route localnet enabled",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "device only route localnet disabled",
+			deviceContent: "0",
+			result:        false,
+		},
+		{
+			desc:          "global enabled device enabled",
+			globalContent: "1",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global enabled device disabled",
+			globalContent: "1",
+			deviceContent: "0",
+			result:        true,
+		},
+		{
+			desc:          "global disabled device enabled",
+			globalContent: "0",
+			deviceContent: "1",
+			result:        true,
+		},
+		{
+			desc:          "global disabled device disabled",
+			globalContent: "0",
+			deviceContent: "0",
+			result:        false,
+		},
+		{
+			desc:   "all route localnet missing",
+			result: false,
+		},
+	}
+
+	deviceName := "test-dev"
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tdir := t.TempDir()
+			tmpl := filepath.Join(tdir, "/%s_route_localnet")
+			devPath := fmt.Sprintf(tmpl, deviceName)
+			globalPath := fmt.Sprintf(tmpl, routeLocalnetGlobalName)
+			if tc.globalContent != "" {
+				f, err := os.Create(globalPath)
+				must.NoError(t, err)
+				_, err = f.WriteString(tc.globalContent)
+				must.NoError(t, err)
+				f.Close()
+			}
+
+			if tc.deviceContent != "" {
+				f, err := os.Create(devPath)
+				must.NoError(t, err)
+				_, err = f.WriteString(tc.deviceContent)
+				must.NoError(t, err)
+				f.Close()
+			}
+
+			vt, _ := TestNew(t, WithRoutingLocalnetPathTemplate(tmpl))
+			must.Eq(t, tc.result, vt.loopbackPortForwardsSupported(deviceName))
+		})
+	}
+}
+
+// genChainName generates a unique chain name for tests.
+func genChainName() string {
+	return fmt.Sprintf("NOMAD_VT_TEST_%s", uuid.Short())
+}
+
+// chainRemover returns a function that deletes chains from the nat table.
+func chainRemover(t *testing.T, ipt IPTables, names ...string) func() {
+	return func() {
+		t.Helper()
+		for _, name := range names {
+			if err := ipt.ClearChain("nat", name); err != nil {
+				t.Logf("error clearing chain %q in nat table (%s), continuing...", name, err)
+				continue
+			}
+			if err := ipt.DeleteChain("nat", name); err != nil {
+				t.Logf("error deleting chain %q in nat table (%s), continuing...", name, err)
+			}
+		}
+	}
+}
+
+// enableLocalnetRouting writes a file with a `1` for content and returns
+// the path. Can be used with `WithRoutingLocalnetTemplate`.
+func enableLocalnetRouting(t *testing.T, device string) string {
+	if device == "" {
+		device = routeLocalnetGlobalName
+	}
+
+	tmpl := filepath.Join(t.TempDir(), "localnet-routing-%s")
+	path := fmt.Sprintf(tmpl, device)
+	f, err := os.Create(path)
+	must.NoError(t, err)
+	_, err = f.WriteString("1")
+	must.NoError(t, err)
+	must.NoError(t, f.Close())
+
+	return tmpl
+}
+
+var (
+	_ filter.Filter = (*virtTables)(nil)
+)

--- a/net/filter/iptables/tables_test.go
+++ b/net/filter/iptables/tables_test.go
@@ -34,24 +34,20 @@ func Test_virtTables_Configure(t *testing.T) {
 			n := TestNewNames()
 			hostIP := "192.168.44.22"
 			taskIP := "10.0.22.33"
-			maskedHostIP := "192.168.44.22/32"
-			maskedTaskIP := "10.0.22.33/32"
 			ifaceName := "test0"
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
-				mock_iptables.ListChains{Table: "filter"},
-				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
-					"-d", maskedHostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222",
+				mock_iptables.AppendUnique{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
+					"-d", hostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222",
 					"-j", "DNAT", "--to-destination", taskIP + ":8000"}},
-				mock_iptables.Append{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
-					"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+				mock_iptables.AppendUnique{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
+					"-d", taskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
 					"--dport", "8000", "-j", "ACCEPT"}},
-				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
-					"-d", maskedHostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22223",
+				mock_iptables.AppendUnique{Table: "nat", Chain: n.chains.Nomad.Prerouting, RuleSpec: []string{
+					"-d", hostIP, "-i", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22223",
 					"-j", "DNAT", "--to-destination", taskIP + ":2222"}},
-				mock_iptables.Append{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
-					"-d", maskedTaskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
+				mock_iptables.AppendUnique{Table: "filter", Chain: n.chains.Nomad.Forward, RuleSpec: []string{
+					"-d", taskIP, "-p", "tcp", "-m", "state", "--state", "NEW", "-m", "tcp",
 					"--dport", "2222", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
@@ -83,21 +79,21 @@ func Test_virtTables_Configure(t *testing.T) {
 
 			expected := [][]string{
 				{
-					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"nat", n.chains.Nomad.Prerouting, "-d", hostIP, "-i", ifaceName, "-p",
 					"tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT", "--to-destination",
 					taskIP + ":8000",
 				},
 				{
-					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"filter", n.chains.Nomad.Forward, "-d", taskIP, "-p", "tcp", "-m",
 					"state", "--state", "NEW", "-m", "tcp", "--dport", "8000", "-j", "ACCEPT",
 				},
 				{
-					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"nat", n.chains.Nomad.Prerouting, "-d", hostIP, "-i", ifaceName, "-p",
 					"tcp", "-m", "tcp", "--dport", "22223", "-j", "DNAT", "--to-destination",
 					taskIP + ":2222",
 				},
 				{
-					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"filter", n.chains.Nomad.Forward, "-d", taskIP, "-p", "tcp", "-m",
 					"state", "--state", "NEW", "-m", "tcp", "--dport", "2222", "-j", "ACCEPT",
 				},
 			}
@@ -111,21 +107,21 @@ func Test_virtTables_Configure(t *testing.T) {
 			n := TestNewNames()
 			hostIP := "127.0.0.1"
 			taskIP := "10.0.22.33"
-			maskedHostIP := "127.0.0.1/32"
 
 			ifaceName := "testlo0"
 			dstIfaceName := "testbr0"
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.ChainExists{Table: "nat", Chain: n.chains.Nomad.Output},
+				mock_iptables.ChainExists{Table: "nat", Chain: n.chains.Nomad.Postrouting},
 				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Output},
 				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Postrouting},
-				mock_iptables.Insert{Table: "nat", Chain: "OUTPUT", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Output}},
-				mock_iptables.Insert{Table: "nat", Chain: "POSTROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Postrouting}},
-				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Postrouting, RuleSpec: []string{
+				mock_iptables.InsertUnique{Table: "nat", Chain: "OUTPUT", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Output}},
+				mock_iptables.InsertUnique{Table: "nat", Chain: "POSTROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Postrouting}},
+				mock_iptables.AppendUnique{Table: "nat", Chain: n.chains.Nomad.Postrouting, RuleSpec: []string{
 					"-o", dstIfaceName, "-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST", "-j", "MASQUERADE"}},
-				mock_iptables.Append{Table: "nat", Chain: n.chains.Nomad.Output, RuleSpec: []string{
-					"-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT",
+				mock_iptables.AppendUnique{Table: "nat", Chain: n.chains.Nomad.Output, RuleSpec: []string{
+					"-s", hostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT",
 					"--to-destination", taskIP + ":8000"}},
 			)
 			defer ipt.AssertExpectations()
@@ -153,7 +149,7 @@ func Test_virtTables_Configure(t *testing.T) {
 
 			expected := [][]string{
 				{
-					"nat", n.chains.Nomad.Output, "-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
+					"nat", n.chains.Nomad.Output, "-s", hostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
 					"--dport", "22222", "-j", "DNAT", "--to-destination", taskIP + ":8000",
 				},
 			}
@@ -239,21 +235,21 @@ func Test_virtTables_Configure(t *testing.T) {
 
 			expected := [][]string{
 				{
-					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"nat", n.chains.Nomad.Prerouting, "-d", hostIP, "-i", ifaceName, "-p",
 					"tcp", "-m", "tcp", "--dport", "22222", "-j", "DNAT", "--to-destination",
 					taskIP + ":8000",
 				},
 				{
-					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"filter", n.chains.Nomad.Forward, "-d", taskIP, "-p", "tcp", "-m",
 					"state", "--state", "NEW", "-m", "tcp", "--dport", "8000", "-j", "ACCEPT",
 				},
 				{
-					"nat", n.chains.Nomad.Prerouting, "-d", maskedHostIP, "-i", ifaceName, "-p",
+					"nat", n.chains.Nomad.Prerouting, "-d", hostIP, "-i", ifaceName, "-p",
 					"tcp", "-m", "tcp", "--dport", "22223", "-j", "DNAT", "--to-destination",
 					taskIP + ":2222",
 				},
 				{
-					"filter", n.chains.Nomad.Forward, "-d", maskedTaskIP, "-p", "tcp", "-m",
+					"filter", n.chains.Nomad.Forward, "-d", taskIP, "-p", "tcp", "-m",
 					"state", "--state", "NEW", "-m", "tcp", "--dport", "2222", "-j", "ACCEPT",
 				},
 			}
@@ -278,8 +274,10 @@ func Test_virtTables_Configure(t *testing.T) {
 				fmt.Sprintf("-A %s -d %s -p tcp -m state --state NEW -m tcp --dport 2222 -j ACCEPT", n.chains.Nomad.Forward, maskedTaskIP),
 			}
 
-			must.SliceContainsSubset(t, natRules, expectedNats)
-			must.SliceContainsSubset(t, filterRules, expectedFilters)
+			must.SliceContainsSubset(t, natRules, expectedNats,
+				must.Sprintf("nat rules: %#v", natRules))
+			must.SliceContainsSubset(t, filterRules, expectedFilters,
+				must.Sprintf("filter rules: %#v", filterRules))
 		})
 
 		t.Run("loopback", func(t *testing.T) {
@@ -313,7 +311,7 @@ func Test_virtTables_Configure(t *testing.T) {
 
 			expected := [][]string{
 				{
-					"nat", n.chains.Nomad.Output, "-s", maskedHostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
+					"nat", n.chains.Nomad.Output, "-s", hostIP, "-o", ifaceName, "-p", "tcp", "-m", "tcp",
 					"--dport", "22222", "-j", "DNAT", "--to-destination", taskIP + ":8000",
 				},
 			}
@@ -336,9 +334,12 @@ func Test_virtTables_Configure(t *testing.T) {
 				fmt.Sprintf("-A %s -s %s -o %s -p tcp -m tcp --dport 22222 -j DNAT --to-destination %s:8000", n.chains.Nomad.Output, maskedHostIP, ifaceName, taskIP),
 			}
 
-			must.SliceContainsSubset(t, natChains, []string{n.chains.Postrouting, n.chains.Output})
-			must.SliceContainsSubset(t, postRules, expectedPostRules)
-			must.SliceContainsSubset(t, outRules, expectedOutRules)
+			must.SliceContainsSubset(t, natChains, []string{n.chains.Postrouting, n.chains.Output},
+				must.Sprintf("nat chains: %#v", natChains))
+			must.SliceContainsSubset(t, postRules, expectedPostRules,
+				must.Sprintf("POSTROUTING rules: %#v", postRules))
+			must.SliceContainsSubset(t, outRules, expectedOutRules,
+				must.Sprintf("OUTPUT rules: %#v", outRules))
 		})
 
 		t.Run("with teardown", func(t *testing.T) {
@@ -424,14 +425,12 @@ func Test_virtTables_setup(t *testing.T) {
 		t.Run("not setup", func(t *testing.T) {
 			n := TestNewNames()
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING"}},
-				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD"}},
-				mock_iptables.List{Table: "nat", Chain: "PREROUTING"},
-				mock_iptables.List{Table: "filter", Chain: "FORWARD"},
+				mock_iptables.ChainExists{Table: "nat", Chain: n.chains.Nomad.Prerouting},
+				mock_iptables.ChainExists{Table: "filter", Chain: n.chains.Nomad.Forward},
 				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Prerouting},
 				mock_iptables.NewChain{Table: "filter", Chain: n.chains.Nomad.Forward},
-				mock_iptables.Insert{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
-				mock_iptables.Insert{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
+				mock_iptables.InsertUnique{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
+				mock_iptables.InsertUnique{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
 			)
 			defer ipt.AssertExpectations()
 
@@ -442,18 +441,16 @@ func Test_virtTables_setup(t *testing.T) {
 		t.Run("already setup", func(t *testing.T) {
 			n := TestNewNames()
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING"}},
-				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD"}},
-				mock_iptables.List{Table: "nat", Chain: "PREROUTING"},
-				mock_iptables.List{Table: "filter", Chain: "FORWARD"},
+				mock_iptables.ChainExists{Table: "nat", Chain: n.chains.Nomad.Prerouting},
+				mock_iptables.ChainExists{Table: "filter", Chain: n.chains.Nomad.Forward},
 				mock_iptables.NewChain{Table: "nat", Chain: n.chains.Nomad.Prerouting},
 				mock_iptables.NewChain{Table: "filter", Chain: n.chains.Nomad.Forward},
-				mock_iptables.Insert{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
-				mock_iptables.Insert{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
-				mock_iptables.ListChains{Table: "nat", Result: []string{"PREROUTING", n.chains.Nomad.Prerouting}},
-				mock_iptables.ListChains{Table: "filter", Result: []string{"FORWARD", n.chains.Nomad.Forward}},
-				mock_iptables.List{Table: "nat", Chain: "PREROUTING", Result: []string{"-A PREROUTING -j " + n.chains.Nomad.Prerouting}},
-				mock_iptables.List{Table: "filter", Chain: "FORWARD", Result: []string{"-A FORWARD -j " + n.chains.Nomad.Forward}},
+				mock_iptables.InsertUnique{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
+				mock_iptables.InsertUnique{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
+				mock_iptables.ChainExists{Table: "nat", Chain: n.chains.Nomad.Prerouting, Result: true},
+				mock_iptables.ChainExists{Table: "filter", Chain: n.chains.Nomad.Forward, Result: true},
+				mock_iptables.InsertUnique{Table: "nat", Chain: "PREROUTING", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Prerouting}},
+				mock_iptables.InsertUnique{Table: "filter", Chain: "FORWARD", Pos: 1, RuleSpec: []string{"-j", n.chains.Nomad.Forward}},
 			)
 			defer ipt.AssertExpectations()
 			vt, _ := TestNew(t, WithNames(t, n), WithIPTables(ipt))
@@ -472,7 +469,6 @@ func Test_virtTables_setup(t *testing.T) {
 
 		t.Run("not setup", func(t *testing.T) {
 			vt, cleanup := TestNew(t)
-			// Perform an initial cleanup to provide a clean start.
 			t.Cleanup(cleanup)
 
 			// Run the setup.
@@ -533,16 +529,17 @@ func Test_virtTables_add(t *testing.T) {
 			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest1},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest2},
 				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
 				mock_iptables.NewChain{Table: "nat", Chain: nomadTest2},
-				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.AppendUnique{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -551,7 +548,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -566,17 +563,18 @@ func Test_virtTables_add(t *testing.T) {
 			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest1},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest2},
 				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
 				mock_iptables.NewChain{Table: "nat", Chain: nomadTest2},
-				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
-				mock_iptables.Insert{Table: "nat", Chain: nomadTest2, Pos: 1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.AppendUnique{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.InsertUnique{Table: "nat", Chain: nomadTest2, Pos: 1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -585,8 +583,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
-			req.addRules([]*rule{
+			}...)
+			req.addRule([]*rule{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -598,7 +596,7 @@ func Test_virtTables_add(t *testing.T) {
 					position: 1,
 					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
 				},
-			})
+			}...)
 
 			must.NoError(t, vt.add(req))
 		})
@@ -608,15 +606,16 @@ func Test_virtTables_add(t *testing.T) {
 			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest1},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest2, Result: true},
 				mock_iptables.NewChain{Table: "nat", Chain: nomadTest1},
-				mock_iptables.Append{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.AppendUnique{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -625,7 +624,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -640,14 +639,15 @@ func Test_virtTables_add(t *testing.T) {
 			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
-				mock_iptables.List{Table: "nat", Chain: nomadTest1, Result: []string{"-A " + nomadTest1 + " -p tcp -j ACCEPT"}},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest1, Result: true},
+				mock_iptables.ChainExists{Table: "nat", Chain: nomadTest2, Result: true},
+				mock_iptables.AppendUnique{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -656,7 +656,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -676,7 +676,7 @@ func Test_virtTables_add(t *testing.T) {
 			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
 
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -685,7 +685,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -703,7 +703,7 @@ func Test_virtTables_add(t *testing.T) {
 			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
 
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -712,8 +712,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
-			req.addRules([]*rule{
+			}...)
+			req.addRule([]*rule{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -725,7 +725,7 @@ func Test_virtTables_add(t *testing.T) {
 					position: 1,
 					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
 				},
-			})
+			}...)
 
 			must.NoError(t, vt.add(req))
 
@@ -753,7 +753,7 @@ func Test_virtTables_add(t *testing.T) {
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
 
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -762,7 +762,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -793,7 +793,7 @@ func Test_virtTables_add(t *testing.T) {
 			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
 
 			req := newRequest()
-			req.addChains([]*chain{
+			req.addChain([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -802,7 +802,7 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			})
+			}...)
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -830,51 +830,14 @@ func Test_virtTables_remove(t *testing.T) {
 			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
-				mock_iptables.List{Table: "nat", Chain: nomadTest1, Result: []string{"-A " + nomadTest1 + " -p tcp -j ACCEPT"}},
-				mock_iptables.Delete{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
-				mock_iptables.ClearChain{Table: "nat", Chain: nomadTest2},
-				mock_iptables.DeleteChain{Table: "nat", Chain: nomadTest2},
+				mock_iptables.DeleteIfExists{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
+				mock_iptables.ClearAndDeleteChain{Table: "nat", Chain: nomadTest2},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRule(&rule{
-				table: "nat",
-				chain: nomadTest1,
-				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
-			})
-
-			must.NoError(t, vt.remove(req))
-		})
-
-		t.Run("no rules", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest1, nomadTest2}},
-				mock_iptables.List{Table: "nat", Chain: nomadTest1},
-				mock_iptables.ClearChain{Table: "nat", Chain: nomadTest2},
-				mock_iptables.DeleteChain{Table: "nat", Chain: nomadTest2},
-			)
-			defer ipt.AssertExpectations()
-
-			vt, _ := TestNew(t, WithIPTables(ipt))
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
+			req.addChain(&chain{table: "nat", chain: nomadTest2})
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -886,21 +849,59 @@ func Test_virtTables_remove(t *testing.T) {
 
 		t.Run("no chains", func(t *testing.T) {
 			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
 
 			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
+				mock_iptables.DeleteIfExists{Table: "nat", Chain: nomadTest1, RuleSpec: []string{"-p", "tcp", "-j", "ACCEPT"}},
 			)
 			defer ipt.AssertExpectations()
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
+			req.addRule(&rule{
+				table: "nat",
+				chain: nomadTest1,
+				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
 			})
+
+			must.NoError(t, vt.remove(req))
+		})
+
+		t.Run("no rules", func(t *testing.T) {
+			nomadTest1 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ClearAndDeleteChain{Table: "nat", Chain: nomadTest1},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChain(&chain{table: "nat", chain: nomadTest1})
+
+			must.NoError(t, vt.remove(req))
+		})
+
+		t.Run("empty request", func(t *testing.T) {
+			ipt := mock_iptables.New(t)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+
+			must.NoError(t, vt.remove(req))
+		})
+
+		t.Run("rule on deleted chain", func(t *testing.T) {
+			nomadTest1 := genChainName()
+
+			ipt := mock_iptables.New(t).Expect(
+				mock_iptables.ClearAndDeleteChain{Table: "nat", Chain: nomadTest1},
+			)
+			defer ipt.AssertExpectations()
+
+			vt, _ := TestNew(t, WithIPTables(ipt))
+			req := newRequest()
+			req.addChain(&chain{table: "nat", chain: nomadTest1})
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -922,18 +923,9 @@ func Test_virtTables_remove(t *testing.T) {
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
 			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
-			t.Cleanup(func() {
-				vt.ipt.ClearChain("nat", nomadTest1)
-				vt.ipt.DeleteChain("nat", nomadTest2)
-				vt.ipt.DeleteChain("nat", nomadTest1)
-			})
+
 			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
+			req.addChain(&chain{table: "nat", chain: nomadTest2})
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -951,7 +943,7 @@ func Test_virtTables_remove(t *testing.T) {
 			must.Eq(t, rules, []string{"-N " + nomadTest1})
 		})
 
-		t.Run("no rules", func(t *testing.T) {
+		t.Run("no existing rules", func(t *testing.T) {
 			nomadTest1 := genChainName()
 			nomadTest2 := genChainName()
 
@@ -962,12 +954,7 @@ func Test_virtTables_remove(t *testing.T) {
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
 
 			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
+			req.addChain(&chain{table: "nat", chain: nomadTest2})
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -985,20 +972,14 @@ func Test_virtTables_remove(t *testing.T) {
 			must.Eq(t, rules, []string{"-N " + nomadTest1})
 		})
 
-		t.Run("no chains", func(t *testing.T) {
+		t.Run("no existing chains", func(t *testing.T) {
 			nomadTest1 := genChainName()
 			nomadTest2 := genChainName()
 
 			vt, _ := TestNew(t)
-			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
 
 			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
+			req.addChain(&chain{table: "nat", chain: nomadTest2})
 			req.addRule(&rule{
 				table: "nat",
 				chain: nomadTest1,
@@ -1011,230 +992,6 @@ func Test_virtTables_remove(t *testing.T) {
 			must.NoError(t, err)
 			must.SliceNotContains(t, chains, nomadTest1)
 			must.SliceNotContains(t, chains, nomadTest2)
-		})
-	})
-}
-
-func Test_virtTables_buildLists(t *testing.T) {
-	t.Run("mock", func(t *testing.T) {
-		t.Run("empty sets", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat"},
-			)
-			defer ipt.AssertExpectations()
-
-			vt, _ := TestNew(t, WithIPTables(ipt))
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRule(&rule{
-				table: "nat",
-				chain: nomadTest2,
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-			must.Empty(t, chains)
-			must.Empty(t, rules)
-		})
-
-		t.Run("chain exists", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
-				// NOTE: empty chain will contain an empty rule
-				mock_iptables.List{Table: "nat", Chain: nomadTest2, Result: []string{"-N " + nomadTest2}},
-			)
-			defer ipt.AssertExpectations()
-
-			vt, _ := TestNew(t, WithIPTables(ipt))
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRule(&rule{
-				table: "nat",
-				chain: nomadTest2,
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-
-			must.SliceEqual(t, chains.Slice(), []*chain{{table: "nat", chain: nomadTest2}})
-			must.SliceEqual(t, rules.Slice(), []*rule{{table: "nat", chain: nomadTest2}})
-		})
-
-		t.Run("rules exists", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			ipt := mock_iptables.New(t).Expect(
-				mock_iptables.ListChains{Table: "nat", Result: []string{nomadTest2}},
-				mock_iptables.List{Table: "nat", Chain: nomadTest2, Result: []string{"-A " + nomadTest2 + " -p tcp -j ACCEPT"}},
-			)
-			defer ipt.AssertExpectations()
-
-			vt, _ := TestNew(t, WithIPTables(ipt))
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRules([]*rule{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-
-			must.SliceEqual(t, chains.Slice(), []*chain{{table: "nat", chain: nomadTest2}})
-			expectedRule := &rule{table: "nat", chain: nomadTest2, spec: []string{"-p", "tcp", "-j", "ACCEPT"}}
-			must.True(t, rules.Contains(expectedRule),
-				must.Sprintf("missing expected rule: %s", expectedRule))
-		})
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		t.Run("empty sets", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			vt, _ := TestNew(t)
-			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
-
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRule(&rule{
-				table: "nat",
-				chain: nomadTest2,
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-			// NOTE: There's probably other chains, so just confirm that
-			// the test chains aren't included.
-			must.SliceNotContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest1})
-			must.SliceNotContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
-			must.Empty(t, rules)
-		})
-
-		t.Run("chain exists", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			vt, _ := TestNew(t)
-			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
-
-			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
-			t.Cleanup(func() { vt.ipt.DeleteChain("nat", nomadTest2) })
-
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRule(&rule{
-				table: "nat",
-				chain: nomadTest2,
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-
-			must.SliceContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
-			must.SliceEqual(t, rules.Slice(), []*rule{{table: "nat", chain: nomadTest2}})
-		})
-
-		t.Run("rules exists", func(t *testing.T) {
-			nomadTest1 := genChainName()
-			nomadTest2 := genChainName()
-
-			vt, _ := TestNew(t)
-			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
-
-			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
-			must.NoError(t, vt.ipt.Append("nat", nomadTest2, "-p", "tcp", "-j", "ACCEPT"))
-			t.Cleanup(func() {
-				vt.ipt.ClearChain("nat", nomadTest2)
-				vt.ipt.DeleteChain("nat", nomadTest2)
-			})
-			req := newRequest()
-			req.addChains([]*chain{
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-			})
-			req.addRules([]*rule{
-				{
-					table: "nat",
-					chain: nomadTest2,
-				},
-				{
-					table: "nat",
-					chain: nomadTest1,
-				},
-			})
-
-			chains, rules, err := vt.buildLists(req)
-			must.NoError(t, err)
-
-			must.SliceContains(t, chains.Slice(), &chain{table: "nat", chain: nomadTest2})
-			expectedRule := &rule{table: "nat", chain: nomadTest2, spec: []string{"-p", "tcp", "-j", "ACCEPT"}}
-			must.True(t, rules.Contains(expectedRule),
-				must.Sprintf("missing expected rule: %s", expectedRule))
 		})
 	})
 }
@@ -1336,12 +1093,9 @@ func chainRemover(t *testing.T, ipt IPTables, names ...string) func() {
 	return func() {
 		t.Helper()
 		for _, name := range names {
-			if err := ipt.ClearChain("nat", name); err != nil {
-				t.Logf("error clearing chain %q in nat table (%s), continuing...", name, err)
-				continue
-			}
-			if err := ipt.DeleteChain("nat", name); err != nil {
+			if err := ipt.ClearAndDeleteChain("nat", name); err != nil {
 				t.Logf("error deleting chain %q in nat table (%s), continuing...", name, err)
+				continue
 			}
 		}
 	}

--- a/net/filter/iptables/tables_test.go
+++ b/net/filter/iptables/tables_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -190,7 +190,7 @@ func Test_virtTables_Configure(t *testing.T) {
 			}
 
 			_, err := vt.Configure(resources, cfg, taskIP)
-			must.ErrorContains(t, err, "loopback port forwarding not enabled")
+			must.ErrorIs(t, err, errLoopbackNotEnabled)
 		})
 	})
 
@@ -539,7 +539,7 @@ func Test_virtTables_add(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -548,8 +548,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -574,7 +574,7 @@ func Test_virtTables_add(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -583,8 +583,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule([]*rule{
+			})
+			req.rules.InsertSlice([]*rule{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -596,7 +596,7 @@ func Test_virtTables_add(t *testing.T) {
 					position: 1,
 					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
 				},
-			}...)
+			})
 
 			must.NoError(t, vt.add(req))
 		})
@@ -615,7 +615,7 @@ func Test_virtTables_add(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -624,8 +624,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -647,7 +647,7 @@ func Test_virtTables_add(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -656,8 +656,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -676,7 +676,7 @@ func Test_virtTables_add(t *testing.T) {
 			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
 
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -685,8 +685,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -703,7 +703,7 @@ func Test_virtTables_add(t *testing.T) {
 			t.Cleanup(chainRemover(t, vt.ipt, nomadTest1, nomadTest2))
 
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -712,8 +712,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule([]*rule{
+			})
+			req.rules.InsertSlice([]*rule{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -725,7 +725,7 @@ func Test_virtTables_add(t *testing.T) {
 					position: 1,
 					spec:     []string{"-p", "tcp", "-j", "ACCEPT"},
 				},
-			}...)
+			})
 
 			must.NoError(t, vt.add(req))
 
@@ -753,7 +753,7 @@ func Test_virtTables_add(t *testing.T) {
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
 
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -762,8 +762,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -790,10 +790,10 @@ func Test_virtTables_add(t *testing.T) {
 			// Create both chains and rule so no changes are needed.
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
-			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
+			must.NoError(t, vt.ipt.AppendUnique("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
 
 			req := newRequest()
-			req.addChain([]*chain{
+			req.chains.InsertSlice([]*chain{
 				{
 					table: "nat",
 					chain: nomadTest1,
@@ -802,8 +802,8 @@ func Test_virtTables_add(t *testing.T) {
 					table: "nat",
 					chain: nomadTest2,
 				},
-			}...)
-			req.addRule(&rule{
+			})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -837,8 +837,8 @@ func Test_virtTables_remove(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest2})
-			req.addRule(&rule{
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest2})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -857,7 +857,7 @@ func Test_virtTables_remove(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addRule(&rule{
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -876,7 +876,7 @@ func Test_virtTables_remove(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest1})
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest1})
 
 			must.NoError(t, vt.remove(req))
 		})
@@ -901,8 +901,8 @@ func Test_virtTables_remove(t *testing.T) {
 
 			vt, _ := TestNew(t, WithIPTables(ipt))
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest1})
-			req.addRule(&rule{
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest1})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -922,11 +922,11 @@ func Test_virtTables_remove(t *testing.T) {
 
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest1))
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
-			must.NoError(t, vt.ipt.Append("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
+			must.NoError(t, vt.ipt.AppendUnique("nat", nomadTest1, "-p", "tcp", "-j", "ACCEPT"))
 
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest2})
-			req.addRule(&rule{
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest2})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -954,8 +954,8 @@ func Test_virtTables_remove(t *testing.T) {
 			must.NoError(t, vt.ipt.NewChain("nat", nomadTest2))
 
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest2})
-			req.addRule(&rule{
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest2})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},
@@ -979,8 +979,8 @@ func Test_virtTables_remove(t *testing.T) {
 			vt, _ := TestNew(t)
 
 			req := newRequest()
-			req.addChain(&chain{table: "nat", chain: nomadTest2})
-			req.addRule(&rule{
+			req.chains.Insert(&chain{table: "nat", chain: nomadTest2})
+			req.rules.Insert(&rule{
 				table: "nat",
 				chain: nomadTest1,
 				spec:  []string{"-p", "tcp", "-j", "ACCEPT"},

--- a/net/filter/iptables/testing.go
+++ b/net/filter/iptables/testing.go
@@ -178,6 +178,6 @@ func (n *virtTables) cleanup(t must.T) {
 	})
 
 	if err := n.remove(req); err != nil {
-		t.Fatalf("error encountered during iptables cleanup: %w", err)
+		t.Fatalf("error encountered during iptables cleanup: %s", err)
 	}
 }

--- a/net/filter/iptables/testing.go
+++ b/net/filter/iptables/testing.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2024, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package iptables
+
+import (
+	"net"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/shoenig/test/must"
+)
+
+type testOption func(*virtTables)
+
+// interfaceByIPGetter is the function signature used to identify the host's
+// interface using a passed IP address. This is primarily used for testing,
+// where we don't know the host, and we want to ensure stability and
+// consistency when this is called.
+type interfaceByIPGetter func(ip net.IP) (string, error)
+
+// routingInterfaceByIPGetter is the function signature used to identify
+// the host interface used for an IP address.
+type routingInterfaceByIPGetter func(ip string) (string, error)
+
+// WithIPTables sets a custom IPTables implementation.
+func WithIPTables(ipt IPTables) testOption {
+	return func(n *virtTables) {
+		n.ipt = ipt
+	}
+}
+
+// WithInterfaceByIPGetter sets a custom interfaceByIPGetter.
+func WithInterfaceByIPGetter(fn interfaceByIPGetter) testOption {
+	return func(n *virtTables) {
+		n.interfaceByIPGetter = fn
+	}
+}
+
+// WithRoutingInterfaceByIPGetter sets a custom routingInterfaceByIPGetter.
+func WithRoutingInterfaceByIPGetter(fn routingInterfaceByIPGetter) testOption {
+	return func(n *virtTables) {
+		n.routingInterfaceByIPGetter = fn
+	}
+}
+
+// WithRoutingLocalnetPathTemplate sets a custom routeLocalnetPathTemplate.
+func WithRoutingLocalnetPathTemplate(tmpl string) testOption {
+	return func(n *virtTables) {
+		n.routeLocalnetPathTemplate = tmpl
+	}
+}
+
+// WithNames sets custom names and will fill in any unset values with defaults.
+func WithNames(t must.T, nm *names) testOption {
+	return func(n *virtTables) {
+		dec, err := mapstructure.NewDecoder(
+			&mapstructure.DecoderConfig{
+				Deep:   true,
+				Result: n.names,
+			},
+		)
+		must.NoError(t, err, must.Sprint("failed to create mapstructure decoder"))
+		err = dec.Decode(nm)
+		must.NoError(t, err, must.Sprint("failed to decode names for iptables"))
+	}
+}
+
+// WithLogger sets a custom logger.
+func WithLogger(logger hclog.Logger) testOption {
+	return func(n *virtTables) {
+		n.logger = logger
+	}
+}
+
+// Create a new VirtTables test instance. Returns an optional cleanup
+// to remove iptables modifications.
+func TestNew(t must.T, opts ...testOption) (*virtTables, func()) {
+	t.Helper()
+	nt := &virtTables{
+		interfaceByIPGetter:        getInterfaceByIP,
+		names:                      TestNewNames(),
+		routingInterfaceByIPGetter: getRoutingInterfaceByIP,
+		logger:                     hclog.NewNullLogger(),
+	}
+
+	for _, optFn := range opts {
+		optFn(nt)
+	}
+
+	if nt.ipt == nil {
+		ipt, err := iptables.New()
+		must.NoError(t, err, must.Sprint("failed to create iptables instance"))
+		nt.ipt = ipt
+	}
+
+	return nt, func() { nt.cleanup(t) }
+}
+
+// NewNames creates a new instance with all nomad chain name values
+// set to generated testing names.
+func TestNewNames() *names {
+	return &names{
+		chains: &ChainNames{
+			Forward:     defaultChainNameForward,
+			Output:      defaultChainNameOutput,
+			Postrouting: defaultChainNamePostrouting,
+			Prerouting:  defaultChainNamePrerouting,
+			Nomad: &NomadChainNames{
+				Forward:     genTestName(defaultChainNameNomadForward),
+				Postrouting: genTestName(defaultChainNameNomadPostrouting),
+				Prerouting:  genTestName(defaultChainNameNomadPrerouting),
+				Output:      genTestName(defaultChainNameNomadOutput),
+			},
+		},
+		tables: &TableNames{
+			Filter: defaultTableNameFilter,
+			NAT:    defaultTableNameNAT,
+		},
+	}
+}
+
+// genTestName appends a short uuid to the prefix to provide a unique
+// name for testing.
+func genTestName(prefix string) string {
+	return prefix + "_" + uuid.Short()
+}
+
+// cleanup is used to remove entries from iptables when tests
+// are interacting directly with iptables and are not mocked.
+func (n *virtTables) cleanup(t must.T) {
+	req := newRequest()
+
+	// Add all the custom chains to be removed.
+	req.chains.InsertSlice([]*chain{
+		{
+			table: n.names.tables.Filter,
+			chain: n.names.chains.Nomad.Forward,
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Nomad.Postrouting,
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Nomad.Prerouting,
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Nomad.Output,
+		},
+	})
+
+	// Add all the jump rules to be removed.
+	req.rules.InsertSlice([]*rule{
+		{
+			table: n.names.tables.Filter,
+			chain: n.names.chains.Forward,
+			spec:  []string{"-j", n.names.chains.Nomad.Forward},
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Postrouting,
+			spec:  []string{"-j", n.names.chains.Nomad.Postrouting},
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Prerouting,
+			spec:  []string{"-j", n.names.chains.Nomad.Prerouting},
+		},
+		{
+			table: n.names.tables.NAT,
+			chain: n.names.chains.Output,
+			spec:  []string{"-j", n.names.chains.Nomad.Output},
+		},
+	})
+
+	if err := n.remove(req); err != nil {
+		t.Fatalf("error encountered during iptables cleanup: %w", err)
+	}
+}

--- a/net/filter/iptables/testing.go
+++ b/net/filter/iptables/testing.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -99,7 +99,7 @@ func TestNew(t must.T, opts ...testOption) (*virtTables, func()) {
 	return nt, func() { nt.cleanup(t) }
 }
 
-// NewNames creates a new instance with all nomad chain name values
+// TestNewNames creates a new instance with all nomad chain name values
 // set to generated testing names.
 func TestNewNames() *names {
 	return &names{

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -130,6 +130,9 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger = logger.Named(pluginName)
 
+	// Set the default logger.
+	hclog.SetDefault(logger)
+
 	// Should we check if extentions and kernel modules are there?
 	// grep -E 'svm|vmx' /proc/cpuinfo
 	// lsmod | grep kvm -> kvm_intel, kvm_amd, nvme-tcp

--- a/testutil/mock/iptables/iptables.go
+++ b/testutil/mock/iptables/iptables.go
@@ -21,6 +21,23 @@ type Append struct {
 	Err          error
 }
 
+type AppendUnique struct {
+	Table, Chain string
+	RuleSpec     []string
+	Err          error
+}
+
+type ChainExists struct {
+	Table, Chain string
+	Result       bool
+	Err          error
+}
+
+type ClearAndDeleteChain struct {
+	Table, Chain string
+	Err          error
+}
+
 type ClearChain struct {
 	Table, Chain string
 	Err          error
@@ -50,6 +67,13 @@ type Insert struct {
 	Err          error
 }
 
+type InsertUnique struct {
+	Table, Chain string
+	Pos          int
+	RuleSpec     []string
+	Err          error
+}
+
 type List struct {
 	Table  string
 	Chain  string
@@ -69,17 +93,21 @@ type NewChain struct {
 }
 
 type mockIPTables struct {
-	appends        []Append
-	clearChains    []ClearChain
-	deletes        []Delete
-	deleteChains   []DeleteChain
-	deleteIfExists []DeleteIfExists
-	inserts        []Insert
-	lists          []List
-	listChains     []ListChains
-	newChains      []NewChain
-	t              must.T
-	m              sync.Mutex
+	appends              []Append
+	appendUniques        []AppendUnique
+	chainExists          []ChainExists
+	clearAndDeleteChains []ClearAndDeleteChain
+	clearChains          []ClearChain
+	deletes              []Delete
+	deleteChains         []DeleteChain
+	deleteIfExists       []DeleteIfExists
+	inserts              []Insert
+	insertUniques        []InsertUnique
+	lists                []List
+	listChains           []ListChains
+	newChains            []NewChain
+	t                    must.T
+	m                    sync.Mutex
 }
 
 // Expect adds a list of expected calls.
@@ -88,6 +116,12 @@ func (m *mockIPTables) Expect(calls ...any) *mockIPTables {
 		switch c := call.(type) {
 		case Append:
 			m.ExpectAppend(c)
+		case AppendUnique:
+			m.ExpectAppendUnique(c)
+		case ChainExists:
+			m.ExpectChainExists(c)
+		case ClearAndDeleteChain:
+			m.ExpectClearAndDeleteChain(c)
 		case ClearChain:
 			m.ExpectClearChain(c)
 		case Delete:
@@ -98,6 +132,8 @@ func (m *mockIPTables) Expect(calls ...any) *mockIPTables {
 			m.ExpectDeleteIfExists(c)
 		case Insert:
 			m.ExpectInsert(c)
+		case InsertUnique:
+			m.ExpectInsertUnique(c)
 		case List:
 			m.ExpectList(c)
 		case ListChains:
@@ -118,6 +154,33 @@ func (m *mockIPTables) ExpectAppend(app Append) *mockIPTables {
 	defer m.m.Unlock()
 
 	m.appends = append(m.appends, app)
+	return m
+}
+
+// ExpectAppendUnique adds an expected AppendUnique call.
+func (m *mockIPTables) ExpectAppendUnique(app AppendUnique) *mockIPTables {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.appendUniques = append(m.appendUniques, app)
+	return m
+}
+
+// ExpectChainExists adds an expected ChainExists call.
+func (m *mockIPTables) ExpectChainExists(c ChainExists) *mockIPTables {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.chainExists = append(m.chainExists, c)
+	return m
+}
+
+// ExpectClearAndDeleteChain adds an expected ClearAndDeleteChain call.
+func (m *mockIPTables) ExpectClearAndDeleteChain(c ClearAndDeleteChain) *mockIPTables {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.clearAndDeleteChains = append(m.clearAndDeleteChains, c)
 	return m
 }
 
@@ -166,6 +229,15 @@ func (m *mockIPTables) ExpectInsert(ins Insert) *mockIPTables {
 	return m
 }
 
+// ExpectInsertUnique adds an expected InsertUnique call.
+func (m *mockIPTables) ExpectInsertUnique(ins InsertUnique) *mockIPTables {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.insertUniques = append(m.insertUniques, ins)
+	return m
+}
+
 // ExpectList adds an expected List call.
 func (m *mockIPTables) ExpectList(list List) *mockIPTables {
 	m.m.Lock()
@@ -211,6 +283,71 @@ func (m *mockIPTables) Append(table, chain string, rulespec ...string) error {
 	}
 	must.Eq(m.t, call, received,
 		must.Sprint("Append received incorrect arguments"))
+
+	return call.Err
+}
+
+func (m *mockIPTables) AppendUnique(table, chain string, rulespec ...string) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.appendUniques,
+		must.Sprintf("Unexpected call to AppendUnique - AppendUnique(%q, %q, %q)", table, chain, rulespec))
+	call := m.appendUniques[0]
+	m.appendUniques = m.appendUniques[1:]
+	received := AppendUnique{
+		Table:    table,
+		Chain:    chain,
+		RuleSpec: rulespec,
+		Err:      call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("AppendUnique received incorrect arguments"))
+
+	return call.Err
+}
+
+func (m *mockIPTables) ChainExists(table, chain string) (bool, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.chainExists,
+		must.Sprintf("Unexpected call to ChainExists - ChainExists(%q, %q)", table, chain))
+	call := m.chainExists[0]
+	m.chainExists = m.chainExists[1:]
+	received := ChainExists{
+		Table:  table,
+		Chain:  chain,
+		Result: call.Result,
+		Err:    call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("ChainExists received incorrect arguments"))
+
+	return call.Result, call.Err
+}
+
+func (m *mockIPTables) ClearAndDeleteChain(table, chain string) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.clearAndDeleteChains,
+		must.Sprintf("Unexpected call to ClearAndDeleteChain - ClearAndDeleteChain(%q, %q)", table, chain))
+	call := m.clearAndDeleteChains[0]
+	m.clearAndDeleteChains = m.clearAndDeleteChains[1:]
+	received := ClearAndDeleteChain{
+		Table: table,
+		Chain: chain,
+		Err:   call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("ClearAndDeleteChain received incorrect arguments"))
 
 	return call.Err
 }
@@ -324,6 +461,29 @@ func (m *mockIPTables) Insert(table, chain string, pos int, rulespec ...string) 
 	return call.Err
 }
 
+func (m *mockIPTables) InsertUnique(table, chain string, pos int, rulespec ...string) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.insertUniques,
+		must.Sprintf("Unexpected call to InsertUnique - InsertUnique(%q, %q, %q, %q)", table, chain, pos, rulespec))
+	call := m.insertUniques[0]
+	m.insertUniques = m.insertUniques[1:]
+	received := InsertUnique{
+		Table:    table,
+		Chain:    chain,
+		Pos:      pos,
+		RuleSpec: rulespec,
+		Err:      call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("InsertUnique received incorrect arguments"))
+
+	return call.Err
+}
+
 func (m *mockIPTables) List(table, chain string) ([]string, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -393,6 +553,12 @@ func (m *mockIPTables) AssertExpectations() {
 
 	must.SliceEmpty(m.t, m.appends,
 		must.Sprintf("Append expecting %d more invocations", len(m.appends)))
+	must.SliceEmpty(m.t, m.appendUniques,
+		must.Sprintf("AppendUnique expecting %d more invocations", len(m.appendUniques)))
+	must.SliceEmpty(m.t, m.chainExists,
+		must.Sprintf("ChainExists expecting %d more invocations", len(m.chainExists)))
+	must.SliceEmpty(m.t, m.clearAndDeleteChains,
+		must.Sprintf("ClearAndDeleteChain expecting %d more invocations", len(m.clearAndDeleteChains)))
 	must.SliceEmpty(m.t, m.clearChains,
 		must.Sprintf("ClearChain expecting %d more invocations", len(m.clearChains)))
 	must.SliceEmpty(m.t, m.deletes,
@@ -403,6 +569,8 @@ func (m *mockIPTables) AssertExpectations() {
 		must.Sprintf("DeleteIfExists expecting %d more invocations", len(m.deleteIfExists)))
 	must.SliceEmpty(m.t, m.inserts,
 		must.Sprintf("Insert expecting %d more invocations", len(m.inserts)))
+	must.SliceEmpty(m.t, m.insertUniques,
+		must.Sprintf("InsertUnique expecting %d more invocations", len(m.insertUniques)))
 	must.SliceEmpty(m.t, m.lists,
 		must.Sprintf("List expecting %d more invocations", len(m.lists)))
 	must.SliceEmpty(m.t, m.listChains,

--- a/testutil/mock/iptables/iptables_test.go
+++ b/testutil/mock/iptables/iptables_test.go
@@ -56,6 +56,140 @@ func TestIPTables_Append(t *testing.T) {
 	})
 }
 
+func TestIPTables_AppendUnique(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectAppendUnique(AppendUnique{
+			Table:    "default",
+			Chain:    "default",
+			RuleSpec: []string{"RULE1"},
+		})
+
+		err := iptables.AppendUnique("default", "default", "RULE1")
+		must.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectAppendUnique(AppendUnique{
+			Table:    "default",
+			Chain:    "default",
+			RuleSpec: []string{"RULE1"},
+			Err:      mock.MockTestErr,
+		})
+
+		err := iptables.AppendUnique("default", "default", "RULE1")
+		must.ErrorIs(t, err, mock.MockTestErr)
+	})
+
+	t.Run("incorrect arguments", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		iptables.ExpectAppendUnique(AppendUnique{
+			Table:    "default",
+			Chain:    "non-default",
+			RuleSpec: []string{"RULE1"},
+		})
+		defer mock.AssertIncorrectArguments(t, "AppendUnique")
+
+		iptables.AppendUnique("default", "default")
+	})
+
+	t.Run("unexpected", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		defer mock.AssertUnexpectedCall(t, "AppendUnique")
+
+		iptables.AppendUnique("default", "default")
+	})
+}
+
+func TestIPTables_ChainExists(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectChainExists(ChainExists{
+			Table:  "default",
+			Chain:  "default",
+			Result: true,
+		})
+
+		result, err := iptables.ChainExists("default", "default")
+		must.True(t, result)
+		must.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectChainExists(ChainExists{
+			Table: "default",
+			Chain: "default",
+			Err:   mock.MockTestErr,
+		})
+
+		_, err := iptables.ChainExists("default", "default")
+		must.ErrorIs(t, err, mock.MockTestErr)
+	})
+
+	t.Run("incorrect arguments", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		iptables.ExpectChainExists(ChainExists{
+			Table: "default",
+			Chain: "default",
+		})
+		defer mock.AssertIncorrectArguments(t, "ChainExists")
+
+		iptables.ChainExists("default", "non-default")
+	})
+
+	t.Run("unexpected", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		defer mock.AssertUnexpectedCall(t, "ChainExists")
+
+		iptables.ChainExists("default", "default")
+	})
+}
+
+func TestIPTables_ClearAndDeleteChain(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectClearAndDeleteChain(ClearAndDeleteChain{
+			Table: "default",
+			Chain: "default",
+		})
+
+		err := iptables.ClearAndDeleteChain("default", "default")
+		must.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectClearAndDeleteChain(ClearAndDeleteChain{
+			Table: "default",
+			Chain: "default",
+			Err:   mock.MockTestErr,
+		})
+
+		err := iptables.ClearAndDeleteChain("default", "default")
+		must.ErrorIs(t, err, mock.MockTestErr)
+	})
+
+	t.Run("incorrect arguments", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		iptables.ExpectClearAndDeleteChain(ClearAndDeleteChain{
+			Table: "default",
+			Chain: "default",
+		})
+		defer mock.AssertIncorrectArguments(t, "ClearAndDeleteChain")
+
+		iptables.ClearAndDeleteChain("default", "non-default")
+	})
+
+	t.Run("unexpected", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		defer mock.AssertUnexpectedCall(t, "ClearAndDeleteChain")
+
+		iptables.ClearAndDeleteChain("default", "default")
+	})
+}
+
 func TestIPTables_ClearChain(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		iptables := New(t)
@@ -278,6 +412,55 @@ func TestIPTables_Insert(t *testing.T) {
 		defer mock.AssertUnexpectedCall(t, "Insert")
 
 		iptables.Insert("default", "non-default", 1, "RULE1")
+	})
+}
+
+func TestIPTables_InsertUnique(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectInsertUnique(InsertUnique{
+			Table:    "default",
+			Chain:    "default",
+			Pos:      1,
+			RuleSpec: []string{"RULE1"},
+		})
+
+		err := iptables.InsertUnique("default", "default", 1, "RULE1")
+		must.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		iptables := New(t)
+		iptables.ExpectInsertUnique(InsertUnique{
+			Table:    "default",
+			Chain:    "default",
+			Pos:      1,
+			RuleSpec: []string{"RULE1"},
+			Err:      mock.MockTestErr,
+		})
+
+		err := iptables.InsertUnique("default", "default", 1, "RULE1")
+		must.ErrorIs(t, err, mock.MockTestErr)
+	})
+
+	t.Run("incorrect arguments", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		iptables.ExpectInsertUnique(InsertUnique{
+			Table:    "default",
+			Chain:    "default",
+			Pos:      1,
+			RuleSpec: []string{"RULE1"},
+		})
+		defer mock.AssertIncorrectArguments(t, "InsertUnique")
+
+		iptables.InsertUnique("default", "non-default", 1, "RULE1")
+	})
+
+	t.Run("unexpected", func(t *testing.T) {
+		iptables := New(mock.MockT())
+		defer mock.AssertUnexpectedCall(t, "InsertUnique")
+
+		iptables.InsertUnique("default", "non-default", 1, "RULE1")
 	})
 }
 

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -121,6 +121,19 @@ type TeardownSpec struct {
 	Network string
 }
 
+// FilterRemoval contains the information required to remove any configuration
+// applied to the packet filter for routing to/from the task Virtual Machine.
+type FilterRemoval struct {
+	// Name is the name of the package that created the
+	// FilterRemoval information.
+	Name string
+
+	// Data is an encodable type that provides the required information
+	// to remove any packet filtering configuration related to the task.
+	// The actual type will be dependent on the underlying package in use.
+	Data any
+}
+
 // Equal returns if the given TeardownSpec is equal.
 func (t *TeardownSpec) Equal(rhs *TeardownSpec) bool {
 	if t == nil && rhs == nil {


### PR DESCRIPTION
Extracts iptables functionality from the libvirt provider into a standalone package. The implementation has been updated to a singleton allowing additions and removals to be serialized. Chain and rule modifications are now collected and executed together as a single request which allows inspecting the existing iptables state and pruning the request to only include needed modifications.

Testing has also been updated to use generated chain names to prevent clobbering the actual chains used by the plugin. The helper for generating a new testing instance also includes an optional cleanup helper to remove the iptables modifications from the test.

_EDIT_: I've tacked on a couple extra commits to this PR. The first moves the location of the package from `./net/iptables` to `./net/filter/iptables`. The second adds a `filter.Filter` generic interface which iptables is implementing. This will make it easier to have alternative implementations (which will be needed soon).