### PR TITLE
config: remove deprecated configuration

### DIFF
--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -165,9 +165,6 @@ func (d *VirtDriverPlugin) SetConfig(cfg *base.Config) error {
 	// Save the configuration to the plugin
 	d.config = &config
 
-	// Apply any required configuration updates
-	d.config.Compat()
-
 	// Validate the configuration
 	if err := d.config.Validate(); err != nil {
 		return err
@@ -585,12 +582,6 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 
 	dc.Mounts = mounts
 	dc.BOOTCMDs = bootCMDs
-
-	// Compat to add old config into disks
-	if driverConfig.ImagePath != "" {
-		vdisks = vdisks.CompatAddImage(driverConfig.ImagePath, int64(driverConfig.PrimaryDiskSize),
-			driverConfig.UseThinCopy)
-	}
 
 	// Fix up the image paths
 	vdisks.ResolveImages(imagePaths)

--- a/virt/config.go
+++ b/virt/config.go
@@ -5,7 +5,6 @@ package virt
 
 import (
 	"fmt"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -19,27 +18,11 @@ import (
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 )
 
-const (
-	// These were the original default path and pool name used within
-	// the libvirt provider.
-	compatDefaultStoragePath = "/var/lib"
-	compatDefaultStoragePool = "virt-sp"
-)
-
 var (
 	configSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"emulator": hclspec.NewBlock("emulator", false, hclspec.NewObject(map[string]*hclspec.Spec{
-			"uri": hclspec.NewDefault(
-				hclspec.NewAttr("uri", "string", false),
-				hclspec.NewLiteral(`"qemu:///system"`),
-			),
-			"user":     hclspec.NewAttr("user", "string", false),
-			"password": hclspec.NewAttr("password", "string", false),
-		})),
 		"provider": hclspec.NewBlock("provider", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"libvirt": libvirt.ConfigSpec(),
 		})),
-		"data_dir":      hclspec.NewAttr("data_dir", "string", false),
 		"image_paths":   hclspec.NewAttr("image_paths", "list(string)", false),
 		"storage_pools": hclspec.NewBlock("storage_pools", false, storage.ConfigSpec()),
 	})
