### PR TITLE
net: address discovery using arp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/hashicorp/go-set v0.1.14
 	github.com/hashicorp/go-set/v3 v3.0.1
 	github.com/hashicorp/nomad v1.11.3
+	github.com/jsimonetti/rtnetlink/v2 v2.2.0
 	github.com/shoenig/test v1.13.2
+	golang.org/x/sys v0.44.0
 	libvirt.org/go/libvirt v1.12003.0
 	libvirt.org/go/libvirtxml v1.12002.0
 )
@@ -98,6 +100,8 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mdlayher/netlink v1.8.0 // indirect
+	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/miekg/dns v1.1.72 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -138,7 +142,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/ceph/go-ceph v0.39.0/go.mod h1:UId58dqtDKTwnv3OY8rdpC+Ulz/AVpcvZqjXDI
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cilium/ebpf v0.20.0 h1:atwWj9d3NffHyPZzVlx3hmw1on5CLe9eljR8VuHTwhM=
+github.com/cilium/ebpf v0.20.0/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -272,6 +274,8 @@ github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f/go.mod h1:3J2
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/jsimonetti/rtnetlink/v2 v2.2.0 h1:/KfZ310gOAFrXXol5VwnFEt+ucldD/0dsSRZwpHCP9w=
+github.com/jsimonetti/rtnetlink/v2 v2.2.0/go.mod h1:lbjDHxC+5RJ08lzPeA90Ls2pEoId3F08MoEMlhfHxeI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -303,6 +307,10 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5YyvvlM=
+github.com/mdlayher/netlink v1.8.0/go.mod h1:UhgKXUlDQhzb09DrCl2GuRNEglHmhYoWAHid9HK3594=
+github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
+github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
 github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/net/arp/arp.go
+++ b/net/arp/arp.go
@@ -1,0 +1,24 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arp
+
+import (
+	"context"
+	"net"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+type ARP interface {
+	// Discover will poll known ARP records on an interface for a matching MAC
+	// address and send any detected IP addresses to the channel for the life
+	// of the context.
+	Discover(context.Context, *net.Interface, net.HardwareAddr) (<-chan net.IP, error)
+
+	// SetLogger sets a custom logger.
+	SetLogger(hclog.Logger)
+
+	// SetContext sets a custom context.
+	SetContext(context.Context)
+}

--- a/net/arp/arp_nonlinux.go
+++ b/net/arp/arp_nonlinux.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !linux
+
+package arp
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/internal/errs"
+)
+
+// IsAvailable returns if ARP functionality is available.
+func IsAvailable() bool {
+	return false
+}
+
+func New() *arper {
+	return &arper{}
+}
+
+type arper struct{}
+
+func (a *arper) Discover(context.Context, *net.Interface, net.HardwareAddr) (<-chan net.IP, error) {
+	return nil, fmt.Errorf("ARP is %w on this platform", errs.ErrNotImplemented)
+}
+
+func (a *arper) SetLogger(hclog.Logger) {}
+
+func (a *arper) SetContext(context.Context) {}

