### PR TITLE
cloudinit: enable set timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ plugin "nomad-driver-virt" {
 * **hostname** - Hostname assigned. Must be a valid DNS label according to RFC 1123. Defaults to a name based on the task name.
 * **network_interface** A list of network interfaces to be attached to the VM. Currently only a single entry is supported.
 * **os** - Configuration for specific machine and architecture to emulate. Default to match host machine.
+* **timezone** - Set time zone on the VM by time zone name. Example: `America/New_York`. 
 * **user_data** - Path to a cloud-init compliant user data file to be used as the user-data for the cloud-init configuration.
 
 _Note_: The driver currently has support for cpuSets or cores and memory. Every core will be treated as a vcpu. Do not use `resources.cpus`, they will be ignored.

--- a/cloudinit/cloudinit.go
+++ b/cloudinit/cloudinit.go
@@ -54,9 +54,10 @@ type VendorData struct {
 	// RunCMD will be run inside the VM once it has started.
 	RunCMD []string
 	// BootCMD will be run inside the VM at booting time.
-	BootCMD []string
-	Mounts  []MountFileConfig
-	Files   []File
+	BootCMD  []string
+	Mounts   []MountFileConfig
+	Files    []File
+	Timezone string
 }
 
 type File struct {

--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -204,6 +204,19 @@ func TestExecuteTemplate(t *testing.T) {
 			expectedContent: "#cloud-config\n",
 		},
 		{
+			name: "with_timezone",
+			config: &Config{
+				VendorData: VendorData{
+					Timezone: "America/Los_Angeles",
+				},
+			},
+			templatePath: "vendor-data.tmpl",
+			expectError:  false,
+			expectedContent: `#cloud-config
+timezone: America/Los_Angeles
+`,
+		},
+		{
 			name: "vendor_data_without_user_data",
 			config: &Config{
 				VendorData: VendorData{

--- a/cloudinit/templates/vendor-data.tmpl
+++ b/cloudinit/templates/vendor-data.tmpl
@@ -53,3 +53,7 @@ bootcmd:
   - {{.}}
   {{- end }}
 {{- end }}
+
+{{- if .VendorData.Timezone}}
+timezone: {{.VendorData.Timezone}}
+{{- end }}

--- a/internal/shared/vm.go
+++ b/internal/shared/vm.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-driver-virt/cloudinit"
@@ -97,7 +96,7 @@ type Config struct {
 	CPUs              uint
 	OsVariant         *OSVariant
 	HostName          string
-	Timezone          *time.Location
+	Timezone          string
 	Mounts            []MountFileConfig
 	Files             []File
 	SSHKey            string
@@ -160,6 +159,7 @@ func (vm *Config) Copy() *Config {
 		CMDs:              slices.Clone(vm.CMDs),
 		BOOTCMDs:          slices.Clone(vm.BOOTCMDs),
 		CIUserData:        vm.CIUserData,
+		Timezone:          vm.Timezone,
 	}
 
 	if vm.OsVariant != nil {
@@ -167,10 +167,6 @@ func (vm *Config) Copy() *Config {
 			Arch:    vm.OsVariant.Arch,
 			Machine: vm.OsVariant.Machine,
 		}
-	}
-
-	if vm.Timezone != nil {
-		*copy.Timezone = *vm.Timezone
 	}
 
 	return copy

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -536,6 +536,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 		SSHKey:            driverConfig.DefaultUserSSHKey,
 		Files:             []vm.File{createEnvsFile(cfg.Env)},
 		NetworkInterfaces: driverConfig.NetworkInterfacesConfig,
+		Timezone:          driverConfig.Timezone,
 	}
 
 	// Run validation

--- a/virt/config.go
+++ b/virt/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad-driver-virt/internal/errs"
@@ -39,6 +38,7 @@ var (
 		"default_user_authorized_ssh_key": hclspec.NewAttr("default_user_authorized_ssh_key", "string", false),
 		"default_user_password":           hclspec.NewAttr("default_user_password", "string", false),
 		"cmds":                            hclspec.NewAttr("cmds", "list(string)", false),
+		"timezone":                        hclspec.NewAttr("timezone", "string", false),
 		"os": hclspec.NewBlock("os", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"arch":    hclspec.NewAttr("arch", "string", false),
 			"machine": hclspec.NewAttr("machine", "string", false),
@@ -62,14 +62,14 @@ func TaskConfigSpec() *hclspec.Spec {
 // TaskConfig contains configuration information for a task that runs within
 // this plugin.
 type TaskConfig struct {
-	Hostname            string         `codec:"hostname"`
-	OS                  *OS            `codec:"os"`
-	UserData            string         `codec:"user_data"`
-	TimeZone            *time.Location `codec:"timezone"`
-	CMDs                []string       `codec:"cmds"`
-	DefaultUserSSHKey   string         `codec:"default_user_authorized_ssh_key"`
-	DefaultUserPassword string         `codec:"default_user_password"`
-	Disks               disks.Disks    `codec:"disk"`
+	Hostname            string      `codec:"hostname"`
+	OS                  *OS         `codec:"os"`
+	UserData            string      `codec:"user_data"`
+	Timezone            string      `codec:"timezone"`
+	CMDs                []string    `codec:"cmds"`
+	DefaultUserSSHKey   string      `codec:"default_user_authorized_ssh_key"`
+	DefaultUserPassword string      `codec:"default_user_password"`
+	Disks               disks.Disks `codec:"disk"`
 	// The list of network interfaces that should be added to the VM.
 	net.NetworkInterfacesConfig `codec:"network_interface"`
 }

--- a/virt/config_test.go
+++ b/virt/config_test.go
@@ -136,6 +136,7 @@ config {
 			ports = ["ssh"]
 		}
 	}
+	timezone = "America/New_York",
 }
 `,
 			expectedOutput: TaskConfig{
@@ -151,7 +152,9 @@ config {
 							Ports: []string{"ssh"},
 						},
 					},
-				}},
+				},
+				Timezone: "America/New_York",
+			},
 		},
 	}
 


### PR DESCRIPTION
This change updates the internal type used for the timezone value to a string and passes it through to be included within the cloud-init configuration.