### PR TITLE
libvirt: use iptables package

### DIFF
--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
@@ -98,6 +99,10 @@ var (
 	ErrStartingLibvirt = errors.New("unable to start libvirt")
 	ErrImageNotFound   = errors.New("disk image not found at path")
 	ErrTaskCrashed     = errors.New("task has crashed")
+
+	// loggerMu is used for synchronizing the setting of the default
+	// logger. It only matters for testing.
+	loggerMu sync.Mutex
 )
 
 // TaskState is the runtime state which is encoded in the handle returned to
@@ -135,7 +140,7 @@ func NewPlugin(ctx context.Context, logger hclog.Logger) drivers.DriverPlugin {
 	})
 
 	// Set the default logger.
-	hclog.SetDefault(logger)
+	setDefaultLogger(logger)
 
 	// Should we check if extentions and kernel modules are there?
 	// grep -E 'svm|vmx' /proc/cpuinfo
@@ -804,4 +809,14 @@ func (d *VirtDriverPlugin) volumeCleanup(s storage.Storage, vols []storage.Volum
 			d.logger.Error("volume cleanup failure", "pool", v.Pool, "volume", v.Name, "error", err)
 		}
 	}
+}
+
+// setDefaultLogger synchronizes the setting of the default hclog
+// logger. It is used to prevent race conditions from being detected
+// when testing.
+func setDefaultLogger(logger hclog.Logger) {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
+	hclog.SetDefault(logger)
 }

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
 	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/net/filter/iptables"
 	"github.com/hashicorp/nomad-driver-virt/providers"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/storage"
@@ -907,7 +908,14 @@ func TestVirtDriver_Libvirt(t *testing.T) {
 			MountFilesystems: set.From([]libvirt.MountFilesystem{libvirt.MountFs9p}),
 		},
 	}
-	prv := providers.New(t.Context(), logger, libvirt.WithCaps(nil, guests))
+	// Use a testing iptables that has generated names to prevent
+	// clobbering local iptables configuration.
+	ipt, cleanup := iptables.TestNew(t)
+	t.Cleanup(cleanup)
+	prv := providers.New(t.Context(), logger,
+		libvirt.WithCaps(nil, guests),
+		libvirt.WithNetworkFilter(ipt),
+	)
 	driver := testHarness(t, config, prv, cloudinitMock, task, 5*time.Second)
 
 	// Stub the cloudinit generated file

--- a/providers/libvirt/libvirt.go
+++ b/providers/libvirt/libvirt.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/nomad-driver-virt/internal/errs"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/net/filter"
 	libvirtnet "github.com/hashicorp/nomad-driver-virt/providers/libvirt/net"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	libvirt_storage "github.com/hashicorp/nomad-driver-virt/providers/libvirt/storage"
@@ -191,6 +192,13 @@ func WithCaps(host *libvirtxml.CapsHost, guests map[string]*CapsGuest) Option {
 			Host:   host,
 			Guests: guests,
 		}
+	}
+}
+
+// WithNetworkFilter sets the filter on the networking.
+func WithNetworkFilter(f filter.Filter) Option {
+	return func(p *provider) {
+		p.networking.SetFilter(f)
 	}
 }
 
@@ -1084,12 +1092,6 @@ func (p *provider) getDomainVolumes(dom *libvirt.Domain) ([]storage.Volume, erro
 	}
 
 	return p.storage.DiscoverVolumes(info.Devices.Disks)
-}
-
-// mountFsAvailable returns if the requested filesystems support is available.
-func (p *provider) mountFsAvailable(name string) bool {
-	_, ok := p.availableMountFs[name]
-	return ok
 }
 
 // generateVirtiofsMountCmds generates mounts commands for virtiofs.

--- a/providers/libvirt/net/net.go
+++ b/providers/libvirt/net/net.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-driver-virt/net/filter"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 )
 
@@ -27,30 +28,14 @@ var (
 type Controller struct {
 	logger  hclog.Logger
 	netConn shims.Connect
+	filter  filter.Filter
 
 	dhcpLeaseDiscoveryInterval time.Duration
 	dhcpLeaseDiscoveryTimeout  time.Duration
 
-	// routeLocalnetTemplate is a template for creating the path to the kernel
-	// runtime configuration for device localnet routing.
-	routeLocalnetTemplate string
-
-	// interfaceByIPGetter is the function that queries the host using the
-	// passed IP address and identifies the interface it is assigned to. It is
-	// a field within the controller to aid testing.
-	interfaceByIPGetter
-
 	// ipByInterfaceGetter is the function that queries the host using the
 	// passed interface name and identifies the IP address assigned to it.
 	ipByInterfaceGetter
-
-	// iptablesInterfaceGetter is the function that returns an interface
-	// for IPTables.
-	iptablesInterfaceGetter
-
-	// routingIngerfaceByIPGetter is the function that queries the host using
-	// the passed IP address and identifies the interface used to reach it.
-	routingInterfaceByIPGetter
 }
 
 // NewController returns a Controller which implements the net.Net interface
@@ -60,30 +45,12 @@ func NewController(logger hclog.Logger, conn shims.Connect) *Controller {
 	return &Controller{
 		dhcpLeaseDiscoveryInterval: defaultDHCPLeaseDiscoveryInterval,
 		dhcpLeaseDiscoveryTimeout:  defaultDHCPLeaseDiscoveryTimeout,
-		interfaceByIPGetter:        getInterfaceByIP,
 		ipByInterfaceGetter:        getIPByInterface,
-		iptablesInterfaceGetter:    newIPTables,
 		logger:                     logger.Named("net"),
 		netConn:                    conn,
-		routingInterfaceByIPGetter: getRoutingInterfaceByIP,
-		routeLocalnetTemplate:      routeLocalnetPathTemplate,
 	}
 }
-
-// interfaceByIPGetter is the function signature used to identify the host's
-// interface using a passed IP address. This is primarily used for testing,
-// where we don't know the host, and we want to ensure stability and
-// consistency when this is called.
-type interfaceByIPGetter func(ip stdnet.IP) (string, error)
 
 // ipByInterfaceGetter is the function that queries the host using the
 // passed interface name and identifies the IP address assigned to it.
 type ipByInterfaceGetter func(name string) (stdnet.IP, error)
-
-// iptablesInterfaceGetter is the function that returns an interface
-// for IPTables.
-type iptablesInterfaceGetter func() (IPTables, error)
-
-// routingInterfaceByIPGetter is the function signature used to identify
-// the host interface used for an IP address.
-type routingInterfaceByIPGetter func(ip string) (string, error)

--- a/providers/libvirt/net/net_linux.go
+++ b/providers/libvirt/net/net_linux.go
@@ -9,20 +9,16 @@ import (
 	"errors"
 	"fmt"
 	stdnet "net"
-	"net/netip"
-	"os"
 	"slices"
-	"strconv"
-	"strings"
-	"sync"
 	"syscall"
 	"time"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/nomad-driver-virt/net/filter"
+	"github.com/hashicorp/nomad-driver-virt/net/filter/iptables"
 	"github.com/hashicorp/nomad-driver-virt/providers/libvirt/shims"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -32,71 +28,46 @@ import (
 )
 
 const (
-	// postroutingIPTablesChainName is the IPTables chain name used by the
-	// driver for postrouting rules. This is currently used for entries within
-	// the nat table specifically for handling the special case of loopback
-	// addresses.
-	postroutingIPTablesChainName = "NOMAD_VT_PST"
-
-	// preroutingIPTablesChainName is the IPTables chain name used by the
-	// driver for prerouting rules. This is currently used for entries within
-	// the nat table.
-	preroutingIPTablesChainName = "NOMAD_VT_PRT"
-
-	// forwardIPTablesChainName is the IPTables chain name used by the driver
-	// for forwarding rules. This is currently used for entries within the
-	// filter table.
-	forwardIPTablesChainName = "NOMAD_VT_FW"
-
-	// outputIPTablesChainName is the IPTables chain name used by the driver
-	// for output rules. This is currently used for entries within the nat
-	// table specifically for handling the special case of loopback addresses.
-	outputIPTablesChainName = "NOMAD_VT_OUT"
-
-	// iptablesNATTableName is the name of the nat table within iptables.
-	iptablesNATTableName = "nat"
-
-	// iptablesFilterTableName is the name of the filter table within iptables.
-	iptablesFilterTableName = "filter"
-
 	// automaticParentIndex is the special libvirt value to automatically
 	// determine placement when adding an element.
 	automaticParentIndex = -1
 
 	// dhcpServerPort is the port the DHCP server is listening on.
 	dhcpServerPort = "67"
-
-	// routeLocalnetPathTemplate is the template for generating the path to check for device specific routing support.
-	routeLocalnetPathTemplate = "/proc/sys/net/ipv4/conf/%s/route_localnet"
-
-	// routeLocalnetGlobalName is the name of the global kernel configuration for localnet routing.
-	routeLocalnetGlobalName = "all"
 )
-
-// initLock is used to prevent multiple controller.Init's running at once.
-var initLock sync.Mutex
-
-// loopbackForwardsLock is used to prevent multiple loopback forwards enablements
-// and loopback device enablements from running at once.
-var loopbackForwardsLock sync.Mutex
 
 // Copy returns a new copy of the controller.
 func (c *Controller) Copy(conn shims.Connect) *Controller {
 	return &Controller{
 		dhcpLeaseDiscoveryInterval: c.dhcpLeaseDiscoveryInterval,
 		dhcpLeaseDiscoveryTimeout:  c.dhcpLeaseDiscoveryTimeout,
-		interfaceByIPGetter:        c.interfaceByIPGetter,
 		ipByInterfaceGetter:        c.ipByInterfaceGetter,
-		iptablesInterfaceGetter:    c.iptablesInterfaceGetter,
+		filter:                     c.filter,
 		logger:                     c.logger,
 		netConn:                    conn,
-		routingInterfaceByIPGetter: c.routingInterfaceByIPGetter,
-		routeLocalnetTemplate:      c.routeLocalnetTemplate,
 	}
 }
 
-func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
+// Init initializes the network controller.
+func (c *Controller) Init() error {
+	// Set the filter if unset.
+	if c.filter == nil {
+		f, err := iptables.New()
+		if err != nil {
+			return err
+		}
+		c.filter = f
+	}
 
+	return nil
+}
+
+// SetFilter sets a custom network filter for the controller.
+func (c *Controller) SetFilter(f filter.Filter) {
+	c.filter = f
+}
+
+func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
 	// List the network names. This is terminal to the fingerprint process, as
 	// without this, we have nothing to query.
 	networkNames, err := c.netConn.ListNetworks()
@@ -145,90 +116,6 @@ func (c *Controller) Fingerprint(attr map[string]*structs.Attribute) {
 	}
 }
 
-func (c *Controller) Init() error {
-	var err error
-	initLock.Lock()
-	defer initLock.Unlock()
-
-	err = c.ensureIPTables()
-
-	return err
-}
-
-// ensureIPTables is responsible for ensuring the local host machine iptables
-// are configured with the chains and rules needed by the driver.
-//
-// On a new machine, this function creates the "NOMAD_VT_PRT" and "NOMAD_VT_FW"
-// chains. The "NOMAD_VT_PRT" chain then has a jump rule added to the "nat"
-// table; the "NOMAD_VT_FW" chain has a jump rule added to the "filter" table.
-func (c *Controller) ensureIPTables() error {
-
-	ipt, err := c.iptablesInterfaceGetter()
-	if err != nil {
-		return fmt.Errorf("failed to create iptables handle: %w", err)
-	}
-
-	// Ensure the NAT prerouting chain is available and create the jump rule if
-	// needed.
-	natCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, preroutingIPTablesChainName)
-	if err != nil {
-		return fmt.Errorf("failed to create iptables chain %q: %w",
-			preroutingIPTablesChainName, err)
-	}
-	if natCreated {
-		if err := ipt.Insert(iptablesNATTableName, "PREROUTING", 1, []string{"-j", preroutingIPTablesChainName}...); err != nil {
-			return err
-		}
-		c.logger.Info("successfully created NAT prerouting iptables chain",
-			"name", preroutingIPTablesChainName)
-	}
-
-	// Ensure the filter forward chain is available and create the jump rule if
-	// needed.
-	filterCreated, err := ensureIPTablesChain(ipt, iptablesFilterTableName, forwardIPTablesChainName)
-	if err != nil {
-		return fmt.Errorf("failed to create iptables chain %q: %w",
-			forwardIPTablesChainName, err)
-	}
-	if filterCreated {
-		if err := ipt.Insert(iptablesFilterTableName, "FORWARD", 1, []string{"-j", forwardIPTablesChainName}...); err != nil {
-			return err
-		}
-		c.logger.Info("successfully created filter forward iptables chain",
-			"name", forwardIPTablesChainName)
-	}
-
-	return nil
-}
-
-func ensureIPTablesChain(ipt IPTables, table, chain string) (bool, error) {
-
-	// List and iterate the currently configured iptables chains, so we can
-	// identify whether the chain already exist.
-	chains, err := ipt.ListChains(table)
-	if err != nil {
-		return false, err
-	}
-	for _, ch := range chains {
-		if ch == chain {
-			return false, nil
-		}
-	}
-
-	err = ipt.NewChain(table, chain)
-
-	// The error returned needs to be carefully checked as an exit code of 1
-	// indicates the chain exists. This might happen when another routine has
-	// created it.
-	var e *iptables.Error
-
-	if errors.As(err, &e) && e.ExitStatus() == 1 {
-		return false, nil
-	}
-
-	return true, err
-}
-
 func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStartedBuildResponse, error) {
 	if req == nil {
 		return nil, errors.New("net controller: no request provided")
@@ -273,7 +160,7 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 			req.Hostname, "mac", macAddr, "error", err)
 	}
 
