### PR TITLE
libvirt: add controller for scsi disks

### DIFF
--- a/providers/libvirt/domain.go
+++ b/providers/libvirt/domain.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	vm "github.com/hashicorp/nomad-driver-virt/internal/shared"
+	"github.com/hashicorp/nomad-driver-virt/storage"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -226,6 +227,8 @@ func (p *provider) generateDomainDeviceDisks(config *vm.Config, dom *libvirtxml.
 		dom.Devices = &libvirtxml.DomainDeviceList{}
 	}
 
+	var needScsi bool
+
 	vols := config.Volumes
 	result := make([]libvirtxml.DomainDisk, len(vols))
 	for i, fd := range vols {
@@ -239,10 +242,29 @@ func (p *provider) generateDomainDeviceDisks(config *vm.Config, dom *libvirtxml.
 			disk.Boot = &libvirtxml.DomainDeviceBoot{Order: 1}
 		}
 
+		if fd.BusType == storage.BusTypeScsi {
+			needScsi = true
+		}
+
 		result[i] = *disk
 	}
 
 	dom.Devices.Disks = result
+
+	// If a scsi disk was found, manually add a controller to ensure
+	// that virtio-scsi is used. The auto detected controller may not
+	// be scsi which can result in cdrom support failing (and the generated
+	// cloud-init is always attached as scsi).
+	if needScsi {
+		if dom.Devices.Controllers == nil {
+			dom.Devices.Controllers = make([]libvirtxml.DomainController, 0)
+		}
+
+		dom.Devices.Controllers = append(dom.Devices.Controllers, libvirtxml.DomainController{
+			Type:  "scsi",
+			Model: "virtio-scsi",
+		})
+	}
 
 	return nil
 }

--- a/providers/libvirt/domain_test.go
+++ b/providers/libvirt/domain_test.go
@@ -15,9 +15,10 @@ import (
 
 func Test_generateDomainDeviceDisks(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		volumes []storage.Volume
-		result  []libvirtxml.DomainDisk
+		desc        string
+		volumes     []storage.Volume
+		result      []libvirtxml.DomainDisk
+		controllers []libvirtxml.DomainController
 	}{
 		{
 			desc: "ok",
@@ -40,6 +41,39 @@ func Test_generateDomainDeviceDisks(t *testing.T) {
 					},
 					Target: &libvirtxml.DomainDiskTarget{},
 					Driver: &libvirtxml.DomainDiskDriver{},
+				},
+			},
+		},
+		{
+			desc: "scsi",
+			volumes: []storage.Volume{
+				{
+					Name:    "primary",
+					Primary: true,
+					Block:   "/dev/null",
+					BusType: storage.BusTypeScsi,
+				},
+			},
+			result: []libvirtxml.DomainDisk{
+				{
+					Source: &libvirtxml.DomainDiskSource{
+						Block: &libvirtxml.DomainDiskSourceBlock{
+							Dev: "/dev/null",
+						},
+					},
+					Boot: &libvirtxml.DomainDeviceBoot{
+						Order: 1,
+					},
+					Target: &libvirtxml.DomainDiskTarget{
+						Bus: "scsi",
+					},
+					Driver: &libvirtxml.DomainDiskDriver{},
+				},
+			},
+			controllers: []libvirtxml.DomainController{
+				{
+					Type:  "scsi",
+					Model: "virtio-scsi",
 				},
 			},
 		},
@@ -89,6 +123,7 @@ func Test_generateDomainDeviceDisks(t *testing.T) {
 			dom := &libvirtxml.Domain{}
 			must.NoError(t, p.generateDomainDeviceDisks(config, dom))
 			must.Eq(t, tc.result, dom.Devices.Disks)
+			must.Eq(t, tc.controllers, dom.Devices.Controllers)
 		})
 	}
 }


### PR DESCRIPTION
When scsi disks are in use, explicitly add a controller to ensure that virtio-scsi is used. This prevents the auto-detection from picking a different model that may not properly handle cdrom.