### PR TITLE
libvirt: remove controllers from domain

### DIFF
--- a/providers/libvirt/domain.go
+++ b/providers/libvirt/domain.go
@@ -5,11 +5,8 @@ package libvirt
 
 import (
 	"fmt"
-	"slices"
 
-	"github.com/hashicorp/go-set/v3"
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
-	"github.com/hashicorp/nomad-driver-virt/storage"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -42,7 +39,6 @@ func (p *provider) generateDomain(config *vm.Config) (string, error) {
 		p.configureDomainDeviceConsoles,
 		p.configureDomainDeviceChannels,
 		p.generateDomainDeviceDisks,
-		p.generateDomainDeviceControllers,
 		p.generateDomainDeviceFilesystems,
 		p.generateDomainDeviceInterfaces,
 		p.configureDomainDeviceRNG,
@@ -208,33 +204,6 @@ func (p *provider) configureDomainDeviceConsoles(config *vm.Config, dom *libvirt
 			},
 		},
 	}
-
-	return nil
-}
-
-// generateDomainDeviceControllers configure the required controllers.
-func (p *provider) generateDomainDeviceControllers(config *vm.Config, dom *libvirtxml.Domain) error {
-	if dom.Devices == nil {
-		dom.Devices = &libvirtxml.DomainDeviceList{}
-	}
-
-	zero := uint(0)
-	types := set.New[string](0)
-	for _, v := range config.Volumes {
-		switch v.BusType {
-		case storage.BusTypeVirtio:
-			types.Insert("virtio-serial")
-		default:
-			types.Insert(v.BusType)
-		}
-	}
-
-	controllers := make([]libvirtxml.DomainController, 0)
-	for _, t := range slices.Sorted(types.Items()) {
-		controllers = append(controllers, libvirtxml.DomainController{Type: t, Index: &zero})
-	}
-
-	dom.Devices.Controllers = controllers
 
 	return nil
 }

--- a/providers/libvirt/domain_test.go
+++ b/providers/libvirt/domain_test.go
@@ -13,50 +13,6 @@ import (
 	"libvirt.org/go/libvirtxml"
 )
 
-func Test_generateDomainDeviceControllers(t *testing.T) {
-	zero := uint(0)
-	testCases := []struct {
-		desc    string
-		volumes []storage.Volume
-		result  []libvirtxml.DomainController
-	}{
-		{
-			desc: "ok",
-			volumes: []storage.Volume{
-				{BusType: storage.BusTypeUsb},
-				{BusType: storage.BusTypeVirtio},
-			},
-			result: []libvirtxml.DomainController{
-				{Type: "usb", Index: &zero},
-				{Type: "virtio-serial", Index: &zero},
-			},
-		},
-		{
-			desc: "duplicates",
-			volumes: []storage.Volume{
-				{BusType: storage.BusTypeUsb},
-				{BusType: storage.BusTypeVirtio},
-				{BusType: storage.BusTypeUsb},
-				{BusType: storage.BusTypeVirtio},
-			},
-			result: []libvirtxml.DomainController{
-				{Type: "usb", Index: &zero},
-				{Type: "virtio-serial", Index: &zero},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			p, _ := testNew(t, overrideFs(defaultArch, MountFs9p))
-			config := &vm.Config{Volumes: tc.volumes}
-			dom := &libvirtxml.Domain{Devices: &libvirtxml.DomainDeviceList{}}
-			must.NoError(t, p.generateDomainDeviceControllers(config, dom))
-			must.Eq(t, tc.result, dom.Devices.Controllers)
-		})
-	}
-}
-
 func Test_generateDomainDeviceDisks(t *testing.T) {
 	testCases := []struct {
 		desc    string


### PR DESCRIPTION
Remove controllers from domain when generating the domain configuration to create the domain. Needed controllers will be detected and added automatically and are not recommended to be included unless there is a specific need for the layout and configuration.