-	teardownRules, err := c.configureIPTables(req.Resources, netInterface.Bridge, ipAddr)
+	teardownRules, err := c.filter.Configure(req.Resources, netInterface.Bridge, ipAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure port mapping: %w", err)
 	}
@@ -283,11 +170,43 @@ func (c *Controller) VMStartedBuild(req *net.VMStartedBuildRequest) (*net.VMStar
 			IP: ipAddr,
 		},
 		TeardownSpec: &net.TeardownSpec{
-			IPTablesRules:   teardownRules,
+			FilterRemoval:   teardownRules,
 			DHCPReservation: dhcpEntry,
 			Network:         networkName,
 		},
 	}, nil
+}
+
+func (c *Controller) VMTerminatedTeardown(req *net.VMTerminatedTeardownRequest) (*net.VMTerminatedTeardownResponse, error) {
+	// We can't be exactly sure what the caller will give us, so make sure we
+	// don't panic the driver.
+	if req == nil || req.TeardownSpec == nil {
+		return &net.VMTerminatedTeardownResponse{}, nil
+	}
+
+	// Collect all the errors, so we provide the operator with enough
+	// information to manually tidy if needed.
+	var mErr *multierror.Error
+
+	// Teardown any filter rules.
+	if req.TeardownSpec.FilterRemoval != nil {
+		mErr = multierror.Append(mErr,
+			c.filter.Teardown(req.TeardownSpec.FilterRemoval))
+	}
+
+	// Remove the DHCP IP reservation.
+	if req.TeardownSpec.Network != "" && req.TeardownSpec.DHCPReservation != "" {
+		mErr = multierror.Append(mErr,
+			c.removeIPReservation(req.TeardownSpec.Network, req.TeardownSpec.DHCPReservation))
+
+		// Release the DHCP lease. This is best effort only, so any errors encountered
+		// are simply logged.
+		if err := c.releaseDHCPLease(req.TeardownSpec.Network, req.TeardownSpec.DHCPReservation); err != nil {
+			c.logger.Error("failed to release DHCP lease", "error", err)
+		}
+	}
+
+	return &net.VMTerminatedTeardownResponse{}, mErr.ErrorOrNil()
 }
 
 // reserveIP reserves an IP address with the DHCP server for a specific domain
@@ -431,344 +350,12 @@ func (c *Controller) discoverDHCPLeaseIP(
 	}
 }
 