@@ -51,9 +34,6 @@ var (
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 		"network_interface":               net.NetworkInterfaceHCLSpec(),
 		"disk":                            disks.ConfigSpec(),
-		"use_thin_copy":                   hclspec.NewAttr("use_thin_copy", "bool", false),
-		"primary_disk_size":               hclspec.NewAttr("primary_disk_size", "number", false),
-		"image":                           hclspec.NewAttr("image", "string", false),
 		"hostname":                        hclspec.NewAttr("hostname", "string", false),
 		"user_data":                       hclspec.NewAttr("user_data", "string", false),
 		"default_user_authorized_ssh_key": hclspec.NewAttr("default_user_authorized_ssh_key", "string", false),
@@ -82,7 +62,6 @@ func TaskConfigSpec() *hclspec.Spec {
 // TaskConfig contains configuration information for a task that runs within
 // this plugin.
 type TaskConfig struct {
-	ImagePath           string         `codec:"image"`
 	Hostname            string         `codec:"hostname"`
 	OS                  *OS            `codec:"os"`
 	UserData            string         `codec:"user_data"`
@@ -90,8 +69,6 @@ type TaskConfig struct {
 	CMDs                []string       `codec:"cmds"`
 	DefaultUserSSHKey   string         `codec:"default_user_authorized_ssh_key"`
 	DefaultUserPassword string         `codec:"default_user_password"`
-	UseThinCopy         bool           `codec:"use_thin_copy"`
-	PrimaryDiskSize     uint64         `codec:"primary_disk_size"`
 	Disks               disks.Disks    `codec:"disk"`
 	// The list of network interfaces that should be added to the VM.
 	net.NetworkInterfacesConfig `codec:"network_interface"`
@@ -102,17 +79,9 @@ type OS struct {
 	Machine string `codec:"machine"`
 }
 
-type Emulator struct {
-	URI      string `codec:"uri"`
-	User     string `codec:"user"`
-	Password string `codec:"password"`
-}
-
 // Config contains configuration information for the plugin
 type Config struct {
-	Emulator     *Emulator       `codec:"emulator"`
 	Provider     *Provider       `codec:"provider"`
-	DataDir      string          `codec:"data_dir"`
 	ImagePaths   []string        `codec:"image_paths"` // allow-list of host paths to load
 	StoragePools *storage.Config `codec:"storage_pools"`
 }
@@ -132,52 +101,6 @@ func (c *Config) Validate() error {
 	)
 
 	return mErr.ErrorOrNil()
-}
-
-// Compat sets appropriate configuration using deprecated options.
-func (c *Config) Compat() {
-	if c.Emulator != nil {
-		if c.Provider == nil {
-			c.Provider = &Provider{Libvirt: &libvirt.Config{}}
-		}
-
-		if c.Provider.Libvirt == nil {
-			c.Provider.Libvirt = &libvirt.Config{}
-		}
-
-		if c.Provider.Libvirt.URI == "" {
-			c.Provider.Libvirt.URI = c.Emulator.URI
-		}
-
-		if c.Provider.Libvirt.User == "" {
-			c.Provider.Libvirt.User = c.Emulator.User
-		}
-
-		if c.Provider.Libvirt.Password == "" {
-			c.Provider.Libvirt.Password = c.Emulator.Password
-		}
-	}
-
-	// If the deprecated DataDir value is set, use it to create the compat pool.
-	if c.DataDir != "" {
-		if c.StoragePools == nil {
-			c.StoragePools = storage.NewConfig()
-		}
-
-		c.StoragePools.Directory[compatDefaultStoragePool] = storage.Directory{
-			Path: filepath.Join(c.DataDir, compatDefaultStoragePool),
-		}
-	}
-
-	// If no storage pools are defined, add in the compat pool.
-	if c.StoragePools == nil || (len(c.StoragePools.Ceph) == 0 && len(c.StoragePools.Directory) == 0) {
-		if c.StoragePools == nil {
-			c.StoragePools = storage.NewConfig()
-		}
-		c.StoragePools.Directory[compatDefaultStoragePool] = storage.Directory{
-			Path: filepath.Join(compatDefaultStoragePath, compatDefaultStoragePool),
-		}
-	}
 }
 
 // Provider contains provider specific configuration

--- a/virt/config_test.go
+++ b/virt/config_test.go
@@ -20,25 +20,20 @@ func TestConfig_Task(t *testing.T) {
 	parser := hclutils.NewConfigParser(taskConfigSpec)
 
 	expectedHostname := "test-hostname"
-	expectedImg := "/path/to/image/here"
 	expectedUserData := "/path/to/user/data"
 	expectedCmds := []string{"redis"}
 	expectedDefaultUserSSHKey := "ssh-ed25519 testtesttest..."
 	expectedDefaultUserPassword := "password"
-	expectedUseThinCopy := true
 	expectedARCH := "arm78"
 	expectedMachine := "R2D2"
 
 	validHCL := `
 config {
-	image = "/path/to/image/here"
-	primary_disk_size = 26000
 	cmds = ["redis"]
 	hostname = "test-hostname"
 	user_data = "/path/to/user/data"
 	default_user_authorized_ssh_key =  "ssh-ed25519 testtesttest..."
 	default_user_password = "password"
-	use_thin_copy = true
 	os {
 		arch = "arm78"
 		machine = "R2D2"
@@ -49,15 +44,12 @@ config {
 	var tc *TaskConfig
 	parser.ParseHCL(t, validHCL, &tc)
 	must.SliceContainsAll(t, expectedCmds, tc.CMDs)
-	must.StrContains(t, expectedImg, tc.ImagePath)
-	must.Eq(t, expectedUseThinCopy, tc.UseThinCopy)
 	must.StrContains(t, expectedDefaultUserSSHKey, tc.DefaultUserSSHKey)
 	must.StrContains(t, expectedDefaultUserPassword, tc.DefaultUserPassword)
 	must.StrContains(t, expectedHostname, tc.Hostname)
 	must.StrContains(t, expectedUserData, tc.UserData)
 	must.StrContains(t, expectedARCH, tc.OS.Arch)
 	must.StrContains(t, expectedMachine, tc.OS.Machine)
-	must.Eq(t, 26000, tc.PrimaryDiskSize)
 }
 
 func TestConfig_Plugin(t *testing.T) {
@@ -75,7 +67,6 @@ func TestConfig_Plugin(t *testing.T) {
 				},
 			},
 			ImagePaths: []string{"/path/one", "/path/two"},
-			DataDir:    "/path/to/blah",
 			StoragePools: &storage.Config{
 				Default: "test-pool",
 				Directory: map[string]storage.Directory{
@@ -96,7 +87,6 @@ func TestConfig_Plugin(t *testing.T) {
 
 		validHCL := `
 config {
-	data_dir = "/path/to/blah"
 	image_paths = ["/path/one", "/path/two"]
 	provider "libvirt" {
 		uri = "qemu:///user"
@@ -124,48 +114,6 @@ config {
 		parser.ParseHCL(t, validHCL, &result)
 		must.Eq(t, expected, result)
 	})
-
-	t.Run("compat", func(t *testing.T) {
-		expected := &Config{
-			Emulator: &Emulator{
-				URI:      "qemu:///user",
-				User:     "test-user",
-				Password: "test-password",
-			},
-			Provider: &Provider{
-				Libvirt: &libvirt.Config{
-					URI:      "qemu:///user",
-					User:     "test-user",
-					Password: "test-password",
-				},
-			},
-			ImagePaths: []string{"/path/one", "/path/two"},
-			DataDir:    "/path/to/blah",
-			StoragePools: &storage.Config{
-				Directory: map[string]storage.Directory{
-					"virt-sp": {Path: "/path/to/blah/virt-sp"},
-				},
-				Ceph: make(map[string]storage.Ceph),
-			},
-		}
-
-		validHCL := `
-config {
-	data_dir = "/path/to/blah"
-	image_paths = ["/path/one", "/path/two"]
-    emulator {
-		uri = "qemu:///user"
-		user = "test-user"
-		password = "test-password"
-    
-    }
-}
-`
-		var result *Config
-		parser.ParseHCL(t, validHCL, &result)
-		result.Compat()
-		must.Eq(t, expected, result)
-	})
 }
 
 func Test_taskConfigSpec(t *testing.T) {
@@ -178,8 +126,6 @@ func Test_taskConfigSpec(t *testing.T) {
 			name: "network interface with required",
 			inputConfig: `
 config {
-	image = "/path/to/image/here"
-	primary_disk_size = 26000
 	os {
 		arch    = "x86_64"
 		machine = "pc-i440fx-jammy"
@@ -193,8 +139,6 @@ config {
 }
 `,
 			expectedOutput: TaskConfig{
-				ImagePath:       "/path/to/image/here",
-				PrimaryDiskSize: 26000,
 				OS: &OS{
 					Arch:    "x86_64",
 					Machine: "pc-i440fx-jammy",


### PR DESCRIPTION
Removes the deprecated configuration options and the compat helpers to move the configuration values into the correct locations.