--- a/net/arp/arper_linux.go
+++ b/net/arp/arper_linux.go
@@ -1,0 +1,386 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+package arp
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-set/v3"
+	"github.com/jsimonetti/rtnetlink/v2"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// defaultPollingInterval is the polling interval.
+	defaultPollingInterval = 1 * time.Second
+)
+
+var (
+	// loaderMu is used to synchronize singleton creation.
+	loaderMu sync.Mutex
+
+	// singleton is the single instance of the ARP interface.
+	singleton *arper
+)
+
+// IsAvailable returns if ARP functionality is available.
+func IsAvailable() bool {
+	return true
+}
+
+// New returns the ARP interface, creating the singleton if
+// it does not already exist.
+func New() *arper {
+	loaderMu.Lock()
+	defer loaderMu.Unlock()
+
+	if singleton != nil {
+		return singleton
+	}
+
+	singleton = &arper{
+		ctx:              context.Background(),
+		logger:           hclog.Default().Named("arp"),
+		pollingInterval:  defaultPollingInterval,
+		notifyCh:         make(chan struct{}),
+		neighborsFn:      getNeighbors,
+		interfaceByIndex: net.InterfaceByIndex,
+	}
+
+	return singleton
+}
+
+// neighborsFn is the function that returns the list of
+// neighbor table entries.
+type neighborsFn func() ([]rtnetlink.NeighMessage, error)
+
+// interfaceByIndex returns the network interface by the
+// index provided.
+type interfaceByIndex func(int) (*net.Interface, error)
+
+// request is an incoming request for address discovery.
+type request struct {
+	hwaddr net.HardwareAddr // MAC address to match.
+	iface  *net.Interface   // interface to match.
+	ch     chan net.IP      // channel to send results.
+}
+
+// matches returns if entry is a match for the request.
+func (r *request) matches(entry *entry) bool {
+	return !entry.addr.IsUnspecified() &&
+		slices.Equal(entry.hwaddr, r.hwaddr) &&
+		r.iface.Name == entry.device
+}
+
+// entry is an ARP entry.
+type entry struct {
+	addr   net.IP           // IP address.
+	hwaddr net.HardwareAddr // MAC address.
+	device string           // interface name.
+}
+
+// arper implements the ARP interface.
+type arper struct {
+	ctx             context.Context    // controls life of instance. used for testing, background context in actual use.
+	activeReqs      uint               // count of currently active requests
+	entries         []*entry           // ARP table entries.
+	polling         bool               // polling goroutine is running.
+	pollingDone     chan struct{}      // channel that is closed when polling goroutine is complete.
+	pollingCtx      context.Context    // context used by the polling goroutine.
+	pollingCancel   context.CancelFunc // cancel func used to stop the polling goroutine.
+	pollingInterval time.Duration      // polling interval.
+	notifyCh        chan struct{}      // channel that is closed when updated entries are available.
+
+	logger     hclog.Logger
+	notifyChMu sync.Mutex
+	requestsMu sync.Mutex
+	entriesMu  sync.RWMutex
+
+	// Items below are defined to enable testing.
+	neighborsFn      // function to provide neighbor list
+	interfaceByIndex // function to provide network interface by index
+}
+
+// Discover will poll the neighbor entry table (ARP entries) for a matching
+// MAC address and send found IP addresses to the channel until the provided
+// context has been canceled.
+func (a *arper) Discover(ctx context.Context, iface *net.Interface, hwaddr net.HardwareAddr) (<-chan net.IP, error) {
+	return a.addRequest(ctx, &request{
+		hwaddr: hwaddr,
+		iface:  iface,
+		ch:     make(chan net.IP),
+	})
+}
+
+// SetContext sets a custom context.
+func (a *arper) SetContext(ctx context.Context) {
+	a.ctx = ctx
+}
+
+// SetLogger sets a custom logger.
+func (a *arper) SetLogger(logger hclog.Logger) {
+	a.logger = logger
+}
+
+// addRequest adds a new discovery request.
+func (a *arper) addRequest(ctx context.Context, req *request) (<-chan net.IP, error) {
+	a.requestsMu.Lock()
+	defer a.requestsMu.Unlock()
+
+	// The polling goroutine will only run if there are active
+	// requests. If it's not running, start it.
+	if !a.polling {
+		// If the completeCh is available then wait on it in case a
+		// previous polling goroutine is still cleaning up.
+		if a.pollingDone != nil {
+			select {
+			case <-a.pollingDone:
+			case <-a.ctx.Done():
+				return nil, a.ctx.Err()
+			}
+		}
+
+		// Set a new completion channel.
+		a.pollingDone = make(chan struct{})
+		// Create a cancelable context for the polling goroutine.
+		a.pollingCtx, a.pollingCancel = context.WithCancel(a.ctx)
+		// Flag that we are actively polling.
+		a.polling = true
+		// Start the polling goroutine.
+		go a.poll()
+	}
+
+	// Handle the request
+	go a.handleRequest(ctx, req)
+
+	// And send the channel back.
+	return req.ch, nil
+}
+
+// requestStarted increments the active requests count.
+func (a *arper) requestStarted() {
+	a.requestsMu.Lock()
+	defer a.requestsMu.Unlock()
+
+	// Increment the active requests.
+	a.activeReqs++
+}
+
+// requestComplete decrements the active requests count and stops the
+// polling goroutine if there are no remaining active requests.
+func (a *arper) requestComplete() {
+	a.requestsMu.Lock()
+	defer a.requestsMu.Unlock()
+
+	// Decrement the active requests.
+	a.activeReqs--
+
+	// If there are no active requests, stop polling.
+	if a.activeReqs == 0 && a.pollingCancel != nil {
+		// Mark as no longer polling.
+		a.polling = false
+		// Cancel the polling context to stop the polling goroutine.
+		a.pollingCancel()
+	}
+}
+
+// handleRequest will attempt to find IP addresses matching the
+// request until the context (request context or polling context)
+// have completed.
+func (a *arper) handleRequest(ctx context.Context, req *request) {
+	// Increment the active requests count.
+	a.requestStarted()
+
+	// Decrement the active requests count on the way out.
+	defer a.requestComplete()
+
+	// Close the request channel when done handling the request.
+	defer close(req.ch)
+
+	// Remember seen addresses so we only send them once.
+	seenAddrs := set.NewTreeSet(bytes.Compare)
+
+	for {
+		// Find any matches and send them.
+		entries := a.find(req)
+		for _, entry := range entries {
+			// If we have seen this address already, skip.
+			if !seenAddrs.Insert(entry.addr) {
+				continue
+			}
+
+			select {
+			case req.ch <- entry.addr:
+			case <-ctx.Done():
+				// Request context is done so we can bail.
+				return
+			case <-a.pollingCtx.Done():
+				// polling context (or its parent) is done so it's time to go.
+				return
+			}
+		}
+
+		// Wait for new entries to be available or context
+		// to be done.
+		select {
+		case <-a.notificationCh():
+			// New entries available so loop.
+		case <-ctx.Done():
+			// Request context is done so we can bail.
+			return
+		case <-a.pollingCtx.Done():
+			// polling context (or its parent) is done so it's time to go.
+			return
+		}
+	}
+}
+
+// notificationCh returns a channel to wait on for new ARP
+// entries to be available.
+func (a *arper) notificationCh() <-chan struct{} {
+	a.notifyChMu.Lock()
+	defer a.notifyChMu.Unlock()
+
+	return a.notifyCh
+}
+
+// notifyRequests closes the existing readyCh to broadcast
+// notification of new ARP entries and creates a new readyCh
+// for requests to wait on.
+func (a *arper) notifyRequests() {
+	a.notifyChMu.Lock()
+	defer a.notifyChMu.Unlock()
+
+	close(a.notifyCh)
+	a.notifyCh = make(chan struct{})
+}
+
+// poll will load any available ARP entries, notify any
+// waiting requests of new entries, and wait the polling
+// interval before running again until the polling context
+// is canceled.
+func (a *arper) poll() {
+	defer func() {
+		// Ensure the polling context is canceled when we stop polling.
+		a.pollingCancel()
+		// Clear the current list of ARP entries.
+		a.clearEntries()
+		// Notify that this poller is complete.
+		close(a.pollingDone)
+	}()
+
+	for {
+		// Load the currently available ARP entries.
+		a.loadARPs()
+
+		// Notify of new entries.
+		a.notifyRequests()
+
+		select {
+		// If the polling context is done then there are no active requests
+		// or the parent context is done. Either way, we are done here.
+		case <-a.pollingCtx.Done():
+			a.logger.Debug("stopping polling due to context completion")
+			return
+		// Wait for the polling interval before reloading the ARP entries.
+		case <-time.After(a.pollingInterval):
+		}
+	}
+}
+
+// clearEntries cleans up clears any existing ARP table entries.
+func (a *arper) clearEntries() {
+	a.entriesMu.Lock()
+	defer a.entriesMu.Unlock()
+
+	// Clear the current entries list and any requests.
+	a.entries = make([]*entry, 0)
+}
+
+// loadARPs loads all the ARP entries which are currently reachable
+// and are not stale.
+func (a *arper) loadARPs() {
+	a.logger.Trace("loading available ARP entries")
+
+	a.entriesMu.Lock()
+	defer a.entriesMu.Unlock()
+
+	// Start with fetching the neighbors list.
+	neighbors, err := a.neighborsFn()
+	if err != nil {
+		a.logger.Error("failed to get neighbor list", "error", err)
+		return
+	}
+
+	// Collect all the current neighbor entries.
+	results := []*entry{}
+	for _, n := range neighbors {
+		iface, err := a.interfaceByIndex(int(n.Index))
+		if err != nil {
+			a.logger.Warn("invalid interface index for neighbor, ignoring", "error", err, "index", n.Index, "neighbor", n)
+			continue
+		}
+
+		entry := entry{
+			device: iface.Name,
+			hwaddr: n.Attributes.LLAddress,
+			addr:   n.Attributes.Address,
+		}
+
+		// If the entry is not reachable, ignore it.
+		if n.State&unix.NUD_REACHABLE != unix.NUD_REACHABLE {
+			a.logger.Trace("ignoring unreachable entry", "entry", entry)
+			continue
+		}
+
+		// If the entry is stale, ignore it.
+		if n.State&unix.NUD_STALE == unix.NUD_STALE {
+			a.logger.Trace("ignore stale entry", "entry", entry)
+			continue
+		}
+
+		results = append(results, &entry)
+	}
+
+	// Now finish up by updating the entries.
+	a.entries = results
+
+	a.logger.Trace("completed loading ARP entries", "count", len(a.entries))
+}
+
+// find attempts to find any ARP entry matches for the provided
+// request and returns all found matches.
+func (a *arper) find(req *request) []*entry {
+	a.entriesMu.RLock()
+	defer a.entriesMu.RUnlock()
+
+	matches := make([]*entry, 0)
+
+	for _, entry := range a.entries {
+		if req.matches(entry) {
+			matches = append(matches, entry)
+		}
+	}
+
+	return matches
+}
+
+// getNeighbors returns the neighbor list from netlink.
+func getNeighbors() ([]rtnetlink.NeighMessage, error) {
+	// Establish a netlink connection to fetch the neighbors.
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn.Neigh.List()
+}