-// enableLoopbackPortForwards validates that the host system is configured for routing
-// localnet packets and adds the required chains.
-func (c *Controller) enableLoopbackPortForwards() error {
-	loopbackForwardsLock.Lock()
-	defer loopbackForwardsLock.Unlock()
-
-	ipt, err := c.iptablesInterfaceGetter()
-	if err != nil {
-		return err
-	}
-
-	// Add the output chain if it does not exist.
-	outputCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, outputIPTablesChainName)
-	if err != nil {
-		return err
-	}
-	if outputCreated {
-		if err := ipt.Insert(iptablesNATTableName, "OUTPUT", 1, []string{"-j", outputIPTablesChainName}...); err != nil {
-			return err
-		}
-
-		c.logger.Info("successfully created NAT output iptables chain", "name", outputIPTablesChainName)
-	}
-
-	// Add the postrouting chain if it does not exist.
-	postroutingCreated, err := ensureIPTablesChain(ipt, iptablesNATTableName, postroutingIPTablesChainName)
-	if err != nil {
-		return err
-	}
-	if postroutingCreated {
-		if err := ipt.Insert(iptablesNATTableName, "POSTROUTING", 1, []string{"-j", postroutingIPTablesChainName}...); err != nil {
-			return err
-		}
-
-		c.logger.Info("successfully created NAT postrouting iptables chain", "name", postroutingIPTablesChainName)
-	}
-
-	// Log a warning that loopback port forwarding is being enabled.
-	c.logger.Warn("port forwarding for the local loopback is enabled")
-	return nil
-}
-
-// loopbackPortForwardsSupported returns if the host has been configured for routing localnet packets.
-// NOTE: The global configuration overrides device specific configuration.
-func (c *Controller) loopbackPortForwardsSupported(device string) bool {
-	for _, configName := range []string{routeLocalnetGlobalName, device} {
-		tmpl := c.routeLocalnetTemplate
-		if tmpl == "" {
-			tmpl = routeLocalnetPathTemplate
-		}
-
-		cfgPath := fmt.Sprintf(tmpl, configName)
-		content, err := os.ReadFile(cfgPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-
-			c.logger.Error("read failed for device loopback support check", "path", cfgPath, "error", err)
-			return false
-		}
-
-		if strings.TrimSpace(string(content)) == "1" {
-			return true
-		}
-	}
-
-	return false
-}
-
-// loopbackPortForwardsEnabled checks if port forwards are enabled for the loopback device.
-func (c *Controller) loopbackPortForwardsEnabled(ipt IPTables) bool {
-	chains, err := ipt.ListChains(iptablesNATTableName)
-	if err != nil {
-		c.logger.Error("could not list table chains", "table", iptablesNATTableName,
-			"chain", postroutingIPTablesChainName, "error", err)
-		return false
-	}
-
-	return slices.Contains(chains, postroutingIPTablesChainName)
-}
-
-// enableLoopbackForDevice will add the required rule to the postrouting chain
-// for the device to handle port forwards from the loopback device.
-func (c *Controller) enableLoopbackForDevice(ipt IPTables, device string) error {
-	loopbackForwardsLock.Lock()
-	defer loopbackForwardsLock.Unlock()
-
-	// Create the required rule.
-	rule := []string{
-		"-o", device,
-		"-m", "addrtype",
-		"--src-type", "LOCAL",
-		"--dst-type", "UNICAST",
-		"-j", "MASQUERADE",
-	}
-
-	// Check if the rule already exists.
-	existingRules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
-	if err != nil {
-		return fmt.Errorf("failed to list postrouting rules: %w", err)
-	}
-
-	for _, existingRule := range existingRules {
-		// Match the suffix of the existing rule since chain information is not included
-		// in the new rule.
-		if strings.HasSuffix(existingRule, strings.Join(rule, " ")) {
-			return nil
-		}
-	}
-
-	// Still here, then add the rule.
-	if err := ipt.Append(iptablesNATTableName, postroutingIPTablesChainName, rule...); err != nil {
-		return fmt.Errorf("failed to add loopback rule for device: %w", err)
-	}
-
-	return nil
-}
-
-// configureIPTables is responsible for adding the iptables entries to enable
-// port mapping. The function will perform this action for all configured ports
-// within the network interface configuration.
-//
-// The returned array contains the added rules which hopes to make it easier to
-// delete rules when a task is stopped, specifically by avoiding having to
-// generate the information again.
-//
-// TODO (jrasell) it is possible an error occurs after we have configured
-// a number of iptables entries. The function should have a rollback mechanism
-// to clear up, so we do not leak iptables rules. This requires testing, which
-// is tricky, thus is still a todo.
-func (c *Controller) configureIPTables(
-	res *drivers.Resources, cfg *net.NetworkInterfaceBridgeConfig, ip string) ([][]string, error) {
-
-	var teardownRules [][]string
-
-	ipt, err := c.iptablesInterfaceGetter()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create iptables handle: %w", err)
-	}
-
-	// Create lookup mapping for ip:interface-name, so we can cache reads of
-	// this and not have to perform the translation each time.
-	interfaceMapping := make(map[string]string)
-
-	// Iterate the ports configured within the network interface and pull these
-	// from the task allocated ports.
-	for _, port := range cfg.Ports {
-
-		reservedPort, ok := res.Ports.Get(port)
-		if !ok {
-			c.logger.Error("failed to find reserved port", "port", port)
-			continue
-		}
-
-		// Look into the mapping for the interface based on the host IP,
-		// otherwise perform the more expensive actual lookup by querying the
-		// host.
-		iface, ok := interfaceMapping[reservedPort.HostIP]
-		if !ok {
-			iface, err = c.interfaceByIPGetter(stdnet.ParseIP(reservedPort.HostIP))
-			if err != nil {
-				return nil, fmt.Errorf("failed to identify IP interface: %w", err)
-			}
-
-			interfaceMapping[reservedPort.HostIP] = iface
-		}
-
-		// Generate our NAT preroute arguments to include the table and chain
-		// information. This allows us to store all the detail within the
-		// teardownRules easily.
-		var preRouteArgs []string
-
-		hostIP, err := netip.ParseAddr(reservedPort.HostIP)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse host IP address: %w", err)
-		}
-
-		// If the host IP provided is a loopback, it needs to be picked up on the
-		// output chain and redirected to the VM. This is a special case and which
-		// requires the host to be properly configured.
-		if hostIP.IsLoopback() {
-			// Find the interface that the destination address is attached.
-			dstIface, ok := interfaceMapping[ip]
-			if !ok {
-				dstIface, err = c.routingInterfaceByIPGetter(ip)
-				if err != nil {
-					return nil, fmt.Errorf("failed to identify IP interface: %w", err)
-				}
-
-				interfaceMapping[ip] = dstIface
-			}
-
-			// Check if loopback port forwarding is even available before starting.
-			if !c.loopbackPortForwardsSupported(dstIface) {
-				c.logger.Error(fmt.Sprintf("loopback port forwarding requires kernel runtime configuration - net.ipv4.conf.%s.route_localnet=1", dstIface))
-				return nil, fmt.Errorf("loopback port forwarding not enabled for device - %s", dstIface)
-			}
-
-			// Ensure loopback port forwarding is setup
-			if err := c.enableLoopbackPortForwards(); err != nil {
-				return nil, fmt.Errorf("failed to enable loopback port forwarding: %w", err)
-			}
-
-			// Enable the device to handle requests from the loopback device.
-			if err := c.enableLoopbackForDevice(ipt, dstIface); err != nil {
-				return nil, err
-			}
-
-			preRouteArgs = []string{
-				iptablesNATTableName,
-				outputIPTablesChainName,
-				"-s", reservedPort.HostIP,
-				"-o", iface,
-				"-p", "tcp",
-				"-m", "tcp",
-				"--dport", strconv.Itoa(reservedPort.Value),
-				"-j", "DNAT",
-				"--to-destination", fmt.Sprintf("%s:%v", ip, reservedPort.To),
-			}
-
-			if err := ipt.Append(preRouteArgs[0], preRouteArgs[1], preRouteArgs[2:]...); err != nil {
-				return nil, err
-			}
-
-			c.logger.Debug("configured nat output chain for localhost", "args", preRouteArgs)
-			teardownRules = append(teardownRules, preRouteArgs)
-		} else {
-			preRouteArgs = []string{
-				iptablesNATTableName,
-				preroutingIPTablesChainName,
-				"-d", reservedPort.HostIP,
-				"-i", iface,
-				"-p", "tcp",
-				"-m", "tcp",
-				"--dport", strconv.Itoa(reservedPort.Value),
-				"-j", "DNAT",
-				"--to-destination", fmt.Sprintf("%s:%v", ip, reservedPort.To),
-			}
-
-			if err := ipt.Append(preRouteArgs[0], preRouteArgs[1], preRouteArgs[2:]...); err != nil {
-				return nil, err
-			}
-
-			c.logger.Debug("configured nat prerouting chain", "args", preRouteArgs)
-			teardownRules = append(teardownRules, preRouteArgs)
-
-			// Generate our filter forward arguments to include the table and chain
-			// information. This allows us to store all the detail within the
-			// teardownRules easily.
-			filterArgs := []string{
-				iptablesFilterTableName,
-				forwardIPTablesChainName,
-				"-d", ip,
-				"-p", "tcp",
-				"-m", "state",
-				"--state", "NEW",
-				"-m", "tcp",
-				"--dport", strconv.Itoa(reservedPort.To),
-				"-j", "ACCEPT",
-			}
-
-			if err := ipt.Append(filterArgs[0], filterArgs[1], filterArgs[2:]...); err != nil {
-				return nil, err
-			}
-
-			c.logger.Debug("configured filter forward chain", "args", filterArgs)
-			teardownRules = append(teardownRules, filterArgs)
-		}
-		// The process made a change to the system, so log the critical
-		// information that might be useful to operators.
-		c.logger.Info("successfully configured port forwarding rules",
-			"src_ip", reservedPort.HostIP, "src_port", reservedPort.Value,
-			"dst_ip", ip, "dst_port", reservedPort.To, "port_label", port)
-	}
-
-	return teardownRules, nil
-}
-
-// getRoutingInterfaceByIP returns the name of the interface that can be used
-// to reach the provided address.
-func getRoutingInterfaceByIP(ip string) (string, error) {
-	interfaces, err := stdnet.Interfaces()
-	if err != nil {
-		return "", err
-	}
-
-	checkAddr, err := netip.ParseAddr(ip)
-	if err != nil {
-		return "", err
-	}
-
-	for _, iface := range interfaces {
-		if addrs, err := iface.Addrs(); err == nil {
-			for _, addr := range addrs {
-				if prefix, err := netip.ParsePrefix(addr.String()); err == nil {
-					if prefix.Contains(checkAddr) {
-						return iface.Name, nil
-					}
-				}
-			}
-		}
-	}
-
-	return "", fmt.Errorf("failed to find interface for IP %q", ip)
-}
-
-// getInterfaceByIP is a helper function which identifies which host network
-// interface the passed IP address is linked to.
-func getInterfaceByIP(ip stdnet.IP) (string, error) {
-	interfaces, err := stdnet.Interfaces()
-	if err != nil {
-		return "", err
-	}
-	for _, iface := range interfaces {
-		if addrs, err := iface.Addrs(); err == nil {
-			for _, addr := range addrs {
-				if iip, _, err := stdnet.ParseCIDR(addr.String()); err == nil {
-					if iip.Equal(ip) {
-						return iface.Name, nil
-					}
-				} else {
-					continue
-				}
-			}
-		} else {
-			continue
-		}
-	}
-	return "", fmt.Errorf("failed to find interface for IP %q", ip.String())
-}
-
 // getIPByInterface is a helper function which returns the IP address
 // assigned to the interface.
 func getIPByInterface(name string) (stdnet.IP, error) {
 	interfaces, err := stdnet.Interfaces()
 	if err != nil {
-		return stdnet.IP{}, err
+		return nil, err
 	}
 
 	for _, iface := range interfaces {
@@ -778,7 +365,7 @@ func getIPByInterface(name string) (stdnet.IP, error) {
 
 		addrs, err := iface.Addrs()
 		if err != nil {
-			return stdnet.IP{}, err
+			return nil, err
 		}
 
 		for _, addr := range addrs {
@@ -789,59 +376,7 @@ func getIPByInterface(name string) (stdnet.IP, error) {
 		}
 	}
 
-	return stdnet.IP{}, fmt.Errorf("could not find address for interface %s", name)
-}
-
-func (c *Controller) VMTerminatedTeardown(req *net.VMTerminatedTeardownRequest) (*net.VMTerminatedTeardownResponse, error) {
-
-	// We can't be exactly sure what the caller will give us, so make sure we
-	// don't panic the driver.
-	if req == nil || req.TeardownSpec == nil {
-		return &net.VMTerminatedTeardownResponse{}, nil
-	}
-
-	ipt, err := c.iptablesInterfaceGetter()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create iptables handle: %w", err)
-	}
-
-	// Collect all the errors, so we provide the operator with enough
-	// information to manually tidy if needed.
-	var mErr multierror.Error
-
-	// Iterate the teardown rules and delete them from iptables. Do not halt
-	// the loop if we encounter an error, track it and plough forward, so we
-	// attempt to clean up as much as possible.
-	//
-	// Using DeleteIfExists means we do not generate error if the rule does not
-	// exist. This is important for partial failure scenarios where we delete
-	// one or more rules and one or more fail. The client will retry the
-	// stop/kill call until all work is completed successfully. If we return an
-	// error if the rule is not found, we can never recover from partial
-	// failures.
-	for _, iptablesRule := range req.TeardownSpec.IPTablesRules {
-		if err := ipt.DeleteIfExists(iptablesRule[0], iptablesRule[1], iptablesRule[2:]...); err != nil {
-			mErr.Errors = append(
-				mErr.Errors,
-				fmt.Errorf("failed to delete iptables %q entry in %q chain: %w",
-					iptablesRule[0], iptablesRule[1], err))
-		}
-	}
-
-	// Remove the DHCP IP reservation.
-	if err := c.removeIPReservation(req.TeardownSpec.Network, req.TeardownSpec.DHCPReservation); err != nil {
-		mErr.Errors = append(
-			mErr.Errors,
-			fmt.Errorf("failed to update network for IP reservation removal: %w", err))
-	}
-
-	// Release the DHCP lease. This is best effort only, so any errors encountered
-	// are simply logged.
-	if err := c.releaseDHCPLease(req.TeardownSpec.Network, req.TeardownSpec.DHCPReservation); err != nil {
-		c.logger.Error("failed to release DHCP lease", "error", err)
-	}
-
-	return &net.VMTerminatedTeardownResponse{}, mErr.ErrorOrNil()
+	return nil, fmt.Errorf("could not find address for interface %s", name)
 }
 
 // removeIPReservation removes the DHCP IP reservation if it exists.

--- a/providers/libvirt/net/net_linux_test.go
+++ b/providers/libvirt/net/net_linux_test.go
@@ -6,19 +6,12 @@
 package net
 
 import (
-	"fmt"
 	stdnet "net"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad-driver-virt/testutil"
-	iptables_mock "github.com/hashicorp/nomad-driver-virt/testutil/mock/iptables"
+	filter_mock "github.com/hashicorp/nomad-driver-virt/testutil/mock/net/filter"
 	libvirt_mock "github.com/hashicorp/nomad-driver-virt/testutil/mock/providers/libvirt"
 	"github.com/hashicorp/nomad-driver-virt/virt/net"
 	nomadstructs "github.com/hashicorp/nomad/nomad/structs"
@@ -55,413 +48,179 @@ func TestController_Fingerprint(t *testing.T) {
 	must.Eq(t, map[string]*structs.Attribute{}, emptyControllerAttrs)
 }
 
-func TestController_ensureIPTables(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		mockIptables := iptables_mock.New(t).Expect(
-			iptables_mock.ListChains{Table: "nat"},
-			iptables_mock.NewChain{Table: "nat", Chain: "NOMAD_VT_PRT"},
-			iptables_mock.Insert{
-				Table:    "nat",
-				Chain:    "PREROUTING",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_PRT"},
-			},
-			iptables_mock.ListChains{Table: "filter"},
-			iptables_mock.NewChain{Table: "filter", Chain: "NOMAD_VT_FW"},
-			iptables_mock.Insert{
-				Table:    "filter",
-				Chain:    "FORWARD",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_FW"},
-			},
-		)
+func TestController_VMStartedBuild(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
 
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			iptablesInterfaceGetter: func() (IPTables, error) { return mockIptables, nil },
-		}
-
-		// Trigger the ensure function which should add our base iptables chains
-		// and rules for the driver.
-		must.NoError(t, controller.ensureIPTables())
-
-		mockIptables.AssertExpectations()
 	})
+	// define a mock network
+	mockedNet := &libvirt_mock.StaticNetwork{
+		Name:       "default",
+		Active:     true,
+		BridgeName: "virbr0",
+		DhcpLeases: []libvirt.NetworkDHCPLease{
+			{
+				Iface:      "virbr0",
+				ExpiryTime: time.Now().Add(1 * time.Hour),
+				Type:       libvirt.IP_ADDR_TYPE_IPV4,
+				Mac:        "52:54:00:1c:7c:14",
+				IPaddr:     "192.168.122.58",
+				Hostname:   "nomad-0ea818bc",
+				Clientid:   "ff:08:24:45:0e:00:02:00:00:ab:11:35:ab:f3:c7:ac:54:9e:c8",
+			},
+		},
+	}
 
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
+	mockFilter := filter_mock.NewMock(t).Expect(
+		filter_mock.Configure{
+			Resources: &drivers.Resources{Ports: &nomadstructs.AllocatedPorts{
+				{
+					Label:  "ssh",
+					To:     22,
+					HostIP: "10.0.1.161",
+					Value:  27494,
+				},
+				{
+					Label:  "nomad",
+					To:     4646,
+					HostIP: "10.0.1.161",
+					Value:  27512,
+				},
+			}},
+			NetworkConfig: &net.NetworkInterfaceBridgeConfig{
+				Name:  "virbr0",
+				Ports: []string{"ssh", "nomad"},
+			},
+			IP: "192.168.122.58",
+		},
+	)
+	defer mockFilter.AssertExpectations()
 
-		ipt, err := iptables.New()
-		must.NoError(t, err)
+	// define a mock connect instance to provide network information
+	mockConnect := libvirt_mock.NewConnect(t).Expect(
+		libvirt_mock.ListNetworks{Result: []string{"default", "routed"}},
+		libvirt_mock.LookupNetworkByName{Name: "default", Result: mockedNet},
+		libvirt_mock.LookupNetworkByName{Name: "default", Result: mockedNet},
+	)
+	defer mockConnect.AssertExpectations()
 
-		// Always start with clean tables
-		iptablesCleanup(t, ipt)
+	controller := &Controller{
+		dhcpLeaseDiscoveryInterval: 100 * time.Millisecond,
+		dhcpLeaseDiscoveryTimeout:  500 * time.Millisecond,
+		logger:                     hclog.NewNullLogger(),
+		netConn:                    mockConnect,
+		filter:                     mockFilter,
+	}
 
-		// Add a cleanup function which will remove all the added iptables chain
-		// and rule entries.
-		t.Cleanup(func() { iptablesCleanup(t, ipt) })
+	must.NoError(t, controller.Init())
 
-		controller := &Controller{logger: hclog.NewNullLogger(), iptablesInterfaceGetter: newIPTables}
+	// Ensure passing a nil request object doesn't cause the function to panic.
+	nilRequestResp, err := controller.VMStartedBuild(nil)
+	must.ErrorContains(t, err, "no request provided")
+	must.Nil(t, nilRequestResp)
 
-		// Trigger the ensure function which should add our base iptables chains
-		// and rules for the driver.
-		must.NoError(t, controller.ensureIPTables())
+	// Ensure passing an empty request object doesn't cause the function to
+	// panic.
+	nilRequestResp, err = controller.VMStartedBuild(&net.VMStartedBuildRequest{})
+	must.NoError(t, err)
+	must.NotNil(t, nilRequestResp)
+	must.Nil(t, nilRequestResp.TeardownSpec)
 
-		// Ensure the custom chain is found within the NAT table and check that the
-		// table has a jump rule to the custom chain.
-		natChains, err := ipt.ListChains(iptablesNATTableName)
-		must.NoError(t, err)
-		must.SliceContains(t, natChains, preroutingIPTablesChainName)
-
-		natRules, err := ipt.List(iptablesNATTableName, "PREROUTING")
-		must.NoError(t, err)
-		must.SliceContains(t, natRules, "-A PREROUTING -j "+preroutingIPTablesChainName)
-
-		// Ensure the custom chain is found within the filter table and check that
-		// the table has a jump rule to the custom chain.
-		filterChains, err := ipt.ListChains(iptablesFilterTableName)
-		must.NoError(t, err)
-		must.SliceContains(t, filterChains, forwardIPTablesChainName)
-
-		filterRules, err := ipt.List(iptablesFilterTableName, "FORWARD")
-		must.NoError(t, err)
-		must.SliceContains(t, filterRules, "-A FORWARD -j "+forwardIPTablesChainName)
-
-		// Trigger the ensure function again. This tests that the function can
-		// handle being run multiple times without error, whilst maintaining the
-		// iptables setup we require.
-		must.NoError(t, controller.ensureIPTables())
-
-		// Ensure the custom chain is found within the NAT table and check that the
-		// table has a jump rule to the custom chain.
-		natChains, err = ipt.ListChains(iptablesNATTableName)
-		must.NoError(t, err)
-		must.SliceContains(t, natChains, preroutingIPTablesChainName)
-
-		natRules, err = ipt.List(iptablesNATTableName, "PREROUTING")
-		must.NoError(t, err)
-		must.SliceContains(t, natRules, "-A PREROUTING -j "+preroutingIPTablesChainName)
-
-		// Ensure the custom chain is found within the filter table and check that
-		// the table has a jump rule to the custom chain.
-		filterChains, err = ipt.ListChains(iptablesFilterTableName)
-		must.NoError(t, err)
-		must.SliceContains(t, filterChains, forwardIPTablesChainName)
-
-		filterRules, err = ipt.List(iptablesFilterTableName, "FORWARD")
-		must.NoError(t, err)
-		must.SliceContains(t, filterRules, "-A FORWARD -j "+forwardIPTablesChainName)
+	// Pass a request that doesn't contain any configured networks to ensure we
+	// correctly handle that.
+	emptyNetworkRequestResp, err := controller.VMStartedBuild(&net.VMStartedBuildRequest{
+		NetConfig: net.NetworkInterfacesConfig{},
+		Resources: &drivers.Resources{},
 	})
+	must.NoError(t, err)
+	must.NotNil(t, emptyNetworkRequestResp)
+	must.Nil(t, emptyNetworkRequestResp.TeardownSpec)
+
+	// Test a correct and full request.
+	fullReq := net.VMStartedBuildRequest{
+		VMName:   "nomad-0ea818bc",
+		Hostname: "nomad-0ea818bc",
+		Hwaddrs:  []string{"52:54:00:1c:7c:14"},
+		NetConfig: net.NetworkInterfacesConfig{
+			{
+				Bridge: &net.NetworkInterfaceBridgeConfig{
+					Name:  "virbr0",
+					Ports: []string{"ssh", "nomad"},
+				},
+			},
+		},
+		Resources: &drivers.Resources{
+			Ports: &nomadstructs.AllocatedPorts{
+				{
+					Label:  "ssh",
+					Value:  27494,
+					To:     22,
+					HostIP: "10.0.1.161",
+				},
+				{
+					Label:  "nomad",
+					Value:  27512,
+					To:     4646,
+					HostIP: "10.0.1.161",
+				},
+			},
+		},
+	}
+
+	fullReqResp, err := controller.VMStartedBuild(&fullReq)
+	must.NoError(t, err)
+	must.NotNil(t, fullReqResp)
+	must.NotNil(t, fullReqResp.DriverNetwork)
+	must.NotNil(t, fullReqResp.TeardownSpec)
+
+	must.Eq(t, &drivers.DriverNetwork{IP: "192.168.122.58"}, fullReqResp.DriverNetwork)
 }
 
