### PR TITLE
plugin: use common context for plugin instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/hashicorp/nomad-driver-virt/plugin"
 
 	"github.com/hashicorp/go-hclog"
@@ -13,10 +15,10 @@ import (
 func main() {
 
 	// Serve the plugin
-	plugins.Serve(factory)
+	plugins.ServeCtx(factory)
 }
 
 // factory returns a new instance of a nomad driver plugin
-func factory(log hclog.Logger) interface{} {
-	return plugin.NewPlugin(log)
+func factory(ctx context.Context, log hclog.Logger) interface{} {
+	return plugin.NewPlugin(ctx, log)
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -119,26 +119,31 @@ type VirtDriverPlugin struct {
 	config         *virt.Config
 	nomadConfig    *base.ClientDriverConfig
 	tasks          *taskStore
-	signalShutdown context.CancelFunc
+	ctx            context.Context
 	logger         hclog.Logger
 	dataDir        string
 	ci             cloudinit.CloudInit
+	signalShutdown context.CancelFunc
 }
 
 // NewPlugin returns a new driver plugin
-func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewPlugin(ctx context.Context, logger hclog.Logger) drivers.DriverPlugin {
 	logger = logger.Named(pluginName)
+	ctx, cancel := context.WithCancel(ctx)
+	context.AfterFunc(ctx, func() {
+		logger.Info("global plugin context done, shutting down")
+	})
 
 	// Should we check if extentions and kernel modules are there?
 	// grep -E 'svm|vmx' /proc/cpuinfo
 	// lsmod | grep kvm -> kvm_intel, kvm_amd, nvme-tcp
 	return &VirtDriverPlugin{
+		ctx:            ctx,
+		signalShutdown: cancel,
 		providers:      providers.New(ctx, logger),
 		eventer:        eventer.NewEventer(ctx, logger),
 		config:         &virt.Config{},
 		tasks:          newTaskStore(),
-		signalShutdown: cancel,
 		logger:         logger,
 	}
 }
@@ -151,6 +156,13 @@ func (d *VirtDriverPlugin) PluginInfo() (*base.PluginInfoResponse, error) {
 // ConfigSchema returns the plugin configuration schema.
 func (d *VirtDriverPlugin) ConfigSchema() (*hclspec.Spec, error) {
 	return virt.ConfigSpec(), nil
+}
+
+// Shutdown is called when the plugin is going to terminate. Use this to
+// signal the shutdown by canceling the context.
+func (d *VirtDriverPlugin) Shutdown(context.Context) error {
+	d.signalShutdown()
+	return nil
 }
 
 // SetConfig is called by the client to pass the configuration for the plugin.
@@ -226,6 +238,8 @@ func (d *VirtDriverPlugin) handleFingerprint(ctx context.Context, ch chan<- *dri
 		select {
 		case <-ctx.Done():
 			return
+		case <-d.ctx.Done():
+			return
 		case <-ticker.C:
 			ch <- d.buildFingerprint()
 		}
@@ -288,7 +302,7 @@ func (d *VirtDriverPlugin) StopTask(taskID string, timeout time.Duration, signal
 	handle.cancelFn()
 
 	vmname := vmNameFromTaskID(taskID)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(d.ctx)
 	defer cancel()
 	virtualizer, err := d.providers.GetProviderForVM(ctx, vmname)
 	if err != nil {
@@ -321,7 +335,7 @@ func (d *VirtDriverPlugin) DestroyTask(taskID string, force bool) error {
 	handle.cancelFn()
 
 	vmname := vmNameFromTaskID(taskID)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(d.ctx)
 	defer cancel()
 	virtualizer, err := d.providers.GetProviderForVM(ctx, vmname)
 	if err != nil {
@@ -393,6 +407,8 @@ func (d *VirtDriverPlugin) publishStats(ctx context.Context, interval time.Durat
 			sch <- stats
 
 		case <-ctx.Done():
+			return
+		case <-d.ctx.Done():
 			return
 		}
 	}
@@ -512,7 +528,7 @@ func (d *VirtDriverPlugin) StartTask(cfg *drivers.TaskConfig) (_ *drivers.TaskHa
 	cpuSet := idset.Parse[hw.CoreID](cfg.Resources.LinuxResources.CpusetCpus)
 
 	// Create context for this task
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(d.ctx)
 	defer func() {
 		if err != nil {
 			cancel()
@@ -749,7 +765,7 @@ func (d *VirtDriverPlugin) RecoverTask(handle *drivers.TaskHandle) error {
 			handle.Config.ID, err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(d.ctx)
 	h := &taskHandle{
 		name:        vmNameFromTaskID(handle.Config.ID),
 		logger:      d.logger.Named("handle").With("alloc-id", handle.Config.AllocID),

--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -62,7 +62,7 @@ func testHarness(t *testing.T, config *virt.Config, p providers.Providers, ci cl
 		must.Sprint("could not encode plugin configuration"))
 
 	// Create the plugin and set the passed interfaces
-	d := NewPlugin(logger).(*VirtDriverPlugin)
+	d := NewPlugin(t.Context(), logger).(*VirtDriverPlugin)
 	d.providers = p
 	d.ci = ci
 

--- a/plugin/handle.go
+++ b/plugin/handle.go
@@ -121,6 +121,8 @@ func (h *taskHandle) monitor(ctx context.Context, interval time.Duration, exitCh
 
 		case <-ctx.Done():
 			return
+		case <-h.ctx.Done():
+			return
 		}
 	}
 }

--- a/plugin/handle_test.go
+++ b/plugin/handle_test.go
@@ -65,6 +65,7 @@ func Test_GetStats(t *testing.T) {
 			dgm.Expect(tt.info)
 
 			th := &taskHandle{
+				ctx:        t.Context(),
 				name:       "test-vm",
 				taskGetter: dgm,
 			}
@@ -90,6 +91,7 @@ func Test_Monitor(t *testing.T) {
 	)
 
 	th := &taskHandle{
+		ctx:        t.Context(),
 		logger:     hclog.NewNullLogger(),
 		name:       "test-vm",
 		taskGetter: dgm,

--- a/providers/libvirt/libvirt_test.go
+++ b/providers/libvirt/libvirt_test.go
@@ -4,7 +4,6 @@
 package libvirt
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func testNew(t *testing.T, modifiers ...Option) (*provider, string) {
 	poolName := strings.ReplaceAll(t.Name(), "/", "_")
 
 	l := New(
-		context.Background(),
+		t.Context(),
 		hclog.NewNullLogger(),
 		WithConnectionURI(TestURI),
 	)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -146,7 +146,7 @@ func (p *providers) Fingerprint() (*drivers.Fingerprint, error) {
 	p.l.RLock()
 	defer p.l.RUnlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(p.ctx)
 	defer cancel()
 
 	// Start with marking the virt driver in the attributes:
@@ -222,7 +222,7 @@ func (p *providers) GetVM(name string) (*vm.Info, error) {
 	p.l.RLock()
 	defer p.l.RUnlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(p.ctx)
 	defer cancel()
 
 	for _, dispense := range p.dispensers {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -18,20 +18,19 @@ import (
 )
 
 func TestProviders(t *testing.T) {
-	ctx := context.Background()
 	logger := hclog.NewNullLogger()
 	stub := mock_virtualizers.NewStatic()
 	vstub := virt.Virtualizer(stub)
 
 	t.Run("Setup", func(t *testing.T) {
 		t.Run("without config", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			err := p.Setup(nil)
 			must.ErrorIs(t, err, ErrNoProvidersEnabled)
 		})
 
 		t.Run("with empty config", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			err := p.Setup(&virt.Config{})
 			must.ErrorIs(t, err, ErrNoProvidersEnabled)
 		})
@@ -43,7 +42,7 @@ func TestProviders(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		p := New(ctx, logger)
+		p := New(t.Context(), logger)
 		stubProvider(p, "test-virt", stub)
 
 		t.Run("existing provider", func(t *testing.T) {
@@ -61,14 +60,14 @@ func TestProviders(t *testing.T) {
 
 	t.Run("Default", func(t *testing.T) {
 		t.Run("no providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			pv, err := p.Default(t.Context())
 			must.ErrorIs(t, err, ErrUnavailableProvider)
 			must.Nil(t, pv)
 		})
 
 		t.Run("with providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "test-virt", stub)
 			pv, err := p.Default(t.Context())
 			must.NoError(t, err)
@@ -78,14 +77,14 @@ func TestProviders(t *testing.T) {
 
 	t.Run("GetVM", func(t *testing.T) {
 		t.Run("no providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			v, err := p.GetVM("test")
 			must.ErrorIs(t, err, errs.ErrNotFound)
 			must.Nil(t, v)
 		})
 
 		t.Run("with providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "v1", mock_virtualizers.NewStatic())
 			v2 := mock_virtualizers.NewStatic()
 			stubProvider(p, "v2", v2)
@@ -108,14 +107,14 @@ func TestProviders(t *testing.T) {
 
 	t.Run("GetProviderForVM", func(t *testing.T) {
 		t.Run("no providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			v, err := p.GetProviderForVM(t.Context(), "test-vm")
 			must.ErrorIs(t, err, errs.ErrNotFound)
 			must.Nil(t, v)
 		})
 
 		t.Run("no matching providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "test-virt", mock_virtualizers.NewStatic())
 			stubProvider(p, "other-virt", mock_virtualizers.NewStatic())
 			v, err := p.GetProviderForVM(t.Context(), "test-vm")
@@ -124,7 +123,7 @@ func TestProviders(t *testing.T) {
 		})
 
 		t.Run("with matching provider", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "test-virt", mock_virtualizers.NewStatic())
 			stub := &mock_virtualizers.StaticVirt{GetVMResult: &vm.Info{}}
 			stubProvider(p, "other-virt", stub)
@@ -149,7 +148,7 @@ func TestProviders(t *testing.T) {
 		}
 
 		t.Run("with single provider", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "first-stub", first_stub)
 			res, err := p.Fingerprint()
 			must.NoError(t, err)
@@ -165,7 +164,7 @@ func TestProviders(t *testing.T) {
 		})
 
 		t.Run("with multiple providers", func(t *testing.T) {
-			p := New(ctx, logger)
+			p := New(t.Context(), logger)
 			stubProvider(p, "first-stub", first_stub)
 			stubProvider(p, "second-stub", second_stub)
 			res, err := p.Fingerprint()


### PR DESCRIPTION
Update the plugin to use `ServeCtx` and uses the provided context as the parent context for the plugin. Contexts used elsewhere in the plugin are now derived from the parent context rather than the background context.

A `Shutdown` function has been added to handle canceling the parent context using `signalShutdown` when the plugin is to be terminated.

The `Shutdown` addition won't be utilized until hashicorp/nomad#28102 is merged, released, and we've updated to it.