### PR TITLE
libvirt: check caps for features, remove unused

### DIFF
--- a/plugin/driver_test.go
+++ b/plugin/driver_test.go
@@ -220,7 +220,7 @@ func TestVirtDriver(t *testing.T) {
 			mock_storage.DefaultPool{Result: pl},
 			mock_storage.DefaultPool{Result: pl},
 			mock_storage.GenerateDeviceName{BusType: "virtio", ExistingDevices: []string{}, Result: "sda"},
-			mock_storage.GenerateDeviceName{BusType: "ide", ExistingDevices: []string{"sda"}, Result: "hda"},
+			mock_storage.GenerateDeviceName{BusType: "scsi", ExistingDevices: []string{"sda"}, Result: "hda"},
 			mock_storage.DefaultDiskDriver{Result: "test-driver"},
 			mock_storage.DefaultDiskDriver{Result: "test-driver"},
 		)
@@ -300,7 +300,7 @@ func TestVirtDriver(t *testing.T) {
 							Driver:     "test-driver",
 							Format:     "raw",
 							DeviceName: "hda",
-							BusType:    "ide",
+							BusType:    "scsi",
 						},
 					},
 				},

--- a/providers/libvirt/domain.go
+++ b/providers/libvirt/domain.go
@@ -36,7 +36,6 @@ func (p *provider) generateDomain(config *vm.Config) (string, error) {
 		p.configureDomainPowerManagement,
 		p.configureDomainFeatures,
 		p.configureDomainDeviceConsoles,
-		p.configureDomainDeviceConsoles,
 		p.configureDomainDeviceChannels,
 		p.generateDomainDeviceDisks,
 		p.generateDomainDeviceFilesystems,
@@ -57,10 +56,17 @@ func (p *provider) generateDomain(config *vm.Config) (string, error) {
 
 // configureDomainFeatures configures the domain features.
 func (p *provider) configureDomainFeatures(config *vm.Config, dom *libvirtxml.Domain) error {
-	dom.Features = &libvirtxml.DomainFeatureList{
-		VMPort: &libvirtxml.DomainFeatureState{
-			State: "off",
-		},
+	caps, err := p.findGuestCaps(config)
+	if err != nil {
+		return err
+	}
+
+	// If ACPI is an available feature enable it. The feature allows for
+	// graceful shutdowns when stopping a domain.
+	if caps.Features != nil && caps.Features.ACPI != nil {
+		dom.Features = &libvirtxml.DomainFeatureList{
+			ACPI: &libvirtxml.DomainFeature{},
+		}
 	}
 
 	return nil
@@ -68,13 +74,19 @@ func (p *provider) configureDomainFeatures(config *vm.Config, dom *libvirtxml.Do
 
 // configureDomainPowerManagement configures the domain power management settings.
 func (p *provider) configureDomainPowerManagement(config *vm.Config, dom *libvirtxml.Domain) error {
-	dom.PM = &libvirtxml.DomainPM{
-		SuspendToMem: &libvirtxml.DomainPMPolicy{
-			Enabled: "no",
-		},
-		SuspendToDisk: &libvirtxml.DomainPMPolicy{
-			Enabled: "no",
-		},
+	if p.caps.Host.PowerManagement != nil {
+		dom.PM = &libvirtxml.DomainPM{}
+		if p.caps.Host.PowerManagement.SuspendMem != nil {
+			dom.PM.SuspendToMem = &libvirtxml.DomainPMPolicy{
+				Enabled: "no",
+			}
+		}
+
+		if p.caps.Host.PowerManagement.SuspendDisk != nil {
+			dom.PM.SuspendToDisk = &libvirtxml.DomainPMPolicy{
+				Enabled: "no",
+			}
+		}
 	}
 
 	return nil

--- a/virt/disks/config.go
+++ b/virt/disks/config.go
@@ -205,14 +205,13 @@ func (s *Source) Equal(rhs *Source) bool {
 }
 
 // ApplyCloudInit will add a disk entry as a cdrom for cloud-init
-// TODO: adjust this to return errors so stat errors can be surfaced.
 func (d Disks) ApplyCloudInit(isoPath string) Disks {
 	if d == nil {
 		d = Disks{}
 	}
 
 	newDisk := &Disk{
-		BusType: storage.BusTypeIde,
+		BusType: storage.BusTypeScsi,
 		Kind:    storage.DiskKindCdrom,
 		Format:  "raw",
 		Source: &Source{


### PR DESCRIPTION
Use the capabilities to check for support before enabling features on the domain. Remove disabling the vmport as it will not be enabled by default when available. Add the ACPI feature if it is available as this allows for graceful shutdowns.

Default the CDROM for cloud-init to use SCSI instead of IDE since there is wider support for SCSI.

**NOTE:** These are the last changes for s390x to work out of the box.