-func TestController_VMStartedBuild(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		// define a mock network
-		mockedNet := &libvirt_mock.StaticNetwork{
-			Name:       "default",
-			Active:     true,
-			BridgeName: "virbr0",
-			DhcpLeases: []libvirt.NetworkDHCPLease{
-				{
-					Iface:      "virbr0",
-					ExpiryTime: time.Now().Add(1 * time.Hour),
-					Type:       libvirt.IP_ADDR_TYPE_IPV4,
-					Mac:        "52:54:00:1c:7c:14",
-					IPaddr:     "192.168.122.58",
-					Hostname:   "nomad-0ea818bc",
-					Clientid:   "ff:08:24:45:0e:00:02:00:00:ab:11:35:ab:f3:c7:ac:54:9e:c8",
-				},
-			},
-		}
-
-		// define a mock connect instance to provide network information
-		mockConnect := libvirt_mock.NewConnect(t).Expect(
-			libvirt_mock.ListNetworks{Result: []string{"default", "routed"}},
-			libvirt_mock.LookupNetworkByName{Name: "default", Result: mockedNet},
-			libvirt_mock.LookupNetworkByName{Name: "default", Result: mockedNet},
-		)
-
-		// define a mock iptables instance to receive expected setup
-		mockIptables := iptables_mock.New(t).Expect(
-			iptables_mock.ListChains{Table: "nat", Result: []string{}},
-			iptables_mock.NewChain{Table: "nat", Chain: "NOMAD_VT_PRT"},
-			iptables_mock.Insert{
-				Table:    "nat",
-				Chain:    "PREROUTING",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_PRT"},
-			},
-			iptables_mock.ListChains{Table: "filter", Result: []string{}},
-			iptables_mock.NewChain{Table: "filter", Chain: "NOMAD_VT_FW"},
-			iptables_mock.Insert{
-				Table:    "filter",
-				Chain:    "FORWARD",
-				Pos:      1,
-				RuleSpec: []string{"-j", "NOMAD_VT_FW"},
-			},
-			iptables_mock.Append{
-				Table: "nat",
-				Chain: "NOMAD_VT_PRT",
-				RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-					"--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22",
-				},
-			},
-			iptables_mock.Append{
-				Table: "filter",
-				Chain: "NOMAD_VT_FW",
-				RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-					"-m", "tcp", "--dport", "22", "-j", "ACCEPT",
-				},
-			},
-			iptables_mock.Append{
-				Table: "nat",
-				Chain: "NOMAD_VT_PRT",
-				RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-					"--dport", "27512", "-j", "DNAT", "--to-destination", "192.168.122.58:4646",
-				},
-			},
-			iptables_mock.Append{
-				Table: "filter",
-				Chain: "NOMAD_VT_FW",
-				RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-					"-m", "tcp", "--dport", "4646", "-j", "ACCEPT",
-				},
-			},
-		)
-
+func TestController_VMTerminatedTeardown(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
 		controller := &Controller{
-			dhcpLeaseDiscoveryInterval: 100 * time.Millisecond,
-			dhcpLeaseDiscoveryTimeout:  500 * time.Millisecond,
-			logger:                     hclog.NewNullLogger(),
-			netConn:                    mockConnect,
-			interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-			iptablesInterfaceGetter:    func() (IPTables, error) { return mockIptables, nil },
+			logger:  hclog.NewNullLogger(),
+			netConn: &libvirt_mock.StaticConnect{},
+			filter:  filter_mock.NewStatic(),
 		}
 
-		must.NoError(t, controller.Init())
-
-		// Ensure passing a nil request object doesn't cause the function to panic.
-		nilRequestResp, err := controller.VMStartedBuild(nil)
-		must.ErrorContains(t, err, "no request provided")
-		must.Nil(t, nilRequestResp)
-
-		// Ensure passing an empty request object doesn't cause the function to
-		// panic.
-		nilRequestResp, err = controller.VMStartedBuild(&net.VMStartedBuildRequest{})
+		resp, err := controller.VMTerminatedTeardown(nil)
 		must.NoError(t, err)
-		must.NotNil(t, nilRequestResp)
-		must.Nil(t, nilRequestResp.TeardownSpec)
+		must.Eq(t, &net.VMTerminatedTeardownResponse{}, resp)
 
-		// Pass a request that doesn't contain any configured networks to ensure we
-		// correctly handle that.
-		emptyNetworkRequestResp, err := controller.VMStartedBuild(&net.VMStartedBuildRequest{
-			NetConfig: net.NetworkInterfacesConfig{},
-			Resources: &drivers.Resources{},
-		})
+		resp, err = controller.VMTerminatedTeardown(&net.VMTerminatedTeardownRequest{})
 		must.NoError(t, err)
-		must.NotNil(t, emptyNetworkRequestResp)
-		must.Nil(t, emptyNetworkRequestResp.TeardownSpec)
-
-		// Test a correct and full request.
-		fullReq := net.VMStartedBuildRequest{
-			VMName:   "nomad-0ea818bc",
-			Hostname: "nomad-0ea818bc",
-			Hwaddrs:  []string{"52:54:00:1c:7c:14"},
-			NetConfig: net.NetworkInterfacesConfig{
-				{
-					Bridge: &net.NetworkInterfaceBridgeConfig{
-						Name:  "virbr0",
-						Ports: []string{"ssh", "nomad"},
-					},
-				},
-			},
-			Resources: &drivers.Resources{
-				Ports: &nomadstructs.AllocatedPorts{
-					{
-						Label:  "ssh",
-						Value:  27494,
-						To:     22,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "nomad",
-						Value:  27512,
-						To:     4646,
-						HostIP: "10.0.1.161",
-					},
-				},
-			},
-		}
-
-		fullReqResp, err := controller.VMStartedBuild(&fullReq)
-		must.NoError(t, err)
-		must.NotNil(t, fullReqResp)
-		must.NotNil(t, fullReqResp.DriverNetwork)
-		must.NotNil(t, fullReqResp.TeardownSpec)
-
-		must.Eq(t, &drivers.DriverNetwork{IP: "192.168.122.58"}, fullReqResp.DriverNetwork)
-
-		expectedTeardownRules := [][]string{
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"4646", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:4646",
-			},
-		}
-
-		must.EqFunc(t, expectedTeardownRules, fullReqResp.TeardownSpec.IPTablesRules, func(a, b [][]string) bool {
-			if len(a) != len(b) {
-				return false
-			}
-
-			var found int
-
-			for _, ruleA := range a {
-				for _, ruleB := range b {
-					if !reflect.DeepEqual(ruleA, ruleB) {
-						continue
-					}
-					found++
-				}
-			}
-			return found == len(a)
-		})
-
-		// ensure all expectations in the mocks were called
-		mockConnect.AssertExpectations()
-		mockIptables.AssertExpectations()
-
+		must.Eq(t, &net.VMTerminatedTeardownResponse{}, resp)
 	})
 
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
+	t.Run("ok", func(t *testing.T) {
+		req := &net.VMTerminatedTeardownRequest{
+			TeardownSpec: &net.TeardownSpec{
+				FilterRemoval: &net.FilterRemoval{
+					Name: "testing",
+					Data: "test-data",
+				},
+			},
+		}
+
+		mockFilter := filter_mock.NewMock(t).Expect(
+			filter_mock.Teardown{
+				Removal: &net.FilterRemoval{
+					Name: "testing",
+					Data: "test-data",
+				},
+			},
+		)
+		defer mockFilter.AssertExpectations()
 
 		controller := &Controller{
-			dhcpLeaseDiscoveryInterval: 100 * time.Millisecond,
-			dhcpLeaseDiscoveryTimeout:  500 * time.Millisecond,
-			logger:                     hclog.NewNullLogger(),
-			netConn:                    &libvirt_mock.StaticConnect{},
-			interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-			iptablesInterfaceGetter:    newIPTables,
+			logger:  hclog.NewNullLogger(),
+			netConn: &libvirt_mock.StaticConnect{},
+			filter:  mockFilter,
 		}
 
-		must.NoError(t, controller.Init())
-
-		ipt, err := iptables.New()
+		resp, err := controller.VMTerminatedTeardown(req)
 		must.NoError(t, err)
-
-		// Add a cleanup function which will remove all the added iptables chain
-		// and rule entries.
-		t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-		// Ensure passing a nil request object doesn't cause the function to panic.
-		nilRequestResp, err := controller.VMStartedBuild(nil)
-		must.ErrorContains(t, err, "no request provided")
-		must.Nil(t, nilRequestResp)
-
-		// Ensure passing an empty request object doesn't cause the function to
-		// panic.
-		nilRequestResp, err = controller.VMStartedBuild(&net.VMStartedBuildRequest{})
-		must.NoError(t, err)
-		must.NotNil(t, nilRequestResp)
-		must.Nil(t, nilRequestResp.TeardownSpec)
-
-		// Pass a request that doesn't contain any configured networks to ensure we
-		// correctly handle that.
-		emptyNetworkRequestResp, err := controller.VMStartedBuild(&net.VMStartedBuildRequest{
-			NetConfig: net.NetworkInterfacesConfig{},
-			Resources: &drivers.Resources{},
-		})
-		must.NoError(t, err)
-		must.NotNil(t, emptyNetworkRequestResp)
-		must.Nil(t, emptyNetworkRequestResp.TeardownSpec)
-
-		// Test a correct and full request.
-		fullReq := net.VMStartedBuildRequest{
-			VMName:   "nomad-0ea818bc",
-			Hostname: "nomad-0ea818bc",
-			Hwaddrs:  []string{"52:54:00:1c:7c:14"},
-			NetConfig: net.NetworkInterfacesConfig{
-				{
-					Bridge: &net.NetworkInterfaceBridgeConfig{
-						Name:  "virbr0",
-						Ports: []string{"ssh", "nomad"},
-					},
-				},
-			},
-			Resources: &drivers.Resources{
-				Ports: &nomadstructs.AllocatedPorts{
-					{
-						Label:  "ssh",
-						Value:  27494,
-						To:     22,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "nomad",
-						Value:  27512,
-						To:     4646,
-						HostIP: "10.0.1.161",
-					},
-				},
-			},
-		}
-
-		fullReqResp, err := controller.VMStartedBuild(&fullReq)
-		must.NoError(t, err)
-		must.NotNil(t, fullReqResp)
-		must.NotNil(t, fullReqResp.DriverNetwork)
-		must.NotNil(t, fullReqResp.TeardownSpec)
-
-		must.Eq(t, &drivers.DriverNetwork{IP: "192.168.122.58"}, fullReqResp.DriverNetwork)
-
-		expectedTeardownRules := [][]string{
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-			{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"4646", "-j", "ACCEPT",
-			},
-			{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:4646",
-			},
-		}
-
-		must.EqFunc(t, expectedTeardownRules, fullReqResp.TeardownSpec.IPTablesRules, func(a, b [][]string) bool {
-			if len(a) != len(b) {
-				return false
-			}
-
-			var found int
-
-			for _, ruleA := range a {
-				for _, ruleB := range b {
-					if !reflect.DeepEqual(ruleA, ruleB) {
-						continue
-					}
-					found++
-				}
-			}
-			return found == len(a)
-		})
+		must.Eq(t, &net.VMTerminatedTeardownResponse{}, resp)
 	})
 }
 