--- a/net/arp/arper_linux_test.go
+++ b/net/arp/arper_linux_test.go
@@ -1,0 +1,478 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package arp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/jsimonetti/rtnetlink/v2"
+	"github.com/shoenig/test/must"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	testReqMAC    = "10:66:6a:f2:04:dd"
+	testReqIP     = "10.162.122.209"
+	testReqDevice = "eth0"
+
+	testPollingInterval = 50 * time.Millisecond
+)
+
+// setEntries sets a custom list of entries.
+func (a *arper) setEntries(entries []*entry) {
+	a.entriesMu.Lock()
+	defer a.entriesMu.Unlock()
+
+	a.entries = entries
+}
+
+// setNeighbors sets a custom neighbors function.
+func (a *arper) setNeighbors(fn neighborsFn) {
+	a.entriesMu.Lock()
+	defer a.entriesMu.Unlock()
+
+	a.neighborsFn = fn
+}
+
+// isPolling returns currently polling
+func (a *arper) isPolling() bool {
+	a.requestsMu.Lock()
+	defer a.requestsMu.Unlock()
+
+	return a.polling
+}
+
+// activeRequests returns the current number of active requests.
+func (a *arper) activeRequests() uint {
+	a.requestsMu.Lock()
+	defer a.requestsMu.Unlock()
+
+	return a.activeReqs
+}
+
+func mkTestReq(t *testing.T) *request {
+	mac, err := net.ParseMAC(testReqMAC)
+	must.NoError(t, err)
+	return &request{
+		hwaddr: mac,
+		iface:  &net.Interface{Name: testReqDevice},
+		ch:     make(chan net.IP, 1),
+	}
+}
+
+func mkTestEntry(t *testing.T) *entry {
+	mac, err := net.ParseMAC(testReqMAC)
+	must.NoError(t, err)
+	return &entry{
+		hwaddr: mac,
+		addr:   net.ParseIP(testReqIP),
+		device: testReqDevice,
+	}
+}
+
+func mkTestNeighMessage(t *testing.T) rtnetlink.NeighMessage {
+	mac, err := net.ParseMAC(testReqMAC)
+	must.NoError(t, err)
+
+	return rtnetlink.NeighMessage{
+		State: unix.NUD_REACHABLE,
+		Attributes: &rtnetlink.NeighAttributes{
+			Address:   net.ParseIP(testReqIP),
+			LLAddress: mac,
+		},
+	}
+}
+
+func testArper(t *testing.T) *arper {
+	ctx, cancel := context.WithCancel(t.Context())
+	return &arper{
+		ctx:             t.Context(),
+		logger:          hclog.NewNullLogger(),
+		notifyCh:        make(chan struct{}),
+		pollingCtx:      ctx,
+		pollingCancel:   cancel,
+		pollingInterval: testPollingInterval,
+		neighborsFn:     func() (_ []rtnetlink.NeighMessage, _ error) { return },
+		interfaceByIndex: func(int) (*net.Interface, error) {
+			return &net.Interface{Name: "eth0"}, nil
+		},
+	}
+}
+
+func Test_arper_Discover(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		a := testArper(t)
+		a.setNeighbors(func() ([]rtnetlink.NeighMessage, error) {
+			return []rtnetlink.NeighMessage{mkTestNeighMessage(t)}, nil
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		stubReq := mkTestReq(t)
+
+		ch, err := a.Discover(ctx, stubReq.iface, stubReq.hwaddr)
+		must.NoError(t, err)
+
+		// Result should be received.
+		select {
+		case result := <-ch:
+			must.Eq(t, testReqIP, result.String())
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("expected result, received none")
+		}
+
+		must.One(t, a.activeRequests(), must.Sprint("expected on active request"))
+
+		// Polling should be active.
+		must.True(t, a.isPolling(), must.Sprint("expected polling to be active"))
+
+		// Cancel the request context
+		cancel()
+
+		// Wait for the request to complete.
+		select {
+		case <-ch:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("expected request channel to be closed")
+		}
+
+		// With no active requests, the poller should stop.
+		select {
+		case <-a.pollingDone:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("expected polling to be stopped")
+		}
+
+		must.False(t, a.isPolling(), must.Sprint("expected polling to be inactive"))
+		must.Zero(t, a.activeRequests(), must.Sprint("expected no active requests"))
+	})
+
+	t.Run("ok multiple requests", func(t *testing.T) {
+		count := 8
+		reqs := make([]*request, count)
+		messages := make([]rtnetlink.NeighMessage, count)
+		for i := range count {
+			r := mkTestReq(t)
+			mac, _ := net.ParseMAC(strings.ReplaceAll(testReqMAC, ":dd", fmt.Sprintf(":0%d", i)))
+			r.hwaddr = mac
+			reqs[i] = r
+
+			m := mkTestNeighMessage(t)
+			m.Attributes.LLAddress = mac
+			m.Attributes.Address = net.ParseIP(strings.ReplaceAll(testReqIP, "209", fmt.Sprintf("%d", i)))
+			messages[i] = m
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		a := testArper(t)
+		a.ctx = ctx
+		reqChs := make([]<-chan net.IP, count)
+		// Load in all the requests.
+		for i, r := range reqs {
+			ch, err := a.Discover(t.Context(), r.iface, r.hwaddr)
+			must.NoError(t, err)
+			reqChs[i] = ch
+		}
+
+		// Polling should be active now.
+		must.True(t, a.isPolling(), must.Sprint("expected polling to be active"))
+
+		// Check that all requests are waiting.
+		for _, ch := range reqChs {
+			select {
+			case result := <-ch:
+				t.Fatalf("received unexpected result: %v", result)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+
+		// Add half the messages to the neighbor list.
+		a.setNeighbors(func() ([]rtnetlink.NeighMessage, error) {
+			return messages[0 : count/2], nil
+		})
+
+		// Wait for results on first half of requests.
+		for i := range count / 2 {
+			select {
+			case result := <-reqChs[i]:
+				must.Eq(t, messages[i].Attributes.Address, result)
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("failed to receive expected result")
+			}
+		}
+
+		// All requests should still be waiting.
+		for i := range count {
+			select {
+			case result := <-reqChs[i]:
+				t.Fatalf("received unexpected result: %v", result)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+
+		// Add all messages to neighbor list.
+		a.setNeighbors(func() ([]rtnetlink.NeighMessage, error) {
+			return messages, nil
+		})
+
+		// Wait for results on last half of requests.
+		for i := range count - (count / 2) {
+			i = (count / 2) + i
+
+			select {
+			case result := <-reqChs[i]:
+				must.Eq(t, messages[i].Attributes.Address, result)
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("failed to receive expected result")
+			}
+		}
+
+		// All requests should now be waiting.
+		for _, ch := range reqChs {
+			select {
+			case result := <-ch:
+				t.Fatalf("received unexpected result: %v", result)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+
+		// Cancel the parent context to shut the arper down completely.
+		cancel()
+
+		// Wait for it to stop polling.
+		select {
+		case <-a.pollingDone:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("expected polling to stop")
+		}
+
+		// All request channels should now be closed.
+		for _, ch := range reqChs {
+			select {
+			case <-ch:
+			case <-time.After(10 * time.Millisecond):
+				t.Fatal("request channel should be closed")
+			}
+		}
+	})
+}
+
+func Test_arper_handleRequest(t *testing.T) {
+	t.Run("no match request context cancel", func(t *testing.T) {
+		a := testArper(t)
+		req := mkTestReq(t)
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		go a.handleRequest(ctx, req)
+
+		// No address should be sent since no entries are loaded.
+		select {
+		case <-req.ch:
+			t.Fatal("received unexpected result")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		// There should be a single active request.
+		must.One(t, a.activeRequests(), must.Sprint("expected one active request"))
+
+		// Cancel the request context.
+		cancel()
+
+		// Wait on the channel for it to be closed.
+		select {
+		case <-req.ch:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("request channel did not close")
+		}
+
+		// There should be no active requests.
+		must.Zero(t, a.activeRequests(), must.Sprint("expected no active requests"))
+	})
+
+	t.Run("no match parent context cancel", func(t *testing.T) {
+		a := testArper(t)
+		req := mkTestReq(t)
+
+		go a.handleRequest(t.Context(), req)
+
+		// No address should be sent since no entries are loaded.
+		select {
+		case <-req.ch:
+			t.Fatal("received unexpected result")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		// There should be a single active request.
+		must.One(t, a.activeRequests(), must.Sprint("expected one active request"))
+
+		// Cancel the parent context context.
+		a.pollingCancel()
+
+		// Wait on the channel for it to be closed.
+		select {
+		case <-req.ch:
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("request channel did not close")
+		}
+
+		// There should be no active requests.
+		must.Zero(t, a.activeRequests(), must.Sprint("expected no active requests"))
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := testArper(t)
+		req := mkTestReq(t)
+		go a.handleRequest(t.Context(), req)
+
+		// Make sure nothing has been sent.
+		select {
+		case <-req.ch:
+			t.Fatal("received unexpected result")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		// Add a matching entry.
+		a.setEntries([]*entry{mkTestEntry(t)})
+
+		// Notify of new entries.
+		a.notifyRequests()
+
+		// And we should get a match.
+		select {
+		case result := <-req.ch:
+			must.Eq(t, testReqIP, result.String())
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("expected result but none received")
+		}
+
+		// Notify again so the entries are reprocessed.
+		a.notifyRequests()
+
+		// Match was already sent so it should not be
+		// received again.
+		select {
+		case <-req.ch:
+			t.Fatal("match was delivered a second time")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("multiple matches", func(t *testing.T) {
+		a := testArper(t)
+		req := mkTestReq(t)
+		go a.handleRequest(t.Context(), req)
+
+		// Make sure nothing has been sent.
+		select {
+		case <-req.ch:
+			t.Fatal("received unexpected result")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		entries := []*entry{
+			mkTestEntry(t),
+			mkTestEntry(t),
+			mkTestEntry(t),
+		}
+		entries[0].addr = net.ParseIP("10.2.3.2")
+		mac, _ := net.ParseMAC("10:77:6a:00:09:cc")
+		entries[2].hwaddr = mac
+
+		// Set the entries.
+		a.setEntries(entries)
+
+		// Notify of new entries.
+		a.notifyRequests()
+
+		// And we should get both matches.
+		idx := 0
+		var complete bool
+		for !complete {
+			select {
+			case result := <-req.ch:
+				must.Less(t, 2, idx, must.Sprint("too many matches received"))
+				must.Eq(t, entries[idx].addr, result)
+				idx++
+			case <-time.After(50 * time.Millisecond):
+				complete = true
+			}
+		}
+
+		must.True(t, complete)
+	})
+}
+
+func Test_arper_loadARPs(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		a := testArper(t)
+		a.loadARPs()
+
+		must.SliceEmpty(t, a.entries)
+	})
+
+	t.Run("reachable neighbor", func(t *testing.T) {
+		a := testArper(t)
+		a.setNeighbors(func() ([]rtnetlink.NeighMessage, error) {
+			return []rtnetlink.NeighMessage{mkTestNeighMessage(t)}, nil
+		})
+
+		a.loadARPs()
+		must.SliceLen(t, 1, a.entries)
+		must.SliceContains(t, a.entries, mkTestEntry(t),
+			must.Cmp(cmp.AllowUnexported(entry{})))
+	})
+
+	t.Run("stale neighbor", func(t *testing.T) {
+		a := testArper(t)
+		staleNeighbor := mkTestNeighMessage(t)
+		staleNeighbor.Attributes.Address = net.ParseIP("10.0.0.2")
+		staleNeighbor.State |= unix.NUD_STALE
+		a.setNeighbors(func() ([]rtnetlink.NeighMessage, error) {
+			return []rtnetlink.NeighMessage{
+				mkTestNeighMessage(t),
+				staleNeighbor,
+			}, nil
+		})
+
+		a.loadARPs()
+		must.SliceLen(t, 1, a.entries)
+		must.SliceContains(t, a.entries, mkTestEntry(t),
+			must.Cmp(cmp.AllowUnexported(entry{})))
+	})
+}
+
+func Test_arper_find(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		a := testArper(t)
+		must.SliceEmpty(t, a.find(mkTestReq(t)),
+			must.Sprint("expected no matches"))
+	})
+
+	t.Run("match", func(t *testing.T) {
+		a := testArper(t)
+		testEntry := mkTestEntry(t)
+		a.setEntries([]*entry{testEntry})
+
+		result := a.find(mkTestReq(t))
+		must.Eq(t, []*entry{testEntry}, result)
+	})
+
+	t.Run("multiple matches", func(t *testing.T) {
+		a := testArper(t)
+		firstMatch := mkTestEntry(t)
+		secondMatch := mkTestEntry(t)
+		secondMatch.addr = net.ParseIP("10.162.122.111")
+		a.setEntries([]*entry{
+			firstMatch,
+			secondMatch,
+		})
+
+		result := a.find(mkTestReq(t))
+		must.Eq(t, []*entry{firstMatch, secondMatch}, result)
+	})
+}


### PR DESCRIPTION
Adds a new `arp` package which can be used for discovering a task's address using the MAC address of the virtual machine network interface device. Discover requests will poll the neighbor list using netlink to find matches that are reachable and not stale.