### PR TITLE
libvirt: update storage disk naming

### DIFF
--- a/providers/libvirt/storage/storage.go
+++ b/providers/libvirt/storage/storage.go
@@ -177,12 +177,10 @@ func (s *Storage) ImageHandler() image_tools.ImageHandler {
 func (s *Storage) GenerateDeviceName(busType string, existingNames []string) string {
 	var prefix string
 	switch busType {
-	case "ide":
-		prefix = "hd"
 	case "virtio":
 		prefix = "vd"
 	default:
-		prefix = "sr"
+		prefix = "sd"
 	}
 	validNames := []string{}
 	for _, n := range existingNames {


### PR DESCRIPTION
Naming for most disk types now use the `sd` prefix. Adjust to only detect and specialize for virtio disks. Otherwise just use the `sd` prefix.