@@ -561,657 +320,6 @@ func TestController_discoverDHCPLeaseIP(t *testing.T) {
 	must.NoError(t, err)
 	must.Eq(t, macOnlyNoHostnameResp, "192.168.122.99")
 	must.Eq(t, mac, "11:22:11:22:11:22")
-}
-
-// NOTE: stopping here. all the other loopback related tests are completed below. just
-// need to add in the full blown bits here to do the actual loopback forward thing.
-func TestController_configureIPTables(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		t.Run("loopback", func(t *testing.T) {
-			t.Run("not enabled", func(t *testing.T) {
-				mockIptables := iptables_mock.New(t)
-				defer mockIptables.AssertExpectations()
-
-				controller := &Controller{
-					logger:                     hclog.NewNullLogger(),
-					netConn:                    &libvirt_mock.StaticConnect{},
-					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-					iptablesInterfaceGetter:    func() (IPTables, error) { return mockIptables, nil },
-					routingInterfaceByIPGetter: func(string) (string, error) { return "lo", nil },
-					routeLocalnetTemplate:      routeLocalnetFile(t, false),
-				}
-
-				driverReq := drivers.Resources{
-					Ports: &nomadstructs.AllocatedPorts{
-						{
-							Label:  "ssh",
-							Value:  27494,
-							To:     22,
-							HostIP: "127.0.0.1",
-						},
-					},
-				}
-
-				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-					Name:  "virbr0",
-					Ports: []string{"ssh"},
-				}
-
-				_, err := controller.configureIPTables(
-					&driverReq, &netInterfaceReq, "192.168.122.58")
-				must.ErrorContains(t, err, "loopback port forwarding not enabled")
-			})
-
-			t.Run("enabled", func(t *testing.T) {
-				mockIptables := iptables_mock.New(t).Expect(
-					iptables_mock.ListChains{Table: iptablesNATTableName},
-					iptables_mock.NewChain{Table: iptablesNATTableName, Chain: outputIPTablesChainName},
-					iptables_mock.Insert{
-						Table:    iptablesNATTableName,
-						Chain:    "OUTPUT",
-						Pos:      1,
-						RuleSpec: []string{"-j", outputIPTablesChainName},
-					},
-					iptables_mock.ListChains{Table: iptablesNATTableName},
-					iptables_mock.NewChain{Table: iptablesNATTableName, Chain: postroutingIPTablesChainName},
-					iptables_mock.Insert{
-						Table:    iptablesNATTableName,
-						Chain:    "POSTROUTING",
-						Pos:      1,
-						RuleSpec: []string{"-j", postroutingIPTablesChainName},
-					},
-					iptables_mock.List{Table: iptablesNATTableName, Chain: postroutingIPTablesChainName},
-					iptables_mock.Append{
-						Table:    iptablesNATTableName,
-						Chain:    postroutingIPTablesChainName,
-						RuleSpec: []string{"-o", "virbr0", "-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST", "-j", "MASQUERADE"},
-					},
-					iptables_mock.Append{
-						Table:    iptablesNATTableName,
-						Chain:    outputIPTablesChainName,
-						RuleSpec: []string{"-s", "127.0.0.1", "-o", "lo", "-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"},
-					},
-				)
-				defer mockIptables.AssertExpectations()
-
-				controller := &Controller{
-					logger:                     hclog.NewNullLogger(),
-					netConn:                    &libvirt_mock.StaticConnect{},
-					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "lo", nil },
-					iptablesInterfaceGetter:    func() (IPTables, error) { return mockIptables, nil },
-					routingInterfaceByIPGetter: func(string) (string, error) { return "virbr0", nil },
-					routeLocalnetTemplate:      routeLocalnetFile(t, true),
-				}
-
-				driverReq := drivers.Resources{
-					Ports: &nomadstructs.AllocatedPorts{
-						{
-							Label:  "ssh",
-							Value:  27494,
-							To:     22,
-							HostIP: "127.0.0.1",
-						},
-					},
-				}
-
-				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-					Name:  "virbr0",
-					Ports: []string{"ssh"},
-				}
-
-				teardown, err := controller.configureIPTables(
-					&driverReq, &netInterfaceReq, "192.168.122.58")
-				must.NoError(t, err)
-				expectedTeardown := []string{iptablesNATTableName, outputIPTablesChainName, "-s", "127.0.0.1", "-o", "lo", "-p", "tcp",
-					"-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"}
-				must.Eq(t, [][]string{expectedTeardown}, teardown)
-			})
-		})
-
-		t.Run("comprehensive", func(t *testing.T) {
-			mockIptables := iptables_mock.New(t).Expect(
-				iptables_mock.ListChains{Table: "nat"},
-				iptables_mock.NewChain{Table: "nat", Chain: "NOMAD_VT_PRT"},
-				iptables_mock.Insert{
-					Table:    "nat",
-					Chain:    "PREROUTING",
-					Pos:      1,
-					RuleSpec: []string{"-j", "NOMAD_VT_PRT"},
-				},
-				iptables_mock.ListChains{Table: "filter"},
-				iptables_mock.NewChain{Table: "filter", Chain: "NOMAD_VT_FW"},
-				iptables_mock.Insert{
-					Table:    "filter",
-					Chain:    "FORWARD",
-					Pos:      1,
-					RuleSpec: []string{"-j", "NOMAD_VT_FW"},
-				},
-				iptables_mock.Append{
-					Table: "nat",
-					Chain: "NOMAD_VT_PRT",
-					RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-						"--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22",
-					},
-				},
-				iptables_mock.Append{
-					Table: "filter",
-					Chain: "NOMAD_VT_FW",
-					RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-						"-m", "tcp", "--dport", "22", "-j", "ACCEPT",
-					},
-				},
-				iptables_mock.Append{
-					Table: "nat",
-					Chain: "NOMAD_VT_PRT",
-					RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-						"--dport", "27512", "-j", "DNAT", "--to-destination", "192.168.122.58:4646",
-					},
-				},
-				iptables_mock.Append{
-					Table: "filter",
-					Chain: "NOMAD_VT_FW",
-					RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state", "--state", "NEW",
-						"-m", "tcp", "--dport", "4646", "-j", "ACCEPT",
-					},
-				},
-			)
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				netConn:                 &libvirt_mock.StaticConnect{},
-				interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-				iptablesInterfaceGetter: func() (IPTables, error) { return mockIptables, nil },
-			}
-
-			// Create driver and network interface request arguments. The allocated
-			// ports includes a port not specified in the task config, to ensure this
-			// does not get configured.
-			driverReq := drivers.Resources{
-				Ports: &nomadstructs.AllocatedPorts{
-					{
-						Label:  "ssh",
-						Value:  27494,
-						To:     22,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "nomad",
-						Value:  27512,
-						To:     4646,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "http",
-						Value:  27513,
-						To:     80,
-						HostIP: "10.0.1.161",
-					},
-				},
-			}
-
-			netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-				Name:  "virbr0",
-				Ports: []string{"ssh", "nomad"},
-			}
-
-			// Init the controller, so we have the required iptables chains available.
-			must.NoError(t, controller.Init())
-
-			// Execute the function, collecting the teardown rules and building our
-			// expected output.
-			actualTeardownRules, err := controller.configureIPTables(
-				&driverReq, &netInterfaceReq, "192.168.122.58")
-			must.NoError(t, err)
-
-			expectedTeardownRules := [][]string{
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"22", "-j", "ACCEPT",
-				},
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:22",
-				},
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"4646", "-j", "ACCEPT",
-				},
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:4646",
-				},
-			}
-
-			// Perform the equality check ensuring the returned rules match exactly
-			// what we expected.
-			must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
-
-				if len(a) != len(b) {
-					return false
-				}
-
-				var found int
-
-				for _, ruleA := range a {
-					for _, ruleB := range b {
-						if !reflect.DeepEqual(ruleA, ruleB) {
-							continue
-						}
-						found++
-					}
-				}
-				return found == len(a)
-			})
-
-			mockIptables.AssertExpectations()
-		})
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
-
-		t.Run("loopback", func(t *testing.T) {
-			t.Run("not enabled", func(t *testing.T) {
-				controller := &Controller{
-					logger:                     hclog.NewNullLogger(),
-					netConn:                    &libvirt_mock.StaticConnect{},
-					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-					iptablesInterfaceGetter:    newIPTables,
-					routingInterfaceByIPGetter: func(string) (string, error) { return "lo", nil },
-					routeLocalnetTemplate:      routeLocalnetFile(t, false),
-				}
-				// Init the controller, so we have the required iptables chains available.
-				must.NoError(t, controller.Init())
-				ipt, err := iptables.New()
-				must.NoError(t, err)
-
-				// Add a cleanup function which will remove all the added iptables chain
-				// and rule entries along with resetting the loopback init.
-				t.Cleanup(func() {
-					iptablesCleanup(t, ipt)
-				})
-
-				driverReq := drivers.Resources{
-					Ports: &nomadstructs.AllocatedPorts{
-						{
-							Label:  "ssh",
-							Value:  27494,
-							To:     22,
-							HostIP: "127.0.0.1",
-						},
-					},
-				}
-
-				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-					Name:  "virbr0",
-					Ports: []string{"ssh"},
-				}
-
-				_, err = controller.configureIPTables(
-					&driverReq, &netInterfaceReq, "192.168.122.58")
-				must.ErrorContains(t, err, "loopback port forwarding not enabled")
-
-				chains, err := ipt.ListChains(iptablesNATTableName)
-				must.NoError(t, err)
-				must.SliceNotContains(t, chains, outputIPTablesChainName)
-				must.SliceNotContains(t, chains, postroutingIPTablesChainName)
-			})
-
-			t.Run("enabled", func(t *testing.T) {
-				controller := &Controller{
-					logger:                     hclog.NewNullLogger(),
-					netConn:                    &libvirt_mock.StaticConnect{},
-					interfaceByIPGetter:        func(_ stdnet.IP) (string, error) { return "lo", nil },
-					iptablesInterfaceGetter:    newIPTables,
-					routingInterfaceByIPGetter: func(string) (string, error) { return "virbr0", nil },
-					routeLocalnetTemplate:      routeLocalnetFile(t, true),
-				}
-				// Init the controller, so we have the required iptables chains available.
-				must.NoError(t, controller.Init())
-				ipt, err := iptables.New()
-				must.NoError(t, err)
-
-				// Add a cleanup function which will remove all the added iptables chain
-				// and rule entries along with resetting the loopback init.
-				t.Cleanup(func() {
-					iptablesCleanup(t, ipt)
-				})
-
-				driverReq := drivers.Resources{
-					Ports: &nomadstructs.AllocatedPorts{
-						{
-							Label:  "ssh",
-							Value:  27494,
-							To:     22,
-							HostIP: "127.0.0.1",
-						},
-					},
-				}
-
-				netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-					Name:  "virbr0",
-					Ports: []string{"ssh"},
-				}
-
-				teardown, err := controller.configureIPTables(
-					&driverReq, &netInterfaceReq, "192.168.122.58")
-				must.NoError(t, err)
-				expectedTeardown := []string{iptablesNATTableName, outputIPTablesChainName, "-s", "127.0.0.1", "-o", "lo", "-p", "tcp",
-					"-m", "tcp", "--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22"}
-				must.Eq(t, [][]string{expectedTeardown}, teardown)
-
-				// Validate that the expected chains for localnet routing exist
-				chains, err := ipt.ListChains(iptablesNATTableName)
-				must.NoError(t, err)
-				must.SliceContains(t, chains, outputIPTablesChainName)
-				must.SliceContains(t, chains, postroutingIPTablesChainName)
-
-				// Validate the routing is applied for the device
-				rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
-				must.NoError(t, err)
-				expectedRules := []string{
-					"-N NOMAD_VT_PST",
-					"-A NOMAD_VT_PST -o virbr0 -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE",
-				}
-				must.Eq(t, expectedRules, rules)
-
-				// Validate the rule exists
-				rules, err = ipt.List(iptablesNATTableName, outputIPTablesChainName)
-				must.NoError(t, err)
-				expectedRules = []string{
-					"-N NOMAD_VT_OUT",
-					"-A NOMAD_VT_OUT -s 127.0.0.1/32 -o lo -p tcp -m tcp --dport 27494 -j DNAT --to-destination 192.168.122.58:22",
-				}
-				must.Eq(t, expectedRules, rules)
-			})
-		})
-
-		t.Run("comprehensive", func(t *testing.T) {
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				netConn:                 &libvirt_mock.StaticConnect{},
-				interfaceByIPGetter:     func(_ stdnet.IP) (string, error) { return "enp126s0", nil },
-				iptablesInterfaceGetter: newIPTables,
-			}
-
-			// Create driver and network interface request arguments. The allocated
-			// ports includes a port not specified in the task config, to ensure this
-			// does not get configured.
-			driverReq := drivers.Resources{
-				Ports: &nomadstructs.AllocatedPorts{
-					{
-						Label:  "ssh",
-						Value:  27494,
-						To:     22,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "nomad",
-						Value:  27512,
-						To:     4646,
-						HostIP: "10.0.1.161",
-					},
-					{
-						Label:  "http",
-						Value:  27513,
-						To:     80,
-						HostIP: "10.0.1.161",
-					},
-				},
-			}
-
-			netInterfaceReq := net.NetworkInterfaceBridgeConfig{
-				Name:  "virbr0",
-				Ports: []string{"ssh", "nomad"},
-			}
-
-			// Init the controller, so we have the required iptables chains available.
-			must.NoError(t, controller.Init())
-
-			ipt, err := iptables.New()
-			must.NoError(t, err)
-
-			// Add a cleanup function which will remove all the added iptables chain
-			// and rule entries.
-			t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-			// Execute the function, collecting the teardown rules and building our
-			// expected output.
-			actualTeardownRules, err := controller.configureIPTables(
-				&driverReq, &netInterfaceReq, "192.168.122.58")
-			must.NoError(t, err)
-
-			expectedTeardownRules := [][]string{
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"22", "-j", "ACCEPT",
-				},
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:22",
-				},
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"4646", "-j", "ACCEPT",
-				},
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:4646",
-				},
-			}
-
-			// Perform the equality check ensuring the returned rules match exactly
-			// what we expected.
-			must.EqFunc(t, expectedTeardownRules, actualTeardownRules, func(a, b [][]string) bool {
-
-				if len(a) != len(b) {
-					return false
-				}
-
-				var found int
-
-				for _, ruleA := range a {
-					for _, ruleB := range b {
-						if !reflect.DeepEqual(ruleA, ruleB) {
-							continue
-						}
-						found++
-					}
-				}
-				return found == len(a)
-			})
-
-			// List the rules directly from the host to ensure we have also made
-			// changes there rather than just populate a return object.
-			//
-			// We can't use expectedTeardownRules as the iptables return includes
-			// bit length of the subnet mask.
-			expectedNATRules := [][]string{
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:22",
-				},
-				{"nat", "NOMAD_VT_PRT", "-d", "10.0.1.161/32", "-i", "enp126s0",
-					"-p", "tcp", "-m", "tcp", "--dport", "27512", "-j", "DNAT",
-					"--to-destination", "192.168.122.58:4646",
-				},
-			}
-
-			natRules, err := ipt.List("nat", "NOMAD_VT_PRT")
-			must.NoError(t, err)
-			must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[0][1:], " "))
-			must.SliceContains(t, natRules, "-A "+strings.Join(expectedNATRules[1][1:], " "))
-
-			expectedFilterRules := [][]string{
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"22", "-j", "ACCEPT",
-				},
-				{"filter", "NOMAD_VT_FW", "-d", "192.168.122.58/32", "-p", "tcp",
-					"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-					"4646", "-j", "ACCEPT",
-				},
-			}
-
-			filterRules, err := ipt.List("filter", "NOMAD_VT_FW")
-			must.NoError(t, err)
-			must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[0][1:], " "))
-			must.SliceContains(t, filterRules, "-A "+strings.Join(expectedFilterRules[1][1:], " "))
-		})
-	})
-}
-
-func TestController_VMTerminatedTeardown(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		mockIptables := iptables_mock.New(t).Expect(
-			iptables_mock.DeleteIfExists{
-				Table: "filter",
-				Chain: "FORWARD",
-				RuleSpec: []string{"-d", "192.168.122.58", "-p", "tcp", "-m", "state",
-					"--state", "NEW", "-m", "tcp", "--dport", "22", "-j", "ACCEPT",
-				},
-			},
-			iptables_mock.DeleteIfExists{
-				Table: "nat",
-				Chain: "PREROUTING",
-				RuleSpec: []string{"-d", "10.0.1.161", "-i", "enp126s0", "-p", "tcp", "-m", "tcp",
-					"--dport", "27494", "-j", "DNAT", "--to-destination", "192.168.122.58:22",
-				},
-			},
-		)
-
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			netConn:                 &libvirt_mock.StaticConnect{},
-			iptablesInterfaceGetter: func() (IPTables, error) { return mockIptables, nil },
-		}
-
-		// Call the function with a nil argument, to ensure it handles this
-		// correctly and doesn't panic.
-		resp, err := controller.VMTerminatedTeardown(nil)
-		must.NoError(t, err)
-		must.NotNil(t, resp)
-
-		iptablesRules := [][]string{
-			{"filter", "FORWARD", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "PREROUTING", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-		}
-
-		request := net.VMTerminatedTeardownRequest{
-			TeardownSpec: &net.TeardownSpec{
-				IPTablesRules: iptablesRules,
-				Network:       "default",
-			},
-		}
-		resp, err = controller.VMTerminatedTeardown(&request)
-		must.NoError(t, err)
-		must.NotNil(t, resp)
-
-		mockIptables.AssertExpectations()
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
-
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			netConn:                 &libvirt_mock.StaticConnect{},
-			iptablesInterfaceGetter: newIPTables,
-		}
-
-		// Call the function with a nil argument, to ensure it handles this
-		// correctly and doesn't panic.
-		resp, err := controller.VMTerminatedTeardown(nil)
-		must.NoError(t, err)
-		must.NotNil(t, resp)
-
-		// Create a couple of iptables entries we will use moving forward. They go
-		// into the default chains, rather than the custom driver ones, so we don't
-		// need to manage the init.
-		iptablesRules := [][]string{
-			{"filter", "FORWARD", "-d", "192.168.122.58", "-p", "tcp",
-				"-m", "state", "--state", "NEW", "-m", "tcp", "--dport",
-				"22", "-j", "ACCEPT",
-			},
-			{"nat", "PREROUTING", "-d", "10.0.1.161", "-i", "enp126s0",
-				"-p", "tcp", "-m", "tcp", "--dport", "27494", "-j", "DNAT",
-				"--to-destination", "192.168.122.58:22",
-			},
-		}
-
-		// Create a teardown spec which has rules that do not exist currently on
-		// the host. It ensures we can loop through, without generating an error.
-		nonExistentRuleArgs := net.VMTerminatedTeardownRequest{
-			TeardownSpec: &net.TeardownSpec{
-				IPTablesRules: iptablesRules,
-				Network:       "default",
-			},
-		}
-		resp, err = controller.VMTerminatedTeardown(&nonExistentRuleArgs)
-		must.NoError(t, err)
-		must.NotNil(t, resp)
-
-		// Grab a handle on iptables, so we can create a couple of test rules for
-		// deletion. The library and iptables uses a lock per write, so this won't
-		// conflict with calls to VMTerminatedTeardown.
-		ipt, err := iptables.New()
-		must.NoError(t, err)
-
-		// Always start with clean tables
-		iptablesCleanup(t, ipt)
-
-		// Add a cleanup function which will remove all the added iptables chain
-		// and rule entries.
-		t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-		// Add a cleanup function which will remove all the added iptables chain
-		// rule entries, in the event of a failure in the post stop failing to do
-		// this.
-		//
-		// Any errors running the cleanup commands are logged, so developers can
-		// spot these and perform manual fixes. To run a manual removal, execute
-		// "sudo iptables -D" followed by the arguments details in each of the
-		// arrays.
-		t.Cleanup(func() {
-			fn := func(e error) {
-				if e != nil {
-					t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
-				}
-			}
-			for _, rule := range iptablesRules {
-				fn(ipt.DeleteIfExists(rule[0], rule[1], rule[2:]...))
-			}
-		})
-
-		// Create some iptables rules, which are based on a real-world example.
-		for _, rule := range iptablesRules {
-			must.NoError(t, ipt.Append(rule[0], rule[1], rule[2:]...))
-		}
-
-		// Perform the post stop request and check that the entries have been
-		// removed by the process, as expected.
-		existentRuleArgs := net.VMTerminatedTeardownRequest{
-			TeardownSpec: &net.TeardownSpec{
-				IPTablesRules: iptablesRules,
-				Network:       "default",
-			},
-		}
-		resp, err = controller.VMTerminatedTeardown(&existentRuleArgs)
-		must.NoError(t, err)
-		must.NotNil(t, resp)
-
-		for _, rule := range iptablesRules {
-			rules, err := ipt.List(rule[0], rule[1])
-			must.NoError(t, err)
-			must.SliceNotContains(t, rules, strings.Join(rule[2:], " "))
-		}
-	})
 }
 
 func TestController_removeIPReservation(t *testing.T) {
@@ -1398,385 +506,4 @@ func TestController_releaseDHCPLease(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestController_enableLoopbackForDevice(t *testing.T) {
-	deviceName := "test-dev"
-	expectedRule := fmt.Sprintf("-A %s -o %s -m addrtype --src-type LOCAL --dst-type UNICAST -j MASQUERADE", postroutingIPTablesChainName, deviceName)
-
-	t.Run("mocked", func(t *testing.T) {
-		t.Run("added", func(t *testing.T) {
-			ipt := iptables_mock.New(t).Expect(
-				iptables_mock.List{
-					Table: iptablesNATTableName,
-					Chain: postroutingIPTablesChainName,
-				},
-				iptables_mock.Append{
-					Table: iptablesNATTableName,
-					Chain: postroutingIPTablesChainName,
-					RuleSpec: []string{
-						"-o", deviceName,
-						"-m", "addrtype",
-						"--src-type", "LOCAL",
-						"--dst-type", "UNICAST",
-						"-j", "MASQUERADE",
-					},
-				},
-			)
-			defer ipt.AssertExpectations()
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-			}
-
-			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
-		})
-
-		t.Run("already exists", func(t *testing.T) {
-			ipt := iptables_mock.New(t).Expect(
-				iptables_mock.List{
-					Table:  iptablesNATTableName,
-					Chain:  postroutingIPTablesChainName,
-					Result: []string{expectedRule},
-				},
-			)
-			defer ipt.AssertExpectations()
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-			}
-
-			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
-		})
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
-
-		t.Run("added", func(t *testing.T) {
-			ipt, err := iptables.New()
-			must.NoError(t, err)
-			t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-				routeLocalnetTemplate:   routeLocalnetFile(t, true),
-			}
-			controller.enableLoopbackPortForwards()
-			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
-
-			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
-
-			rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
-			must.NoError(t, err)
-			must.SliceContains(t, rules, expectedRule)
-		})
-
-		t.Run("already exists", func(t *testing.T) {
-			ipt, err := iptables.New()
-			must.NoError(t, err)
-			t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-				routeLocalnetTemplate:   routeLocalnetFile(t, true),
-			}
-			controller.enableLoopbackPortForwards()
-			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
-
-			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
-
-			rules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
-			must.NoError(t, err)
-			must.SliceContains(t, rules, expectedRule)
-
-			must.NoError(t, controller.enableLoopbackForDevice(ipt, deviceName))
-
-			newRules, err := ipt.List(iptablesNATTableName, postroutingIPTablesChainName)
-			must.Eq(t, rules, newRules)
-		})
-	})
-}
-
-func TestController_enableLoopbackPortForwards(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		ipt := iptables_mock.New(t).Expect(
-			iptables_mock.ListChains{
-				Table:  iptablesNATTableName,
-				Result: []string{preroutingIPTablesChainName},
-			},
-			iptables_mock.NewChain{
-				Table: iptablesNATTableName,
-				Chain: outputIPTablesChainName,
-			},
-			iptables_mock.Insert{
-				Table:    iptablesNATTableName,
-				Chain:    "OUTPUT",
-				Pos:      1,
-				RuleSpec: []string{"-j", outputIPTablesChainName},
-			},
-			iptables_mock.ListChains{
-				Table: iptablesNATTableName,
-				Result: []string{
-					preroutingIPTablesChainName,
-					outputIPTablesChainName,
-				},
-			},
-			iptables_mock.NewChain{
-				Table: iptablesNATTableName,
-				Chain: postroutingIPTablesChainName,
-			},
-			iptables_mock.Insert{
-				Table:    iptablesNATTableName,
-				Chain:    "POSTROUTING",
-				Pos:      1,
-				RuleSpec: []string{"-j", postroutingIPTablesChainName},
-			},
-		)
-		defer ipt.AssertExpectations()
-
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-			routeLocalnetTemplate:   routeLocalnetFile(t, true),
-		}
-		controller.enableLoopbackPortForwards()
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
-
-		ipt, err := iptables.New()
-		must.NoError(t, err)
-		t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-		controller := &Controller{
-			logger:                  hclog.NewNullLogger(),
-			iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-			routeLocalnetTemplate:   routeLocalnetFile(t, true),
-		}
-		controller.enableLoopbackPortForwards()
-
-		chains, err := ipt.ListChains(iptablesNATTableName)
-		must.NoError(t, err)
-		must.SliceContains(t, chains, outputIPTablesChainName)
-		must.SliceContains(t, chains, postroutingIPTablesChainName)
-	})
-}
-
-func TestController_loopbackPortForwardsEnabled(t *testing.T) {
-	t.Run("mocked", func(t *testing.T) {
-		t.Run("not enabled", func(t *testing.T) {
-			ipt := iptables_mock.New(t).Expect(
-				iptables_mock.ListChains{
-					Table: iptablesNATTableName,
-					Result: []string{
-						preroutingIPTablesChainName,
-						forwardIPTablesChainName,
-					},
-				},
-			)
-			defer ipt.AssertExpectations()
-
-			controller := &Controller{logger: hclog.NewNullLogger()}
-			must.False(t, controller.loopbackPortForwardsEnabled(ipt))
-		})
-
-		t.Run("enabled", func(t *testing.T) {
-			ipt := iptables_mock.New(t).Expect(
-				iptables_mock.ListChains{
-					Table: iptablesNATTableName,
-					Result: []string{
-						preroutingIPTablesChainName,
-						postroutingIPTablesChainName,
-						forwardIPTablesChainName,
-					},
-				},
-			)
-			defer ipt.AssertExpectations()
-
-			controller := &Controller{logger: hclog.NewNullLogger()}
-			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
-		})
-	})
-
-	t.Run("direct", func(t *testing.T) {
-		testutil.RequireIPTables(t)
-
-		t.Run("not enabled", func(t *testing.T) {
-			ipt, err := iptables.New()
-			must.NoError(t, err)
-
-			controller := &Controller{logger: hclog.NewNullLogger()}
-			must.False(t, controller.loopbackPortForwardsEnabled(ipt))
-		})
-
-		t.Run("enabled", func(t *testing.T) {
-			ipt, err := iptables.New()
-			must.NoError(t, err)
-			t.Cleanup(func() { iptablesCleanup(t, ipt) })
-
-			controller := &Controller{
-				logger:                  hclog.NewNullLogger(),
-				iptablesInterfaceGetter: func() (IPTables, error) { return ipt, nil },
-				routeLocalnetTemplate:   routeLocalnetFile(t, true),
-			}
-			controller.enableLoopbackPortForwards()
-			must.True(t, controller.loopbackPortForwardsEnabled(ipt))
-		})
-	})
-}
-
-func TestController_loopbackPortForwardsSupported(t *testing.T) {
-	testCases := []struct {
-		desc          string
-		deviceContent string // empty string will result in no file
-		globalContent string // empty string will result in no file
-		result        bool
-	}{
-		{
-			desc:          "global only enabled",
-			globalContent: "1",
-			result:        true,
-		},
-		{
-			desc:          "global only disabled",
-			globalContent: "0",
-			result:        false,
-		},
-		{
-			desc:          "device only route localnet enabled",
-			deviceContent: "1",
-			result:        true,
-		},
-		{
-			desc:          "device only route localnet disabled",
-			deviceContent: "0",
-			result:        false,
-		},
-		{
-			desc:          "global enabled device enabled",
-			globalContent: "1",
-			deviceContent: "1",
-			result:        true,
-		},
-		{
-			desc:          "global enabled device disabled",
-			globalContent: "1",
-			deviceContent: "0",
-			result:        true,
-		},
-		{
-			desc:          "global disabled device enabled",
-			globalContent: "0",
-			deviceContent: "1",
-			result:        true,
-		},
-		{
-			desc:          "global disabled device disabled",
-			globalContent: "0",
-			deviceContent: "0",
-			result:        false,
-		},
-		{
-			desc:   "all route localnet missing",
-			result: false,
-		},
-	}
-
-	deviceName := "test-dev"
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			tdir := t.TempDir()
-			tmpl := filepath.Join(tdir, "/%s_route_localnet")
-			devPath := fmt.Sprintf(tmpl, deviceName)
-			globalPath := fmt.Sprintf(tmpl, routeLocalnetGlobalName)
-			if tc.globalContent != "" {
-				f, err := os.Create(globalPath)
-				must.NoError(t, err)
-				_, err = f.WriteString(tc.globalContent)
-				must.NoError(t, err)
-				f.Close()
-			}
-
-			if tc.deviceContent != "" {
-				f, err := os.Create(devPath)
-				must.NoError(t, err)
-				_, err = f.WriteString(tc.deviceContent)
-				must.NoError(t, err)
-				f.Close()
-			}
-
-			controller := &Controller{
-				logger:                hclog.NewNullLogger(),
-				routeLocalnetTemplate: tmpl,
-			}
-
-			must.Eq(t, tc.result, controller.loopbackPortForwardsSupported(deviceName))
-		})
-	}
-}
-
-// iptablesCleanup can be used as a cleanup function which will remove all the
-// added iptables chain and rule entries. This avoids polluting the machine
-// that runs the test, so our development machines do not require manual
-// intervention after each test run.
-//
-// Any errors running the cleanup commands are logged, so developers can
-// spot these and perform manual fixes. Manual fixes:
-//   - sudo iptables -t filter -D FORWARD -j NOMAD_VT_FW
-//   - sudo iptables -F NOMAD_VT_FW -t filter
-//   - sudo iptables -X NOMAD_VT_FW -t filter
-//   - sudo iptables -t nat -D PREROUTING -j NOMAD_VT_PRT
-//   - sudo iptables -F NOMAD_VT_PRT -t nat
-//   - sudo iptables -X NOMAD_VT_PRT -t nat
-//   - sudo iptables -t nat -D POSTROUTING -j NOMAD_VT_PST
-//   - sudo iptables -F NOMAD_VT_PST -t nat
-//   - sudo iptables -X NOMAD_VT_PST -t nat
-//   - sudo iptables -t nat -D POSTROUTING -j NOMAD_VT_OUT
-//   - sudo iptables -F NOMAD_VT_OUT -t nat
-//   - sudo iptables -X NOMAD_VT_OUT -t nat
-func iptablesCleanup(t *testing.T, ipt *iptables.IPTables) {
-	fn := func(e error) {
-		if e != nil {
-			t.Log(fmt.Sprint("failed to cleanup iptables: %w", e))
-		}
-	}
-
-	fn(ipt.Delete(iptablesNATTableName, "PREROUTING", []string{"-j", preroutingIPTablesChainName}...))
-	fn(ipt.ClearChain(iptablesNATTableName, preroutingIPTablesChainName))
-	fn(ipt.DeleteChain(iptablesNATTableName, preroutingIPTablesChainName))
-
-	fn(ipt.Delete(iptablesFilterTableName, "FORWARD", []string{"-j", forwardIPTablesChainName}...))
-	fn(ipt.ClearChain(iptablesFilterTableName, forwardIPTablesChainName))
-	fn(ipt.DeleteChain(iptablesFilterTableName, forwardIPTablesChainName))
-
-	fn(ipt.Delete(iptablesNATTableName, "POSTROUTING", []string{"-j", postroutingIPTablesChainName}...))
-	fn(ipt.ClearChain(iptablesNATTableName, postroutingIPTablesChainName))
-	fn(ipt.DeleteChain(iptablesNATTableName, postroutingIPTablesChainName))
-
-	fn(ipt.Delete(iptablesNATTableName, "OUTPUT", []string{"-j", outputIPTablesChainName}...))
-	fn(ipt.ClearChain(iptablesNATTableName, outputIPTablesChainName))
-	fn(ipt.DeleteChain(iptablesNATTableName, outputIPTablesChainName))
-}
-
-func routeLocalnetFile(t *testing.T, enabled bool) string {
-	content := "0"
-	if enabled {
-		content = "1"
-	}
-	tmpl := filepath.Join(t.TempDir(), "%s_route_localnet")
-	path := fmt.Sprintf(tmpl, routeLocalnetGlobalName)
-	f, err := os.Create(path)
-	must.NoError(t, err)
-	_, err = f.WriteString(content)
-	must.NoError(t, err)
-	f.Close()
-
-	return tmpl
 }

--- a/providers/libvirt/net/net_test.go
+++ b/providers/libvirt/net/net_test.go
@@ -19,5 +19,4 @@ func Test_NewController(t *testing.T) {
 	c := NewController(hclog.NewNullLogger(), nil)
 	must.Eq(t, c.dhcpLeaseDiscoveryInterval, defaultDHCPLeaseDiscoveryInterval)
 	must.Eq(t, c.dhcpLeaseDiscoveryTimeout, defaultDHCPLeaseDiscoveryTimeout)
-	must.NotNil(t, c.interfaceByIPGetter)
 }

--- a/testutil/mock/iptables/iptables_test.go
+++ b/testutil/mock/iptables/iptables_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2024, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package iptables
@@ -6,8 +6,13 @@ package iptables
 import (
 	"testing"
 
+	"github.com/hashicorp/nomad-driver-virt/net/filter/iptables"
 	"github.com/hashicorp/nomad-driver-virt/testutil/mock"
 	"github.com/shoenig/test/must"
+)
+
+var (
+	_ iptables.IPTables = (*mockIPTables)(nil)
 )
 
 func TestIPTables_Append(t *testing.T) {

--- a/testutil/mock/net/filter/filter.go
+++ b/testutil/mock/net/filter/filter.go
@@ -1,0 +1,222 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package filter
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	virtnet "github.com/hashicorp/nomad-driver-virt/virt/net"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/shoenig/test/must"
+)
+
+func NewStatic() *StaticFilter {
+	return &StaticFilter{}
+}
+
+type StaticFilter struct {
+	ConfigureResult *virtnet.FilterRemoval
+
+	counts map[string]int
+	m      sync.Mutex
+	o      sync.Once
+}
+
+func (s *StaticFilter) incrCount() {
+	s.o.Do(func() {
+		s.counts = make(map[string]int)
+	})
+
+	ctr, _, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("unable to get caller information")
+	}
+	info := runtime.FuncForPC(ctr)
+	if info == nil {
+		panic("unable to get function information")
+	}
+
+	name := info.Name()[strings.LastIndex(info.Name(), ".")+1:]
+	s.counts[name]++
+}
+
+func (s *StaticFilter) CallCount(fnName string) int {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.counts == nil {
+		return 0
+	}
+
+	return s.counts[fnName]
+}
+
+func (s *StaticFilter) Configure(*drivers.Resources, *virtnet.NetworkInterfaceBridgeConfig, string) (*virtnet.FilterRemoval, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.incrCount()
+
+	return s.ConfigureResult, nil
+}
+
+func (s *StaticFilter) Teardown(*virtnet.FilterRemoval) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.incrCount()
+
+	return nil
+}
+
+func (s *StaticFilter) SetLogger(hclog.Logger) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.incrCount()
+}
+
+func NewMock(t must.T) *MockFilter {
+	return &MockFilter{t: t}
+}
+
+type Configure struct {
+	Resources     *drivers.Resources
+	NetworkConfig *virtnet.NetworkInterfaceBridgeConfig
+	IP            string
+	Result        *virtnet.FilterRemoval
+	Err           error
+}
+
+type Teardown struct {
+	Removal *virtnet.FilterRemoval
+	Err     error
+}
+
+type MockFilter struct {
+	configures []Configure
+	teardowns  []Teardown
+	setLoggers []SetLogger
+	t          must.T
+	m          sync.Mutex
+}
+
+type SetLogger struct{}
+
+func (m *MockFilter) Expect(calls ...any) *MockFilter {
+	for _, call := range calls {
+		switch c := call.(type) {
+		case Configure:
+			m.ExpectConfigure(c)
+		case Teardown:
+			m.ExpectTeardown(c)
+		case SetLogger:
+			m.ExpectSetLogger(c)
+		default:
+			panic(fmt.Sprintf("unsupported type for mock expectation: %T", c))
+		}
+	}
+
+	return m
+}
+
+func (m *MockFilter) ExpectConfigure(c Configure) *MockFilter {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.configures = append(m.configures, c)
+	return m
+}
+
+func (m *MockFilter) ExpectTeardown(c Teardown) *MockFilter {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.teardowns = append(m.teardowns, c)
+	return m
+}
+
+func (m *MockFilter) ExpectSetLogger(c SetLogger) *MockFilter {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.setLoggers = append(m.setLoggers, c)
+	return m
+}
+
+func (m *MockFilter) Configure(resources *drivers.Resources, config *virtnet.NetworkInterfaceBridgeConfig, ip string) (*virtnet.FilterRemoval, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.configures,
+		must.Sprintf("Unexpected call to Configure - Configure(%v, %q, %q)", resources, config, ip))
+	call := m.configures[0]
+	m.configures = m.configures[1:]
+
+	// We only care about the ports value within the resources
+	// so break down expectations.
+	if call.Resources.Ports == nil || resources.Ports == nil {
+		must.Eq(m.t, call.Resources.Ports, resources.Ports,
+			must.Sprint("Configured received incorrect arguments for resources Ports"))
+	} else {
+		must.Equal(m.t, *call.Resources.Ports, *resources.Ports,
+			must.Sprint("Configured received incorrect arguments for resources Ports"))
+	}
+
+	received := Configure{
+		NetworkConfig: config,
+		IP:            ip,
+		Resources:     call.Resources,
+		Result:        call.Result,
+		Err:           call.Err,
+	}
+	must.Eq(m.t, call, received,
+		must.Sprint("Configure received incorrect arguments"))
+
+	return call.Result, call.Err
+}
+
+func (m *MockFilter) Teardown(removal *virtnet.FilterRemoval) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.teardowns,
+		must.Sprintf("Unexpected call to Teardown - Teardown(%q)", removal))
+	call := m.teardowns[0]
+	m.teardowns = m.teardowns[1:]
+	must.Eq(m.t, call.Removal, removal,
+		must.Sprint("Teardown received incorrect arguments"))
+
+	return call.Err
+}
+
+func (m *MockFilter) SetLogger(hclog.Logger) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceNotEmpty(m.t, m.setLoggers,
+		must.Sprintf("Unexpected call to SetLogger"))
+	m.setLoggers = m.setLoggers[1:]
+}
+
+func (m *MockFilter) AssertExpectations() {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.t.Helper()
+
+	must.SliceEmpty(m.t, m.configures,
+		must.Sprintf("Configure expecting %d more invocations", len(m.configures)))
+	must.SliceEmpty(m.t, m.teardowns,
+		must.Sprintf("Teardown expecting %d more invocations", len(m.teardowns)))
+	must.SliceEmpty(m.t, m.setLoggers,
+		must.Sprintf("SetLogger expecting %d more invocations", len(m.setLoggers)))
+}

--- a/virt/net/net.go
+++ b/virt/net/net.go
@@ -6,6 +6,8 @@ package net
 import (
 	"slices"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
@@ -104,13 +106,9 @@ type VMTerminatedTeardownResponse struct{}
 // process.
 type TeardownSpec struct {
 
-	// IPTablesRules specifies the rules used to build the initial VM
-	// networking. Each entry is a rule, the rule is a list of strings which
-	// mimics how iptables is called.
-	//   i[0] is the table name.
-	//   i[1] is the chain name.
-	//   i[2:] is the rule args.
-	IPTablesRules [][]string
+	// FilterRemoval contains the information to remove packet filtering
+	// configuration for the virtual machine.
+	FilterRemoval *FilterRemoval
 
 	// DHCPReservation specifies the reservation string used for registering
 	// a DHCP address for a virtual machine.
@@ -136,8 +134,8 @@ type FilterRemoval struct {
 
 // Equal returns if the given TeardownSpec is equal.
 func (t *TeardownSpec) Equal(rhs *TeardownSpec) bool {
-	if t == nil && rhs == nil {
-		return true
+	if t == nil || rhs == nil {
+		return t == rhs
 	}
 
 	if t.DHCPReservation != rhs.DHCPReservation {
@@ -148,17 +146,7 @@ func (t *TeardownSpec) Equal(rhs *TeardownSpec) bool {
 		return false
 	}
 
-	if len(t.IPTablesRules) != len(rhs.IPTablesRules) {
-		return false
-	}
-
-	for i, lhs := range t.IPTablesRules {
-		if slices.Compare(lhs, rhs.IPTablesRules[i]) != 0 {
-			return false
-		}
-	}
-
-	if t == nil || rhs == nil {
+	if !cmp.Equal(t.FilterRemoval, rhs.FilterRemoval, cmp.Options{cmpopts.IgnoreUnexported()}) {
 		return false
 	}
 


### PR DESCRIPTION
Removes direct iptables usage from libvirt net implementation and uses the filter interface to configure iptables rules. 